### PR TITLE
Paint-176: pipette selects visible color from all layers

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/PipetteToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/PipetteToolIntegrationTest.java
@@ -1,0 +1,141 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.espresso.tools;
+
+import android.graphics.Color;
+import android.graphics.PointF;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.PaintroidApplication;
+import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.test.espresso.util.ActivityHelper;
+import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
+import org.catrobat.paintroid.tools.ToolType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.TRANSPARENT_COLOR_PICKER_BUTTON_POSITION;
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getCanvasPointFromScreenPoint;
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.resetColorPicker;
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.resetDrawPaintAndBrushPickerView;
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.selectColorPickerPresetSelectorColor;
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.selectTool;
+import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class PipetteToolIntegrationTest {
+
+	@Rule
+	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
+
+	@Rule
+	public SystemAnimationsRule systemAnimationsRule = new SystemAnimationsRule();
+
+	private ActivityHelper activityHelper;
+	private PointF screenPoint;
+	private PointF canvasPoint;
+
+	@Before
+	public void setUp() {
+		activityHelper = new ActivityHelper(launchActivityRule.getActivity());
+
+		PaintroidApplication.drawingSurface.destroyDrawingCache();
+
+		screenPoint = new PointF(activityHelper.getDisplayWidth() / 2, activityHelper.getDisplayHeight() / 2);
+		canvasPoint = getCanvasPointFromScreenPoint(screenPoint);
+
+		selectTool(ToolType.BRUSH);
+		resetColorPicker();
+		resetDrawPaintAndBrushPickerView();
+	}
+
+	@After
+	public void tearDown() {
+		screenPoint = null;
+		canvasPoint = null;
+		activityHelper = null;
+	}
+
+	@Test
+	public void testEmpty() {
+		int toolColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals("Initial Tool color should be black", Color.BLACK, toolColor);
+
+		int colorAtCanvas = PaintroidApplication.drawingSurface.getPixel(canvasPoint);
+		assertEquals("Get transparent background color", Color.TRANSPARENT, colorAtCanvas);
+
+		selectTool(ToolType.PIPETTE);
+
+		onView(isRoot()).perform(touchAt(screenPoint));
+
+		toolColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals("Tool color should be transparent", colorAtCanvas, toolColor);
+	}
+
+	@Test
+	public void testPipetteAfterBrushOnSingleLayer() {
+
+		onView(isRoot()).perform(touchAt(screenPoint));
+
+		int colorAtCanvas = PaintroidApplication.drawingSurface.getPixel(canvasPoint);
+		assertEquals("After painting black, pixel should be black", Color.BLACK, colorAtCanvas);
+
+		selectColorPickerPresetSelectorColor(TRANSPARENT_COLOR_PICKER_BUTTON_POSITION);
+		selectTool(ToolType.PIPETTE);
+
+		onView(isRoot()).perform(touchAt(screenPoint));
+
+		int pipetteColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals("Tool color should be black", colorAtCanvas, pipetteColor);
+	}
+
+	@Test
+	public void testPipetteAfterBrushOnMultiLayer() {
+		onView(isRoot()).perform(touchAt(screenPoint));
+
+		int colorAtFirstLayer = PaintroidApplication.drawingSurface.getPixel(canvasPoint);
+		assertEquals("After painting black, pixel should be black", Color.BLACK, colorAtFirstLayer);
+
+		onView(withId(R.id.btn_top_layers)).perform(click());
+		onView(withId(R.id.layer_side_nav_button_add)).perform(click());
+
+		int colorAtSecondLayer = PaintroidApplication.drawingSurface.getPixel(canvasPoint);
+		assertEquals("Background color should be transparent on new layer", Color.TRANSPARENT, colorAtSecondLayer);
+
+		onView(isRoot()).perform(click());
+		selectColorPickerPresetSelectorColor(TRANSPARENT_COLOR_PICKER_BUTTON_POSITION);
+		selectTool(ToolType.PIPETTE);
+
+		onView(isRoot()).perform(touchAt(screenPoint));
+
+		int pipetteColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals("Tool color should be black", colorAtFirstLayer, pipetteColor);
+	}
+}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
@@ -19,28 +19,19 @@
 
 package org.catrobat.paintroid.test.junit.tools;
 
-import org.catrobat.paintroid.PaintroidApplication;
-import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.test.junit.stubs.DrawingSurfaceStub;
-import org.catrobat.paintroid.test.utils.PrivateAccess;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.PointF;
+import android.test.UiThreadTest;
+
+import org.catrobat.paintroid.listener.LayerListener;
+import org.catrobat.paintroid.tools.Layer;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.implementation.BaseTool;
-import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
 import org.catrobat.paintroid.tools.implementation.PipetteTool;
