### PR TITLE
PAINT-204: Handle onBackPressed in WelcomeActivity

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/ViewPagerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/ViewPagerIntegrationTest.java
@@ -33,12 +33,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.pressBack;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.swipeLeft;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.TestCase.assertFalse;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.shouldStartSequence;
 
 @RunWith(JUnit4.class)
@@ -92,6 +92,11 @@ public class ViewPagerIntegrationTest extends IntroTestBase {
             assertEquals(i, viewPager.getCurrentItem());
             onView(isRoot()).perform(swipeLeft());
         }
+    }
+
+    @Test
+    public void PressBack() {
+        pressBack();
     }
 
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
@@ -30,14 +30,11 @@ import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Html;
 import android.text.Spanned;
-import android.util.Log;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.catrobat.paintroid.intro.IntroPageViewAdapter;
@@ -273,6 +270,11 @@ public class WelcomeActivity extends AppCompatActivity {
             result = Html.fromHtml(html);
         }
         return result;
+    }
+
+    @Override
+    public void onBackPressed() {
+        launchHomeScreen();
     }
 
     @Override


### PR DESCRIPTION
`WelcomeActivity` now skips the intro when the back button is pressed instead of closing the app.