### PR TITLE
Avoids specifying manual timeouts.

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ActivityOpenedFromPocketCodeNewImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ActivityOpenedFromPocketCodeNewImageTest.java
@@ -58,8 +58,8 @@ public class ActivityOpenedFromPocketCodeNewImageTest extends BaseIntegrationTes
 
 		mSolo.clickOnButton(mSolo.getString(R.string.save_button_text));
 
-		mSolo.waitForDialogToClose(TIMEOUT); //Save Dialog
-        mSolo.waitForDialogToClose(TIMEOUT); //Progress Dialog
+		mSolo.waitForDialogToClose(); //Save Dialog
+        mSolo.waitForDialogToClose(); //Progress Dialog
 
 		assertTrue(imageFile.exists());
 		assertTrue(imageFile.length() > 0);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ActivityOpenedFromPocketCodeTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ActivityOpenedFromPocketCodeTest.java
@@ -62,7 +62,7 @@ public class ActivityOpenedFromPocketCodeTest extends BaseIntegrationTestClass {
 		long fileSizeBefore = imageFile.length();
 		mSolo.clickOnButton(mSolo.getString(R.string.save_button_text));
 
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		assertEquals(PaintroidApplication.catroidPicturePath, imageFile.getAbsolutePath());
 		assertTrue(imageFile.lastModified() > lastModifiedBefore);
@@ -82,7 +82,7 @@ public class ActivityOpenedFromPocketCodeTest extends BaseIntegrationTestClass {
 		assertTrue("click on export", mSolo.searchText(mSolo.getString(R.string.menu_export)));
 		mSolo.clickOnText(mSolo.getString(R.string.menu_export));
 
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		assertEquals(imageFile.lastModified(), lastModifiedBefore);
 		assertEquals(imageFile.length(), fileSizeBefore);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/LayerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/LayerIntegrationTest.java
@@ -53,12 +53,12 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 	public void testShowLayerMenu() {
 		mSolo.clickOnView(mButtonTopLayer);
 		assertTrue("Layers dialog not visible",
-				mSolo.waitForText(mSolo.getString(R.string.layers_title), 1, TIMEOUT, true));
+				mSolo.waitForText(mSolo.getString(R.string.layers_title)));
 	}
 
 	public void testAddOneLayer() {
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		assertTrue("First Layer not visible", mSolo.searchText(LAYER_ZERO));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		assertTrue("New Layer not visible", mSolo.searchText(LAYER_ONE));
@@ -66,7 +66,7 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testDeleteEmptyLayer() {
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		assertTrue("New Layer not visible", mSolo.searchText(LAYER_ONE));
 		mSolo.clickOnText(LAYER_ONE);
@@ -79,11 +79,11 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		PointF checkCanvasPoint = Utils.getCanvasPointFromScreenPoint(checkScreenPoint);
 
 		mSolo.clickOnScreen(checkScreenPoint.x, checkScreenPoint.y);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 		int colorLayerZero = PaintroidApplication.drawingSurface.getPixel(checkCanvasPoint);
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.clickOnText(LAYER_ZERO);
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerDelete));
@@ -106,10 +106,10 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.drag(leftPointOnScreen.x, rightPointOnScreen.x, leftPointOnScreen.y, rightPointOnScreen.y, 2);
 		selectTool(ToolType.FILL);
 		mSolo.clickOnScreen(mScreenWidth / 2, mScreenHeight / 3);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.goBack();
 
@@ -117,7 +117,7 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.drag(leftPointOnScreen.x, rightPointOnScreen.x, leftPointOnScreen.y, rightPointOnScreen.y, 1);
 		selectTool(ToolType.FILL);
 		mSolo.clickOnScreen(mScreenWidth / 2, 2 * mScreenHeight / 3);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		int colorUpperSide = PaintroidApplication.drawingSurface.getPixel(UpperCanvasPoint);
 		int colorLowerSide = PaintroidApplication.drawingSurface.getPixel(LowerCanvasPoint);
@@ -126,14 +126,14 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testTryDeleteOnlyLayer() {
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerDelete));
 		assertTrue("Layer 0 shouldn't be deleted", mSolo.searchText(LAYER_ZERO));
 	}
 
 	public void testMergeTwoEmptyLayers() {
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		assertTrue("New Layer not visible", mSolo.searchText(LAYER_ONE));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerMerge));
@@ -147,10 +147,10 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.drag(leftPointOnScreen.x, rightPointOnScreen.x, leftPointOnScreen.y, rightPointOnScreen.y, 2);
 		selectTool(ToolType.FILL);
 		mSolo.clickOnScreen(mScreenWidth / 2, mScreenHeight / 3);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.goBack();
 
@@ -158,10 +158,10 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.drag(leftPointOnScreen.x, rightPointOnScreen.x, leftPointOnScreen.y, rightPointOnScreen.y, 2);
 		selectTool(ToolType.FILL);
 		mSolo.clickOnScreen(mScreenWidth / 2, 2 * mScreenHeight / 3);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerMerge));
 		mSolo.clickOnText(LAYER_ZERO);
 		assertTrue("Merge two Layers didn't work", mSolo.searchText(LAYER_TWO));
