### PR TITLE
Reset the color in the tear down of robotium tests.

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MenuFileActivityIntegrationTest.java
@@ -164,7 +164,6 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testNewEmptyDrawingDialogOnBackPressed() {
 		selectTool(ToolType.BRUSH);
-		resetColorPicker();
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y);
 
 		openMenu();

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/LineToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/LineToolIntegrationTest.java
@@ -49,7 +49,6 @@ public class LineToolIntegrationTest extends BaseIntegrationTestClass {
 	protected void setUp() {
 		super.setUp();
 		selectTool(ToolType.BRUSH);
-		resetColorPicker();
 	}
 
     protected void tearDown() throws Exception {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/RectangleFillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/RectangleFillToolIntegrationTest.java
@@ -51,13 +51,6 @@ public class RectangleFillToolIntegrationTest extends BaseIntegrationTestClass {
 		super();
 	}
 
-	@Override
-	@Before
-	protected void setUp(){
-		super.setUp();
-		resetColorPicker();
-	}
-
 	@Test
 	public void testFilledRectIsCreated() throws SecurityException, IllegalArgumentException, NoSuchFieldException,
 			IllegalAccessException {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/StampToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/StampToolIntegrationTest.java
@@ -66,7 +66,6 @@ public class StampToolIntegrationTest extends BaseIntegrationTestClass {
 	protected void setUp() {
 		super.setUp();
 		selectTool(ToolType.BRUSH);
-		resetColorPicker();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/ColorPickerDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/ColorPickerDialog.java
@@ -97,7 +97,7 @@ public final class ColorPickerDialog extends BaseDialog {
 		mOnColorPickedListener.remove(listener);
 	}
 
-    private void updateColorChange(int color) {
+    public void updateColorChange(int color) {
         ArrayList<ColorPickerDialog.OnColorPickedListener> itemsToRemoveFromList = new ArrayList<ColorPickerDialog.OnColorPickedListener>();
         for (OnColorPickedListener listener : mOnColorPickedListener) {
             if (listener == null) {


### PR DESCRIPTION
# Old Implementation
The old code did not have any of the desired effects.
I.e. the color and other stuff was not reset.

One reason was the usage of PaintroidApplication.currentTool.getDrawPaint().
This function returns a new instance of a Paint (new Paint(other_paint)).
The stroke width, the stroke cap and the color are of primitive type in Paint.
This means that the new instance has a copy (!) of these values.
Modifying these values for a new Paint instance does not influence the original instance.

# New Implementation
At first I modified getDrawPaint() to not return a copy of Paint and tried
further changes in BaseTool.
Yet none of these changes lead to the desired results.

What works though is to call ColorPickerDialog.getInstance().updateColorChange
directly, which is done now.
For that the updateColorChange function was made public.