### PR TITLE
PAINT-201: Drawer Preview out of sync

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
@@ -25,6 +25,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PointF;
+import android.support.annotation.ColorInt;
 import android.view.View;
 import android.widget.ImageButton;
 
@@ -36,68 +37,37 @@ import org.catrobat.paintroid.ui.button.ColorButton;
 public class EraserTool extends DrawTool {
 
 	private ColorButton mColorButton;
-	private ImageButton mColorPickerPalette;
-	private Paint mPreviousPaint;
+	private View mColorPickerPalette;
+	private @ColorInt int mPreviousColor;
 
 	public EraserTool(Context context, ToolType toolType) {
 		super(context, toolType);
 
-		mPreviousPaint = new Paint(
-				PaintroidApplication.currentTool.getDrawPaint());
-
-		changePaintColor(Color.TRANSPARENT);
-
-		mCanvasPaint.setStrokeCap(mPreviousPaint.getStrokeCap());
-		mCanvasPaint.setStrokeWidth(mPreviousPaint.getStrokeWidth());
-
+		mPreviousColor = Color.MAGENTA;
 		displayEraserInsteadOfSelectedColor();
-
 	}
 
-	public void displayEraserInsteadOfSelectedColor() {
+	private void displayEraserInsteadOfSelectedColor() {
 		mColorButton = (ColorButton) ((Activity) mContext).findViewById(R.id.btn_top_color);
 		mColorButton.setImageResource(R.drawable.icon_topbar_eraser);
 
-		mColorPickerPalette = (ImageButton) ((Activity) mContext).findViewById(R.id.btn_top_color_palette);
+		mColorPickerPalette = ((Activity) mContext).findViewById(R.id.btn_top_color_palette);
 		mColorPickerPalette.setVisibility(View.INVISIBLE);
 
 		mColorButton.setDrawSelectedColor(false);
 	}
 
 	@Override
-	public void draw(Canvas canvas) {
-		super.draw(canvas);
-	}
-
-	@Override
-	public boolean handleDown(PointF coordinate) {
-		return (super.handleDown(coordinate));
-	}
-
-	@Override
-	public boolean handleMove(PointF coordinate) {
-		return (super.handleMove(coordinate));
-	}
-
-	@Override
-	public boolean handleUp(PointF coordinate) {
-		return (super.handleUp(coordinate));
-	}
-
-	@Override
-	public void resetInternalState(StateChange stateChange) {
-		super.resetInternalState(stateChange);
-	}
-
-	@Override
 	public Paint getDrawPaint() {
-		return new Paint(this.mPreviousPaint);
+		Paint paint = super.getDrawPaint();
+		paint.setColor(mPreviousColor);
+		return paint;
 	}
 
 	@Override
 	public void setDrawPaint(Paint paint) {
-		changePaintColor(Color.TRANSPARENT);
-		// previous paint object has already been saved in constructor
+		super.setDrawPaint(paint);
+		mPreviousColor = paint.getColor();
 	}
 
 	@Override


### PR DESCRIPTION
* EraserTool
  * Simplified, removed unnecessary overrides
  * Removed reference to static currentTool
  * Changed previousPaint to previousColor to support change of style
* BottomBar
  * Restructured to use a ToolType instead of Tool reference
  * Mirrored switchTool method and set previous Paint to new Tool
  * Restructured onClick and onLongClick methods to improve readability