### PR TITLE
Overriding methods should do more than simply call the same method in the super class

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MenuFileActivityIntegrationTest.java
@@ -242,10 +242,6 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testSaveLoadedImage() throws URISyntaxException, IOException {
 		final OptionsMenuActivity activityToTest = new OptionsMenuActivity() {
-			@Override
-			public void onActivityResult(int requestCode, int resultCode, Intent data) {
-				super.onActivityResult(requestCode, resultCode, data);
-			}
 		};
 
 		final int requestCodeLoadPicture = 2;

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/LineToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/LineToolIntegrationTest.java
@@ -50,10 +50,6 @@ public class LineToolIntegrationTest extends BaseIntegrationTestClass {
 		super.setUp();
 	}
 
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
-
 	public void testVerticalLineColor()  {
 
 		// TODO: Refactor tests (lot of copy paste code...)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
@@ -47,11 +47,6 @@ public class EraserTool extends DrawTool {
 	}
 
 	@Override
-	public void draw(Canvas canvas) {
-		super.draw(canvas);
-	}
-
-	@Override
 	public boolean handleDown(PointF coordinate) {
 		return (super.handleDown(coordinate));
 	}
@@ -95,11 +90,6 @@ public class EraserTool extends DrawTool {
 	@Override
 	public boolean handleUp(PointF coordinate) {
 		return (super.handleUp(coordinate));
-	}
-
-	@Override
-	public void resetInternalState(StateChange stateChange) {
-		super.resetInternalState(stateChange);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
@@ -75,13 +75,6 @@ public class PipetteTool extends BaseTool {
 	}
 
 	@Override
-	public int getAttributeButtonColor(ToolButtonIDs buttonNumber) {
-
-		return super.getAttributeButtonColor(buttonNumber);
-
-	}
-
-	@Override
 	public void resetInternalState() {
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1185 Overriding methods should do more than simply call the same method in the super class

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1185 

Please let me know if you have any questions.

Zeeshan Asghar