@@ -178,9 +178,9 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 	public void testRenameLayer() {
 		String newName = "New Layer Name";
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerRename));
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		assertTrue("Rename Dialog should be shown", mSolo.searchText("Enter new layer name"));
 		getInstrumentation().sendStringSync(newName);
 		mSolo.clickOnText("OK");
@@ -190,13 +190,13 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 	public void testRenameMergedLayer() {
 		String newName = "Merged Layer";
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerMerge));
 		mSolo.clickOnText(LAYER_ZERO);
 		mSolo.clickOnText(LAYER_TWO);
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerRename));
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		getInstrumentation().sendStringSync(newName);
 		mSolo.clickOnText("OK");
 		assertTrue("Rename Layer didn't work", mSolo.searchText(newName));
@@ -208,12 +208,12 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		int colorTransparent = PaintroidApplication.drawingSurface.getPixel(checkCanvasPoint);
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerLock));
 
 		mSolo.clickOnScreen(checkScreenPoint.x, checkScreenPoint.y);
 		mSolo.goBack();
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 		int colorAfterDraw = PaintroidApplication.drawingSurface.getPixel(checkCanvasPoint);
 		assertEquals("Pixel color should be transparent.", colorTransparent, colorAfterDraw);
 
@@ -226,7 +226,7 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.clickOnScreen(checkScreenPoint.x, checkScreenPoint.y);
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerVisible));
 		mSolo.goBack();
 
@@ -237,13 +237,13 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testLockLayerSetInvisible() {
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerVisible));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerLock));
 		mSolo.goBack();
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerVisible));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerLock));
 		mSolo.goBack();
@@ -253,7 +253,7 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 	public void testTrySetMoreLayersThanLimit() {
 
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
@@ -268,7 +268,7 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 	public void testMultipleLayersNewImageDiscardOld() {
 		mSolo.clickOnScreen(mScreenWidth / 2, mScreenHeight / 3);
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.goBack();
@@ -276,19 +276,18 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_new_image));
 		mSolo.waitForDialogToOpen();
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_new_image_empty_image));
-		mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image), 1, TIMEOUT, true);
+		mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image));
 		mSolo.clickOnButton(mSolo.getString(R.string.discard_button_text));
 		mSolo.waitForDialogToClose();
 		mSolo.clickOnScreen(mScreenWidth / 2, mScreenHeight / 3);
 		mSolo.clickOnView(mButtonTopLayer);
-		assertTrue("Layers dialog not visible",
-				mSolo.waitForText(mSolo.getString(R.string.layers_title), 1, TIMEOUT, true));
+		assertTrue("Layers dialog not visible", mSolo.waitForText(mSolo.getString(R.string.layers_title)));
 	}
 
 	public void testMultipleLayersNewImageSaveOld() {
 		mSolo.clickOnScreen(mScreenWidth / 2, mScreenHeight / 3);
 		mSolo.clickOnView(mButtonTopLayer);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.clickOnView(mSolo.getView(R.id.mButtonLayerNew));
 		mSolo.goBack();
@@ -296,17 +295,16 @@ public class LayerIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_new_image));
 		mSolo.waitForDialogToOpen();
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_new_image_empty_image));
-		mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image), 1, TIMEOUT, true);
+		mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image));
 		mSolo.clickOnButton(mSolo.getString(R.string.save_button_text));
 		mSolo.waitForDialogToClose();
 		mSolo.clickOnScreen(mScreenWidth / 2, mScreenHeight / 3);
 		mSolo.clickOnView(mButtonTopLayer);
-		assertTrue("Layers dialog not visible",
-				mSolo.waitForText(mSolo.getString(R.string.layers_title), 1, TIMEOUT, true));
+		assertTrue("Layers dialog not visible", mSolo.waitForText(mSolo.getString(R.string.layers_title)));
 	}
 
 	public void testOpacityChange() {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		mSolo.sleep(30);
 		PointF screenPoint = new PointF(mScreenWidth / 2, mScreenHeight / 2);
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MainActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MainActivityIntegrationTest.java
@@ -44,7 +44,7 @@ public class MainActivityIntegrationTest extends BaseIntegrationTestClass {
 		String termsOfUseAndServiceTextExpected = getActivity().getString(R.string.terms_of_use_and_service_content);
 
 		assertTrue("Terms of Use and Service dialog text not correct, maybe Dialog not started as expected",
-				mSolo.waitForText(termsOfUseAndServiceTextExpected, 1, TIMEOUT, true, false));
+				mSolo.waitForText(termsOfUseAndServiceTextExpected));
 
 		mSolo.goBack();
 	}
@@ -61,7 +61,7 @@ public class MainActivityIntegrationTest extends BaseIntegrationTestClass {
 		aboutTextExpected = String.format(aboutTextExpected, licenseText);
 
 		assertTrue("About dialog text not correct, maybe Dialog not started as expected",
-				mSolo.waitForText(aboutTextExpected, 1, TIMEOUT, true, false));
+				mSolo.waitForText(aboutTextExpected));
 		mSolo.goBack();
 	}
 
