### PR TITLE
Save loaded image bug fixed

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -191,20 +191,21 @@ public abstract class FileIO {
 	public static Bitmap getBitmapFromUri(Uri bitmapUri) {
 		BitmapFactory.Options options = new BitmapFactory.Options();
 
-		if (PaintroidApplication.openedFromCatroid) {
-			try {
-				InputStream inputStream = PaintroidApplication.applicationContext
-						.getContentResolver().openInputStream(bitmapUri);
-				Bitmap immutableBitmap = BitmapFactory
-						.decodeStream(inputStream);
-				inputStream.close();
-				return immutableBitmap.copy(Bitmap.Config.ARGB_8888, true);
-			} catch (FileNotFoundException e) {
-				e.printStackTrace();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
+//		TODO: special treatment necessary?
+//		if (PaintroidApplication.openedFromCatroid) {
+//			try {
+//				InputStream inputStream = PaintroidApplication.applicationContext
+//						.getContentResolver().openInputStream(bitmapUri);
+//				Bitmap immutableBitmap = BitmapFactory
+//						.decodeStream(inputStream);
+//				inputStream.close();
+//				return immutableBitmap.copy(Bitmap.Config.ARGB_8888, true);
+//			} catch (FileNotFoundException e) {
+//				e.printStackTrace();
+//			} catch (IOException e) {
+//				e.printStackTrace();
+//			}
+//		}
 
 		options.inJustDecodeBounds = true;
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/OptionsMenuActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/OptionsMenuActivity.java
@@ -25,6 +25,7 @@ import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
 import org.catrobat.paintroid.dialog.InfoDialog;
 import org.catrobat.paintroid.dialog.InfoDialog.DialogType;
 import org.catrobat.paintroid.tools.Tool.StateChange;
+import org.catrobat.paintroid.tools.implementation.ImportTool;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -258,12 +259,19 @@ public abstract class OptionsMenuActivity extends SherlockFragmentActivity {
 				PaintroidApplication.isPlainImage = false;
 				PaintroidApplication.isSaved = false;
 				PaintroidApplication.savedPictureUri = null;
+				if (PaintroidApplication.menu.findItem(R.id.menu_item_save_image) != null) {
+					PaintroidApplication.menu.findItem(R.id.menu_item_save_image).setVisible(false);
+				}
+				PaintroidApplication.saveCopy = true;
 				break;
 			case REQUEST_CODE_TAKE_PICTURE:
 				loadBitmapFromUri(mCameraImageUri);
 				PaintroidApplication.isPlainImage = false;
 				PaintroidApplication.isSaved = false;
 				PaintroidApplication.savedPictureUri = null;
+				if (PaintroidApplication.menu.findItem(R.id.menu_item_save_image) != null) {
+					PaintroidApplication.menu.findItem(R.id.menu_item_save_image).setVisible(true);
+				}
 				break;
 			}
 
@@ -321,8 +329,10 @@ public abstract class OptionsMenuActivity extends SherlockFragmentActivity {
 							getSupportFragmentManager(),
 							"loadbitmapdialogerror");
 				} else {
-                    PaintroidApplication.savedPictureUri = uri;
-                }
+					if (!(PaintroidApplication.currentTool instanceof ImportTool)) {
+						PaintroidApplication.savedPictureUri = uri;
+					}
+				}
 			}
 		};
 		thread.start();
@@ -403,6 +413,9 @@ public abstract class OptionsMenuActivity extends SherlockFragmentActivity {
 				Toast.makeText(context, R.string.saved, Toast.LENGTH_LONG)
 						.show();
 			} else {
+				if (PaintroidApplication.menu.findItem(R.id.menu_item_save_image) != null) {
+					PaintroidApplication.menu.findItem(R.id.menu_item_save_image).setVisible(true);
+				}
 				Toast.makeText(context, R.string.copy, Toast.LENGTH_LONG)
 						.show();
 				PaintroidApplication.saveCopy = false;


### PR DESCRIPTION
Prevent out of memory when returing to Pocket Code by scaling loaded images
MenuFileActivityIntegrationTest now deletes files that were created by the tests