### PR TITLE
'public static' fields should be constant

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplication.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplication.java
@@ -43,13 +43,13 @@ public class PaintroidApplication extends Application {
 	public static CommandManager commandManager;
 	public static Tool currentTool;
 	public static Perspective perspective;
-	public static boolean openedFromCatroid = false;
+	public static final boolean openedFromCatroid = false;
 	public static String catroidPicturePath;
-	public static boolean isPlainImage = true;
-	public static Menu menu;
-	public static boolean isSaved = true;
-	public static Uri savedPictureUri = null;
-	public static boolean saveCopy = false;
+	public static final boolean isPlainImage = true;
+	public static final Menu menu;
+	public static final boolean isSaved = true;
+	public static final Uri savedPictureUri = null;
+	public static final boolean saveCopy = false;
 
 	@Override
 	public void onCreate() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1444 'public static' fields should be constant

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444 

Please let me know if you have any questions.

Zeeshan Asghar