@@ -107,7 +107,7 @@ public class MainActivityIntegrationTest extends BaseIntegrationTestClass {
 	}
 
 	private void toolHelpTest(ToolType toolToClick, int idExpectedHelptext) {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		clickLongOnTool(toolToClick);
 
 		String helpTextExpected = mSolo.getString(idExpectedHelptext);
@@ -119,7 +119,7 @@ public class MainActivityIntegrationTest extends BaseIntegrationTestClass {
 		assertTrue("Wrong or missing tool name in dialog", mSolo.searchText(toolNameInHelperDialog, true));
 
 		mSolo.clickOnButton(buttonDoneTextExpected);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		assertFalse("Help text still present", mSolo.searchText(helpTextExpected, true));
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/MenuFileActivityIntegrationTest.java
@@ -92,7 +92,7 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_new_image_empty_image));
 		mSolo.waitForDialogToClose();
 
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		int bitmapPixelColor = PaintroidApplication.drawingSurface.getPixel(new PointF(xCoordinatePixel,
 				yCoordinatePixel));
 		assertEquals("Color should be Transparent", Color.TRANSPARENT, bitmapPixelColor);
@@ -119,7 +119,7 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_load_image));
 		mSolo.waitForDialogToOpen();
 		mSolo.goBack();
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 	}
 
@@ -151,7 +151,7 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 		//mSolo.waitForDialogToOpen();
 		//mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_new_image_empty_image));
 
-		mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image), 1, TIMEOUT, true);
+		mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image));
 
 		mSolo.clickOnButton(mSolo.getString(R.string.discard_button_text));
 		mSolo.waitForDialogToClose();
@@ -170,7 +170,7 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 		openMenu();
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_new_image));
 
-		assertTrue(mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image), 1, TIMEOUT, true));
+		assertTrue(mSolo.waitForText(mSolo.getString(R.string.dialog_warning_new_image)));
 
 		assertTrue("New drawing 'yes' button not found",
 				mSolo.searchButton(mSolo.getString(R.string.save_button_text), true));
@@ -207,7 +207,7 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 
 		openMenu();
 		mSolo.clickOnMenuItem(mSolo.getString(R.string.menu_save_image));
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.waitForDialogToClose();
 		assertEquals("current Activity not MainActivity", MainActivity.class, mSolo.getCurrentActivity().getClass());
 
@@ -224,7 +224,7 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 		openMenu();
 		mSolo.clickOnText(mSolo.getString(R.string.menu_save_image));
 
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.waitForDialogToClose();
 		assertNotNull(PaintroidApplication.savedPictureUri);
 		addUriToDeletionFileList(PaintroidApplication.savedPictureUri);
