### PR TITLE
Unused local variables should be removed

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ScrollingViewIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ScrollingViewIntegrationTest.java
@@ -94,10 +94,6 @@ public class ScrollingViewIntegrationTest extends BaseIntegrationTestClass {
 		PointF leftMiddle = new PointF(xLeft, yMiddle);
 		PointF topMiddle = new PointF(xMiddle, yTop);
 		PointF bottomMiddle = new PointF(xMiddle, yBottom);
-		PointF topLeft = new PointF(xLeft, yTop);
-		PointF bottomRight = new PointF(xRight, yBottom);
-		PointF bottomLeft = new PointF(xLeft, yBottom);
-		PointF topRight = new PointF(xRight, yTop);
 
 		selectTool(ToolType.RECT);
 
@@ -141,7 +137,6 @@ public class ScrollingViewIntegrationTest extends BaseIntegrationTestClass {
 		float yTop = (Utils.getActionbarHeight() + Utils.getStatusbarHeight());
 		float yBottom = surfaceHeight + yTop - 1;
 
-		PointF middle = new PointF(xMiddle, yMiddle);
 		PointF rightMiddle = new PointF(xRight, yMiddle);
 		PointF leftMiddle = new PointF(xLeft, yMiddle);
 		PointF topMiddle = new PointF(xMiddle, yTop);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ResizeToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/ResizeToolIntegrationTest.java
@@ -988,8 +988,6 @@ public class ResizeToolIntegrationTest extends BaseIntegrationTestClass {
 		PrivateAccess.setMemberValue(BaseToolWithShape.class, PaintroidApplication.currentTool,
 				TOOL_MEMBER_POSITION, outsideBitmapToolPosition);
 		mSolo.sleep(SHORT_SLEEP);
-		float leftResizeBorder = (Float) PrivateAccess.getMemberValue(ResizeTool.class,
-				PaintroidApplication.currentTool, TOOL_MEMBER_RESIZE_BOUND_LEFT);
 		mSolo.clickOnView(mMenuBottomParameter2, true);
 		assertTrue("Nothing to resize text missing", mSolo.waitForText(mSolo.getString(
 		R.string.resize_nothing_to_resize)));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1481 Unused local variables should be removed

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1481 

Please let me know if you have any questions.

Zeeshan Asghar