-import org.catrobat.paintroid.ui.DrawingSurface;
-import org.catrobat.paintroid.ui.TopBar;
-import org.catrobat.paintroid.ui.TopBar.ToolButtonIDs;
+import org.catrobat.paintroid.ui.button.LayersAdapter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import android.graphics.Bitmap;
-import android.graphics.Bitmap.Config;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.PointF;
-import android.test.UiThreadTest;
-import android.widget.ImageButton;
 
 public class PipetteToolTest extends BaseToolTest {
 
@@ -48,7 +39,6 @@ public class PipetteToolTest extends BaseToolTest {
 	private final int X_COORDINATE_GREEN = 3;
 	private final int X_COORDINATE_BLUE = 5;
 	private final int X_COORDINATE_PART_TRANSPARENT = 7;
-	private DrawingSurface mOriginalDrawingSurface = null;
 
 	public PipetteToolTest() {
 		super();
@@ -59,23 +49,23 @@ public class PipetteToolTest extends BaseToolTest {
 	public void setUp() throws Exception {
 		mToolToTest = new PipetteTool(getActivity(), ToolType.PIPETTE);
 		super.setUp();
-		DrawingSurfaceStub drawingSurfaceStub = new DrawingSurfaceStub(getActivity());
-		drawingSurfaceStub.mBitmap = Bitmap.createBitmap(10, 1, Config.ARGB_8888);
-		drawingSurfaceStub.mBitmap.setPixel(X_COORDINATE_RED, 0, Color.RED);
-		drawingSurfaceStub.mBitmap.setPixel(X_COORDINATE_GREEN, 0, Color.GREEN);
-		drawingSurfaceStub.mBitmap.setPixel(X_COORDINATE_BLUE, 0, Color.BLUE);
-		drawingSurfaceStub.mBitmap.setPixel(X_COORDINATE_PART_TRANSPARENT, 0, 0xAAAAAAAA);
-		mOriginalDrawingSurface = PaintroidApplication.drawingSurface;
-		PaintroidApplication.drawingSurface = drawingSurfaceStub;
+
+		LayerListener layerListener = LayerListener.getInstance();
+		LayersAdapter layersAdapter = layerListener.getAdapter();
+		Layer layer = layersAdapter.getLayer(0);
+		Bitmap bitmap = layer.getImage();
+		bitmap.setPixel(X_COORDINATE_RED, 0, Color.RED);
+		bitmap.setPixel(X_COORDINATE_GREEN, 0, Color.GREEN);
+		bitmap.setPixel(X_COORDINATE_BLUE, 0, Color.BLUE);
+		bitmap.setPixel(X_COORDINATE_PART_TRANSPARENT, 0, 0xAAAAAAAA);
+		layer.setImage(bitmap);
+
+		((PipetteTool)mToolToTest).updateSurfaceBitmap();
 	}
 
 	@Override
 	@After
 	public void tearDown() {
-		DrawingSurfaceStub drawingSurfaceStub = (DrawingSurfaceStub) PaintroidApplication.drawingSurface;
-		PaintroidApplication.drawingSurface = mOriginalDrawingSurface;
-		drawingSurfaceStub.mBitmap.recycle();
-		drawingSurfaceStub.mBitmap = null;
 		try {
 			super.tearDown();
 		} catch (Exception e) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
@@ -20,18 +20,22 @@
 package org.catrobat.paintroid.tools.implementation;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.PointF;
-import android.widget.LinearLayout;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
+import org.catrobat.paintroid.listener.LayerListener;
 import org.catrobat.paintroid.tools.ToolType;
 
 public class PipetteTool extends BaseTool {
 
+	private Bitmap mSurfaceBitmap;
+
 	public PipetteTool(Context context, ToolType toolType) {
 		super(context, toolType);
+
+		updateSurfaceBitmap();
 	}
 
 	@Override
@@ -57,10 +61,21 @@ public class PipetteTool extends BaseTool {
 		if (coordinate == null) {
 			return false;
 		}
-		int color = PaintroidApplication.drawingSurface.getPixel(coordinate);
+
+		if (coordinate.x < 0 || coordinate.y < 0 ||
+				coordinate.x >= mSurfaceBitmap.getWidth() || coordinate.y >= mSurfaceBitmap.getHeight()) {
+			return false;
+		}
+
+		int color = mSurfaceBitmap.getPixel((int) coordinate.x, (int) coordinate.y);
+
 		ColorPickerDialog.getInstance().setInitialColor(color);
 		changePaintColor(color);
 		return true;
+	}
+
+	public void updateSurfaceBitmap() {
+		mSurfaceBitmap = LayerListener.getInstance().getBitmapOfAllLayersToSave();
 	}
 
 	@Override


### PR DESCRIPTION
* Pipette now uses a buffered bitmap of all merged layers to retrieve color information
* Adapted the existing junit tests
* Added Espresso integration tests
* ~~Added `.externalNativeBuild` to gitignore~~