@@ -236,7 +236,7 @@ public class MenuFileActivityIntegrationTest extends BaseIntegrationTestClass {
 		openMenu();
 		mSolo.clickOnText(mSolo.getString(R.string.menu_save_copy));
 
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 		mSolo.waitForDialogToClose();
 
 		File newFile = new File(PaintroidApplication.savedPictureUri.toString());

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ToolOnBackPressedTests.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/ToolOnBackPressedTests.java
@@ -64,22 +64,22 @@ public class ToolOnBackPressedTests extends BaseIntegrationTestClass {
 		int numberButtonsAtBeginning = mSolo.getCurrentViews(Button.class).size();
 
 		mSolo.goBack();
-		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity"));
 		assertTrue("Yes Option should be available", mSolo.searchText(mSolo.getString(R.string.save_button_text)));
 		assertTrue("Yes Option should be available", mSolo.searchText(mSolo.getString(R.string.discard_button_text)));
 		TextView exitTextView = mSolo.getText(mSolo.getString(R.string.closing_security_question));
 		assertNotNull("No exit Text found", exitTextView);
 
 		mSolo.goBack();
-		assertTrue("Waiting for the exit dialog to close", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for the exit dialog to close", mSolo.waitForActivity("MainActivity"));
 		assertEquals("Two buttons exit screen should be away", mSolo.getCurrentViews(Button.class).size(),
 				numberButtonsAtBeginning);
 
 		mSolo.goBack();
-		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity"));
 		mSolo.clickOnButton(mSolo.getString(R.string.discard_button_text));
 		mSolo.sleep(1000);
-		assertTrue("Waiting for the exit dialog to finish", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for the exit dialog to finish", mSolo.waitForActivity("MainActivity"));
 		assertEquals("Application finished no buttons left", mSolo.getCurrentViews(Button.class).size(), 0);
 	}
 
@@ -102,7 +102,7 @@ public class ToolOnBackPressedTests extends BaseIntegrationTestClass {
 		mSolo.sleep(SHORT_SLEEP);
 
 		mSolo.goBack();
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
 
 		// assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity", TIMEOUT));
 		mSolo.clickOnButton(mSolo.getString(R.string.save_button_text));
@@ -116,18 +116,18 @@ public class ToolOnBackPressedTests extends BaseIntegrationTestClass {
 
 	@Test
 	public void testNotBrushToolBackPressed() {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		selectTool(ToolType.CURSOR);
 
 		mSolo.goBack();
 
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		assertEquals("Switching to another tool", PaintroidApplication.currentTool.getToolType(), ToolType.BRUSH);
 	}
 
 	@Test
 	public void testToolOptionsDisappearWhenBackPressed() {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		selectTool(ToolType.CURSOR);
 		openToolOptionsForCurrentTool(ToolType.CURSOR);
 		String toolName = mSolo.getString(getCurrentTool().getToolType().getNameResource());
@@ -161,22 +161,22 @@ public class ToolOnBackPressedTests extends BaseIntegrationTestClass {
 		int numberButtonsAtBeginning = mSolo.getCurrentViews(Button.class).size();
 
 		mSolo.goBack();
-		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity"));
 		assertTrue("Yes Option should be available", mSolo.searchText(mSolo.getString(R.string.save_button_text)));
 		assertTrue("No Option should be available", mSolo.searchText(mSolo.getString(R.string.discard_button_text)));
 		TextView exitTextView = mSolo.getText(mSolo.getString(R.string.closing_security_question));
 		assertNotNull("No exit Text found", exitTextView);
 
 		mSolo.goBack();
-		assertTrue("Waiting for the exit dialog to close", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for the exit dialog to close", mSolo.waitForActivity("MainActivity"));
 		assertEquals("Two buttons exit screen should be away", mSolo.getCurrentViews(Button.class).size(),
 				numberButtonsAtBeginning);
 
 		mSolo.goBack();
-		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for the exit dialog to appear", mSolo.waitForActivity("MainActivity"));
 		mSolo.clickOnButton(mSolo.getString(R.string.save_button_text));
-		assertTrue("Waiting for the exit dialog to finish", mSolo.waitForActivity("MainActivity", TIMEOUT));
 		mSolo.sleep(8000);
+		assertTrue("Waiting for the exit dialog to finish", mSolo.waitForActivity("MainActivity"));
 		boolean hasStopped = PrivateAccess.getMemberValueBoolean(Activity.class, getActivity(), "mStopped");
 		assertTrue("MainActivity should be finished.", hasStopped);
 		fileToReturnToCatroid = new File(pathToFile);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/UndoRedoIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/UndoRedoIntegrationTest.java
@@ -111,7 +111,7 @@ public class UndoRedoIntegrationTest extends BaseIntegrationTestClass {
 
 		Point pointOnScreen = Utils.convertFromCanvasToScreen(new Point((int)pointOnBitmap.x, (int)pointOnBitmap.y), PaintroidApplication.perspective);
 		mSolo.clickOnScreen(pointOnScreen.x, pointOnScreen.y);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		float scale = 0.5f;
 		PaintroidApplication.perspective.setScale(scale); // done this way since robotium does not support > 1
@@ -147,7 +147,7 @@ public class UndoRedoIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testPreserveZoomAndMoveAfterRedo() throws SecurityException, NoSuchFieldException,
 			IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		PaintroidApplication.perspective.setScale(1.0f);
 
@@ -161,7 +161,7 @@ public class UndoRedoIntegrationTest extends BaseIntegrationTestClass {
 
 		Point pointOnScreen = Utils.convertFromCanvasToScreen(new Point((int)pointOnBitmap.x, (int)pointOnBitmap.y), PaintroidApplication.perspective);
 		mSolo.clickOnScreen(pointOnScreen.x, pointOnScreen.y);
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(pointOnBitmap);
 		assertEquals("Pixel color should be the same", colorToFill, colorAfterFill);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/dialog/BrushPickerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/dialog/BrushPickerIntegrationTest.java
@@ -64,7 +64,7 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 	@Test
 	public void testBrushPickerDialog() throws SecurityException, IllegalArgumentException, NoSuchFieldException,
 			IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		toolOptionsAreShown();
 		openToolOptionsForCurrentTool();
 		TextView brushWidthTextView = mSolo.getText("25");
@@ -78,7 +78,7 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 		int newStrokeWidth = 80;
 		int paintStrokeWidth = -1;
 		mSolo.setProgressBar(0, newStrokeWidth);
-		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class));
 		assertEquals(strokeWidthBar.getProgress(), newStrokeWidth);
 		Paint strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
@@ -89,13 +89,13 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 		assertEquals("Wrong brush width displayed", Integer.valueOf(brushWidthText), Integer.valueOf(newStrokeWidth));
 
 		mSolo.clickOnView(mSolo.getView(R.id.stroke_ibtn_rect));
-		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class));
 		strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		assertEquals(Cap.SQUARE, strokePaint.getStrokeCap());
 
 		closeToolOptionsForCurrentTool();
-		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity"));
 		strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		paintStrokeWidth = (int) strokePaint.getStrokeWidth();
@@ -106,23 +106,23 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 	@Test
 	public void testBrushPickerDialogKeepStrokeOnToolChange() throws SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		openToolOptionsForCurrentTool(ToolType.BRUSH);
 		int newStrokeWidth = 80;
 
 		assertFalse("No progress bar found", mSolo.getCurrentViews(ProgressBar.class).isEmpty());
 		mSolo.setProgressBar(0, newStrokeWidth);
-		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class));
 
 		assertFalse("No image buttons found", mSolo.getCurrentViews(ImageButton.class).isEmpty());
 		mSolo.clickOnView(mSolo.getView(R.id.stroke_ibtn_rect));
-		assertTrue("Waiting for set cap to SQUARE", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set cap to SQUARE", mSolo.waitForView(LinearLayout.class));
 		Paint strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		assertEquals("Wrong stroke cap", Cap.SQUARE, strokePaint.getStrokeCap());
 
 		closeToolOptionsForCurrentTool();
-		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity"));
 
 		selectTool(ToolType.CURSOR);
 		openToolOptionsForCurrentTool(ToolType.CURSOR);
@@ -141,14 +141,14 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 	@Test
 	public void testBrushPickerDialogTestMinimumBrushWidth() throws SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		openToolOptionsForCurrentTool(ToolType.BRUSH);
 		int newStrokeWidth = 0;
 		int minStrokeWidth = 1;
 
 		assertFalse("No progress bar found", mSolo.getCurrentViews(ProgressBar.class).isEmpty());
 		mSolo.setProgressBar(0, newStrokeWidth);
-		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class));
 		ArrayList<ProgressBar> progressBars = mSolo.getCurrentViews(ProgressBar.class);
 		assertEquals(progressBars.size(), 1);
 		SeekBar strokeWidthBar = (SeekBar) progressBars.get(0);
@@ -159,7 +159,7 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 	public void testAntiAliasingOffAtBrushSize1() throws SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
 		openToolOptionsForCurrentTool(ToolType.BRUSH);
-		mSolo.waitForText(mSolo.getString(R.string.stroke_title), 1, TIMEOUT);
+		mSolo.waitForText(mSolo.getString(R.string.stroke_title));
 		mSolo.setProgressBar(0, 1);
 		closeToolOptionsForCurrentTool();
 
@@ -181,13 +181,13 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 		assertFalse("No progress bar found", mSolo.getCurrentViews(ProgressBar.class).isEmpty());
 
 		mSolo.clickOnRadioButton(0);
-		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class));
 		Paint strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		assertEquals(strokePaint.getStrokeCap(), Cap.SQUARE);
 
 		closeToolOptionsForCurrentTool();
-		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity"));
 		strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		assertEquals(strokePaint.getStrokeCap(), Cap.SQUARE);
@@ -197,13 +197,13 @@ public class BrushPickerIntegrationTest extends BaseIntegrationTestClass {
 		assertFalse("No progress bar found", mSolo.getCurrentViews(ProgressBar.class).isEmpty());
 
 		mSolo.clickOnRadioButton(1);
-		assertTrue("Waiting for set stroke cap ROUND ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke cap ROUND ", mSolo.waitForView(LinearLayout.class));
 		strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		assertEquals(strokePaint.getStrokeCap(), Cap.ROUND);
 
 		closeToolOptionsForCurrentTool();
-		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity", TIMEOUT));
+		assertTrue("Waiting for Tool to be ready", mSolo.waitForActivity("MainActivity"));
 		strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		assertEquals(strokePaint.getStrokeCap(), Cap.ROUND);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/dialog/ColorDialogIntegrationTest.java
@@ -77,7 +77,7 @@ public class ColorDialogIntegrationTest extends BaseIntegrationTestClass {
 	public void testStandardTabSelected() throws Throwable {
 		int expectedIndexTab = 0;
 
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		mSolo.clickOnView(mButtonTopColor);
 		mSolo.sleep(COLOR_PICKER_DIALOGUE_APPERANCE_DELAY);
 		TabHost tabhost = (TabHost) mSolo.getView(R.id.colorview_tabColors);
@@ -90,7 +90,7 @@ public class ColorDialogIntegrationTest extends BaseIntegrationTestClass {
 	public void testTabsAreSelectable() throws Throwable {
 		String[] colorChooserTags = { mSolo.getString(R.string.color_pre),mSolo.getString(R.string.color_hsv), mSolo.getString(R.string.color_rgb) };
 
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		mSolo.clickOnView(mButtonTopColor);
 		mSolo.sleep(COLOR_PICKER_DIALOGUE_APPERANCE_DELAY);
 
@@ -118,7 +118,7 @@ public class ColorDialogIntegrationTest extends BaseIntegrationTestClass {
 	public void testColorNewColorButtonChangesStandard() {
 		int numberOfColorsToTest = 20;
 
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		mSolo.clickOnView(mButtonTopColor);
 		mSolo.sleep(COLOR_PICKER_DIALOGUE_APPERANCE_DELAY);
 
@@ -158,21 +158,21 @@ public class ColorDialogIntegrationTest extends BaseIntegrationTestClass {
 	}
 
 	public void testColorPickerDialogOnBackPressed() {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		openColorChooserDialog();
 		mSolo.goBack();
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		int oldColor = getCurrentTool().getDrawPaint().getColor();
 		openColorChooserDialog();
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForText(mSolo.getString(R.string.done), 1, TIMEOUT * 2));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForText(mSolo.getString(R.string.done)));
 
 		TypedArray presetColors = getActivity().getResources().obtainTypedArray(R.array.preset_colors);
 
 		mSolo.clickOnButton(presetColors.length() / 2);
 		mSolo.goBack();
 
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 		int newColor = getCurrentTool().getDrawPaint().getColor();
 		assertFalse("After choosing new color, color should not be the same as before", oldColor == newColor);
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/EraserToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/EraserToolIntegrationTest.java
@@ -56,7 +56,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 	}
 
 	public void testEraseNothing() {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		DrawingSurface drawingSurface = (DrawingSurface) getActivity().findViewById(R.id.drawingSurfaceView);
 
@@ -76,7 +76,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testErase() throws SecurityException, IllegalArgumentException, NoSuchFieldException,
 			IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		PointF screenPoint = new PointF(mScreenWidth / 2, mScreenHeight / 2);
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);
@@ -99,7 +99,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 	public void testSwitchingBetweenBrushAndEraser() throws SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
 
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		PointF screenPoint = new PointF(mScreenWidth / 2, mScreenHeight / 2);
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);
@@ -134,7 +134,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testChangeEraserBrushSize() throws SecurityException, IllegalArgumentException, NoSuchFieldException,
 			IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		PointF screenPoint = new PointF(mScreenWidth / 2, mScreenHeight / 2);
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);
@@ -158,7 +158,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 		int newStrokeWidth = 80;
 		mSolo.setProgressBar(0, newStrokeWidth);
-		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class));
 		assertEquals(strokeWidthBar.getProgress(), newStrokeWidth);
 		closeToolOptionsForCurrentTool();
 		Paint strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
@@ -174,7 +174,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testChangeEraserBrushForm() throws SecurityException, IllegalArgumentException, NoSuchFieldException,
 			IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		PointF screenPoint = new PointF(mScreenWidth / 2, mScreenHeight / 2);
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);
@@ -190,7 +190,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 		mSolo.clickOnView(mSolo.getView(R.id.stroke_ibtn_rect));
 
-		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class));
 		Paint strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		closeToolOptionsForCurrentTool();
