### PR TITLE
Array designators [] should be on the type, not the variable

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ResizeToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ResizeToolIntegrationTest.java
@@ -637,10 +637,10 @@ public class ResizeToolIntegrationTest extends BaseIntegrationTestClass {
 		assertEquals("bottom cropping border should be bitmap height",
 				PaintroidApplication.drawingSurface.getBitmapHeight() - 1.0f, bottomResizeBorder);
 
-		int pixelsLeftHeight[];
-		int pixelsRightHeight[];
-		int pixelsTopWidth[];
-		int pixelsBottomWidth[];
+		int[] pixelsLeftHeight;
+		int[] pixelsRightHeight;
+		int[] pixelsTopWidth;
+		int[] pixelsBottomWidth;
 
 		for (BitmapSide side : BitmapSide.values()) {
 			int cropSizeWidth = 0;
@@ -879,7 +879,7 @@ public class ResizeToolIntegrationTest extends BaseIntegrationTestClass {
 					PaintroidApplication.currentTool, TOOL_MEMBER_HEIGHT);
 			PointF boxPosition = (PointF) PrivateAccess.getMemberValue(BaseToolWithShape.class,
 					PaintroidApplication.currentTool, TOOL_MEMBER_POSITION);
-			int pixels[] = {0};
+			int[] pixels = {0};
 			int bitmapWidth;
 			int bitmapHeight;
 			switch (side) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/utils/Utils.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/utils/Utils.java
@@ -46,7 +46,7 @@ public class Utils {
 	public static int[] bitmapToPixelArray(Bitmap bitmap) {
 		int bitmapWidth = bitmap.getWidth();
 		int bitmapHeight = bitmap.getHeight();
-		int pixelArray[] = new int[bitmapWidth * bitmapHeight];
+		int[] pixelArray = new int[bitmapWidth * bitmapHeight];
 		bitmap.getPixels(pixelArray, 0, bitmapWidth, 0, 0, bitmapWidth, bitmapHeight);
 		return pixelArray;
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.java
@@ -57,7 +57,7 @@ public class FillCommand extends BaseCommand {
 		} else {
 			int colorToReplace = bitmap.getPixel(mClickedPixel.x,
 					mClickedPixel.y);
-			int pixels[] = new int[bitmap.getWidth() * bitmap.getHeight()];
+			int[] pixels = new int[bitmap.getWidth() * bitmap.getHeight()];
 			bitmap.getPixels(pixels, 0, bitmap.getWidth(), 0, 0,
 					bitmap.getWidth(), bitmap.getHeight());
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1197 Array designators [] should be on the type, not the variable

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197 

Please let me know if you have any questions.

Zeeshan Asghar