### PR TITLE
Unused private fields should be removed

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/FillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/FillToolIntegrationTest.java
@@ -36,8 +36,6 @@ import android.widget.TableRow;
 
 public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 
-	private static final int SHORT_WAIT_TRIES = 10;
-
 	public FillToolIntegrationTest() throws Exception {
 		super();
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ImportPngToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ImportPngToolTest.java
@@ -5,8 +5,6 @@ import org.junit.Test;
 
 public class ImportPngToolTest extends BaseIntegrationTestClass {
 
-	private static String FAILING_FILE_NAME = "thisisnofile";
-
 	public ImportPngToolTest() throws Exception {
 		super();
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/StampToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/StampToolIntegrationTest.java
@@ -46,12 +46,10 @@ import android.graphics.PointF;
 public class StampToolIntegrationTest extends BaseIntegrationTestClass {
 
 	private static final int Y_CLICK_OFFSET = 25;
-	private static final int MOVE_TOLERANCE = 10;
 	private static final float SCALE_25 = 0.25f;
 	private static final float STAMP_RESIZE_FACTOR = 1.5f;
 	// Rotation test
 	private static final float SQUARE_LENGTH = 300;
-	private static final float SQUARE_LENGTH_TINY = 50;
 	private static final float MIN_ROTATION = -450f;
 	private static final float MAX_ROTATION = 450f;
 	private static final float ROTATION_STEPSIZE = 30.0f;

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -44,8 +44,6 @@ public class BaseToolWithRectangleShapeToolTest extends BaseToolTest {
 	private static final String TOOL_MEMBER_ROTATION_ENABLED = "mRotationEnabled";
 	private static final String TOOL_MEMBER_ROTATION_SYMBOL_DISTANCE = "mRotationSymbolDistance";
 	private static final int RESIZE_MOVE_DISTANCE = 50;
-	private static final int X_OFFSET = 5;
-	private static final int Y_OFFSET = 40;
 
 	private float mScreenWidth = 1;
 	private float mScreenHeight = 1;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBar.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBar.java
@@ -14,7 +14,6 @@ public class BottomBar implements View.OnTouchListener {
 	private ImageButton mAttributeButton1;
 	private ImageButton mAttributeButton2;
 	private ImageButton mToolMenuButton;
-	private MainActivity mMainActivity;
 
 	public BottomBar(MainActivity mainActivity) {
 		mMainActivity = mainActivity;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1068 Unused private fields should be removed

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1068 

Please let me know if you have any questions.

Zeeshan Asghar