@@ -204,7 +204,7 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testRestorePreviousToolSettings() throws SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		selectTool(ToolType.BRUSH);
 		openToolOptionsForCurrentTool(ToolType.BRUSH);
@@ -219,11 +219,11 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 		int newStrokeWidth = 80;
 		mSolo.setProgressBar(0, newStrokeWidth);
-		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class));
 		assertEquals(strokeWidthBar.getProgress(), newStrokeWidth);
 
 		mSolo.clickOnView(mSolo.getView(R.id.stroke_ibtn_rect));
-		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class));
 		Paint strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		int paintStrokeWidth = (int) strokePaint.getStrokeWidth();
@@ -241,11 +241,11 @@ public class EraserToolIntegrationTest extends BaseIntegrationTestClass {
 
 		int eraserStrokeWidth = 60;
 		mSolo.setProgressBar(0, eraserStrokeWidth);
-		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke width ", mSolo.waitForView(LinearLayout.class));
 		assertEquals(eraserStrokeWidthBar.getProgress(), eraserStrokeWidth);
 
 		mSolo.clickOnView(mSolo.getView(R.id.stroke_ibtn_circle));
-		assertTrue("Waiting for set stroke cap ROUND ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke cap ROUND ", mSolo.waitForView(LinearLayout.class));
 		closeToolOptionsForCurrentTool();
 		Paint eraserStrokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class,
 				PaintroidApplication.currentTool, "mCanvasPaint");

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/FillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/FillToolIntegrationTest.java
@@ -58,7 +58,7 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testFloodFillIfImageLoaded() throws InterruptedException, SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		PaintroidApplication.savedPictureUri = Uri.fromFile(new File("dummy"));
 
