### PR TITLE
'switch' statements should end with a 'default' clause

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ResizeToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ResizeToolIntegrationTest.java
@@ -671,6 +671,8 @@ public class ResizeToolIntegrationTest extends BaseIntegrationTestClass {
 					bitmapCopy.setPixels(pixelsBottomWidth, 0, bitmapWidth,
 							0, bitmapHeight - cropSizeHeight, bitmapWidth, cropSizeHeight);
 					break;
+				default:
+					break;
 			}
 			PaintroidApplication.drawingSurface.setBitmap(bitmapCopy);
 
@@ -924,6 +926,8 @@ public class ResizeToolIntegrationTest extends BaseIntegrationTestClass {
 					bitmapHeight = PaintroidApplication.drawingSurface.getBitmapHeight();
 					pixels = new int[bitmapWidth];
 					PaintroidApplication.drawingSurface.getPixels(pixels, 0, bitmapWidth, 0, bitmapHeight - 1, bitmapWidth, 1);
+					break;
+				default:
 					break;
 			}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/OptionsMenuActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/OptionsMenuActivity.java
@@ -159,6 +159,8 @@ public abstract class OptionsMenuActivity extends SherlockFragmentActivity {
 						case 1:
 							onNewImageFromCamera();
 							break;
+						default:
+							break;
 						}
 					}
 				});
@@ -272,6 +274,8 @@ public abstract class OptionsMenuActivity extends SherlockFragmentActivity {
 				if (PaintroidApplication.menu.findItem(R.id.menu_item_save_image) != null) {
 					PaintroidApplication.menu.findItem(R.id.menu_item_save_image).setVisible(true);
 				}
+				break;
+			default:
 				break;
 			}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/BrushPickerDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/BrushPickerDialog.java
@@ -227,7 +227,8 @@ public final class BrushPickerDialog extends DialogFragment implements
 		case AlertDialog.BUTTON_NEUTRAL:
 			dismiss();
 			break;
-
+		default:
+			break;
 		}
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/DialogAbout.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/DialogAbout.java
@@ -95,6 +95,8 @@ public class DialogAbout extends DialogFragment implements OnClickListener {
 		case AlertDialog.BUTTON_NEUTRAL:
 			dismiss();
 			break;
+		default:
+			break;
 		}
 
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/DialogTermsOfUseAndService.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/DialogTermsOfUseAndService.java
@@ -86,6 +86,8 @@ public class DialogTermsOfUseAndService extends DialogFragment implements OnClic
 		case AlertDialog.BUTTON_NEUTRAL:
 			dismiss();
 			break;
+		default:
+			break;
 		}
 
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
@@ -136,6 +136,8 @@ public class DrawingSurfaceListener implements OnTouchListener {
 			mPointerDistance = 0;
 			mPointerMean.set(0, 0);
 			break;
+		default:
+			break;
 		}
 		return true;
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -619,6 +619,8 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 					deltaXCorrected = ((mBoxWidth * (mBoxHeight - deltaYCorrected)) / mBoxHeight) - mBoxWidth;
 				}
 				break;
+			default:
+				break;
 		}
 
 		float resizeXMoveCenterX = (float) ((deltaXCorrected / 2) * Math


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:SwitchLastCaseIsDefaultCheck 'switch' statements should end with a 'default' clause

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

Zeeshan Asghar