### PR TITLE
Automatize the creation of independent APKs.

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -2,19 +2,31 @@
 apply plugin: 'com.android.application'
 apply from: 'adb_tasks.gradle'
 
+def appId = 'org.catrobat.paintroid'
+def appName = '@string/app_name'
+
+// When -Pindependent was provided on the gradle command the APP name is changed.
+// This allows to have multiple Paintroid versions installed in parallel for testing purposes.
+// Furthermore these installations do not interfere with the actual Paintroid app.
+if (project.hasProperty('independent')) {
+    def today = new Date()
+    appId += '.independent_' + today.format('YYYYMMdd_HHmm')
+    appName = property('independent') ?: 'Paint ' + today.format('MMdd HH:mm')
+}
+
 android {
     compileSdkVersion 25
     buildToolsVersion '25.0.1'
 
     defaultConfig {
-        applicationId "org.catrobat.paintroid"
+        applicationId appId
         minSdkVersion 16
         targetSdkVersion 22
-        testApplicationId "org.catrobat.paintroid.test"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         testInstrumentationRunner "pl.polidea.instrumentation.PolideaInstrumentationTestRunner"
         versionCode 18
         versionName "1.1.15"
+        manifestPlaceholders += [appName: appName]
     }
 
     sourceSets {

--- a/Paintroid/src/main/AndroidManifest.xml
+++ b/Paintroid/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
         android:name=".PaintroidApplication"
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appName}"
         android:largeHeap="true"
         android:supportsRtl="true"
         android:theme="@style/MyMaterialTheme"
@@ -52,7 +52,7 @@
         <activity
             android:name=".WelcomeActivity"
             android:configChanges="locale"
-            android:label="@string/app_name"
+            android:label="${appName}"
             android:screenOrientation="portrait"
             android:theme="@style/WelcomeActivityTheme">
             <intent-filter>
@@ -83,7 +83,7 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="locale"
-            android:label="@string/app_name">
+            android:label="${appName}">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>


### PR DESCRIPTION
Independent APKs are allowed to be installed without affecting the
current Pocket Paint installation.
This is useful for testers to have different versions installed in parallel.
Automating this process makes it more accessible and allows Jenkins
to provide such independent APKs.

# Usage
./gradlew -Pindependent assembleDebug

The created Paintroid-debug.apk file has an internal application name
that depends on the current date and time.
The user displayed label is of the form "Paint MMdd HH:mm" in UTC.

Alternatively you can provide an application name yourself:
./gradlew -Pindependent="Paint Design #2" assembleDebug

# Implementation
The application name and the package name are stored as placeholders in
android manifest.
Moreover the test application id is not set manually anymore, since it
is created automatically by the android gradle plugin.