@@ -72,21 +72,21 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 		PointF checkCanvasPoint = Utils.getCanvasPointFromScreenPoint(checkScreenPoint);
 
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToOpen();
+		mSolo.waitForDialogToClose();
 		mSolo.sleep(SHORT_SLEEP);
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(checkCanvasPoint);
 		assertEquals("Pixel color should be the same.", colorToFill, colorAfterFill);
 
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y);
-		assertTrue("Fill timed out", mSolo.waitForDialogToClose(TIMEOUT));
+		assertTrue("Fill timed out", mSolo.waitForDialogToClose());
 		PaintroidApplication.savedPictureUri = null;
 
 	}
 
 	public void testNoFloodFillIfEmpty() throws InterruptedException, SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		selectTool(ToolType.FILL);
 
@@ -98,14 +98,14 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 		PointF checkCanvasPoint = Utils.getCanvasPointFromScreenPoint(checkScreenPoint);
 
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y); // to fill the bitmap
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(checkCanvasPoint);
 		assertEquals("Pixel color should be the same", colorToFill, colorAfterFill);
 	}
 
 	public void testBitmapIsFilled() throws InterruptedException, SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		selectTool(ToolType.FILL);
 
@@ -118,7 +118,7 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y); // to fill the bitmap
 		mSolo.sleep(SHORT_SLEEP);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(checkCanvasPoint);
 
 		assertEquals("Pixel color should be the same", colorToFill, colorAfterFill);
@@ -126,7 +126,7 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testNothingHappensWhenClickedOutsideDrawingArea() throws InterruptedException, SecurityException,
 			IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		selectTool(ToolType.FILL);
 
@@ -139,8 +139,8 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 		PointF insideCanvasPoint = Utils.getCanvasPointFromScreenPoint(insideScreenPoint);
 
 		mSolo.clickOnScreen(outsideScreenPoint.x, outsideScreenPoint.y);
-		mSolo.waitForDialogToOpen(SHORT_TIMEOUT);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToOpen();
+		mSolo.waitForDialogToClose();
 
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(insideCanvasPoint);
 		assertFalse("Pixel color should not be the same", (colorToFill == colorAfterFill));
@@ -186,7 +186,7 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 		mSolo.clickOnButton(5);
 		mSolo.sleep(SHORT_SLEEP);
 		mSolo.clickOnButton(getActivity().getResources().getString(R.string.done));
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		int colorToFill = PaintroidApplication.currentTool.getDrawPaint().getColor();
 		assertFalse(colorToDrawBorder == colorToFill);
@@ -194,7 +194,7 @@ public class FillToolIntegrationTest extends BaseIntegrationTestClass {
 
 		mSolo.clickOnScreen(clickScreenPoint.x, clickScreenPoint.y);
 		mSolo.sleep(SHORT_SLEEP);
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToClose();
 
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(checkCanvasPoint);
 		assertEquals("Pixel color should be the same", colorToFill, colorAfterFill);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/LineToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/LineToolIntegrationTest.java
@@ -62,7 +62,7 @@ public class LineToolIntegrationTest extends BaseIntegrationTestClass {
 		// Switching to Fullscreen, this makes pointOnCanvas equal to pointOnScreen
 
 		selectTool(ToolType.LINE);
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToClose();
 		//switchToFullscreen(); TODO: there is no more full screen, adapt test if necessary!
 
 		float clickCoordinateX = mScreenWidth / 2;
@@ -87,7 +87,7 @@ public class LineToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testHorizontalLineColor()  {
 		selectTool(ToolType.LINE);
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToClose();
 		//switchToFullscreen(); TODO: there is no more full screen, adapt test if necessary!
 
 		float clickCoordinateX = mScreenWidth / 2;
@@ -112,7 +112,7 @@ public class LineToolIntegrationTest extends BaseIntegrationTestClass {
 
 	public void testDiagonaleLineColor() {
 		selectTool(ToolType.LINE);
-		mSolo.waitForDialogToClose(TIMEOUT);
+		mSolo.waitForDialogToClose();
 		// switchToFullscreen();  TODO: there is no more full screen, adapt test if necessary!
 
 		float clickCoordinateX = mScreenWidth / 2;
@@ -135,7 +135,7 @@ public class LineToolIntegrationTest extends BaseIntegrationTestClass {
 	}
 
 	public void testChangeLineToolForm() throws NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		PointF screenPoint = new PointF(mScreenWidth/2.0f, mScreenHeight/2.0f);
 		PointF pointOnBitmap = Utils.getCanvasPointFromScreenPoint(screenPoint);
@@ -146,7 +146,7 @@ public class LineToolIntegrationTest extends BaseIntegrationTestClass {
 		openToolOptionsForCurrentTool();
 		mSolo.clickOnView(mSolo.getView(R.id.stroke_ibtn_rect));
 
-		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class, 1, TIMEOUT));
+		assertTrue("Waiting for set stroke cap SQUARE ", mSolo.waitForView(LinearLayout.class));
 		Paint strokePaint = (Paint) PrivateAccess.getMemberValue(BaseTool.class, PaintroidApplication.currentTool,
 				"mCanvasPaint");
 		closeToolOptionsForCurrentTool();

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/RectangleFillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/RectangleFillToolIntegrationTest.java
@@ -137,7 +137,7 @@ public class RectangleFillToolIntegrationTest extends BaseIntegrationTestClass {
 	@Test
 	public void testRectOnBitmapHasSameColorAsInColorPickerAfterColorChange() throws SecurityException,
 			IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		int colorPickerColorBeforeChange = getCurrentTool().getDrawPaint().getColor();
 		openColorChooserDialog();

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/StampToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/StampToolIntegrationTest.java
@@ -218,7 +218,7 @@ public class StampToolIntegrationTest extends BaseIntegrationTestClass {
 	@Test
 	public void testStampOutsideDrawingSurface() throws SecurityException, IllegalArgumentException,
 			NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class, 1, TIMEOUT));
+		assertTrue("Waiting for DrawingSurface", mSolo.waitForView(DrawingSurface.class));
 
 		mSolo.clickOnScreen(getSurfaceCenterX(), getSurfaceCenterY() + Utils.getActionbarHeight()
 				+ getStatusbarHeight() - Y_CLICK_OFFSET);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/TransformToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/TransformToolIntegrationTest.java
@@ -29,6 +29,9 @@ import android.test.FlakyTest;
 import android.util.Log;
 import android.view.Display;
 
+import com.robotium.solo.Condition;
+import com.robotium.solo.Timeout;
+
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.dialog.LayersDialog;
@@ -84,14 +87,14 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 	@After
 	protected void tearDown() throws Exception {
 		// eat all toasts
-		final int resizeToastSleepingTime = 100;
-		for (int resizeToastTimeoutCounter = 0; resizeToastSleepingTime * resizeToastTimeoutCounter < TIMEOUT; resizeToastTimeoutCounter++) {
-			if (mSolo.waitForText(mSolo.getString(R.string.resize_to_resize_tap_text), 1, 10)
-					|| mSolo.waitForText(mSolo.getString(R.string.resize_nothing_to_resize), 1, 10))
-				mSolo.sleep(resizeToastSleepingTime);
-			else
-				break;
-		}
+		mSolo.waitForCondition(new Condition() {
+			@Override
+			public boolean isSatisfied() {
+				return mSolo.waitForText(mSolo.getString(R.string.resize_to_resize_tap_text), 1, 10)
+						|| mSolo.waitForText(mSolo.getString(R.string.resize_nothing_to_resize), 1, 10);
+			}
+		}, Timeout.getLargeTimeout());
+
 		super.tearDown();
 	}
 
@@ -115,7 +118,7 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 
 		clickInBox();
 		assertTrue("nothing to crop text missing",
-				mSolo.waitForText(mSolo.getString(R.string.resize_nothing_to_resize), 1, TIMEOUT, true));
+				mSolo.waitForText(mSolo.getString(R.string.resize_nothing_to_resize)));
 
 	}
 
@@ -167,12 +170,11 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 
 		selectTool(ToolType.TRANSFORM);
 		assertTrue("to resize tap text missing",
-				mSolo.waitForText(mSolo.getString(R.string.resize_to_resize_tap_text), 1, TIMEOUT, true));
+				mSolo.waitForText(mSolo.getString(R.string.resize_to_resize_tap_text)));
 		assertTrue("Resize command has not finished", mSolo.waitForDialogToClose());
 
 		clickInBox();
-		assertTrue("nothing to resize text missing",
-				mSolo.waitForText(mSolo.getString(R.string.resize_nothing_to_resize), 1, TIMEOUT, true));
+		assertTrue("nothing to resize text missing", mSolo.waitForText(mSolo.getString(R.string.resize_nothing_to_resize)));
 	}
 
 	@Test
@@ -407,7 +409,7 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 
 		mSolo.clickOnView(mButtonTopUndo);
 
-		assertTrue("Progress dialog did not close", mSolo.waitForDialogToClose(TIMEOUT));
+		assertTrue("Progress dialog did not close", mSolo.waitForDialogToClose());
 		PaintroidApplication.perspective.setScale(1.0f);
 
 		Point bottomRightCanvasPointAfterUndo = new Point(mCurrentDrawingSurfaceBitmap.getWidth() - 1,
@@ -609,7 +611,7 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y);
 		mSolo.sleep(SHORT_SLEEP);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(canvasPoint);
 		assertEquals("Wrong pixel color after fill", colorToFill, colorAfterFill);
 
@@ -861,7 +863,7 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y);
 		mSolo.sleep(SHORT_SLEEP);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(canvasPoint);
 		assertEquals("Wrong pixel color after fill", colorToFill, colorAfterFill);
 
@@ -947,7 +949,7 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 		PointF canvasPoint = Utils.getCanvasPointFromScreenPoint(screenPoint);
 		mSolo.clickOnScreen(screenPoint.x, screenPoint.y);
 		mSolo.sleep(SHORT_SLEEP);
-		mSolo.waitForDialogToClose(SHORT_TIMEOUT);
+		mSolo.waitForDialogToClose();
 		int colorAfterFill = PaintroidApplication.drawingSurface.getPixel(canvasPoint);
 		assertEquals("Wrong pixel color after fill", colorToFill, colorAfterFill);
 
@@ -1111,7 +1113,7 @@ public class TransformToolIntegrationTest extends BaseIntegrationTestClass {
 	private void failWhenCroppingTimedOut() {
 		int croppingTimeoutCounter = hasCroppingTimedOut();
 		if (croppingTimeoutCounter >= 0) {
-			fail("Cropping algorithm took too long " + croppingTimeoutCounter * TIMEOUT + "ms");
+			fail("Cropping algorithm took too long " + croppingTimeoutCounter * Timeout.getLargeTimeout() + "ms");
 		}
 	}
 


### PR DESCRIPTION
* Instead the timeouts are set directly for in the Timeout class used by solo.
* Timeouts are higher when running on the emulator.
* Uses waitForCondition instead of a manual sleep.

These changes make the code more readable.

Note: Might conflict with #365 since the TIMEOUT variable is removed here but used there.
I'll fix the issue for the PR that is accepted later.