### PR TITLE
PAINT-222: remove color picker listeners created by tools

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/ColorPickerDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/ColorPickerDialog.java
@@ -93,6 +93,10 @@ public final class ColorPickerDialog extends BaseDialog {
 		mOnColorPickedListener.add(listener);
 	}
 
+	public void removeOnColorPickedListener(OnColorPickedListener listener) {
+		mOnColorPickedListener.remove(listener);
+	}
+
 	public void updateColorChange(int color) {
 		for (OnColorPickedListener listener : mOnColorPickedListener) {
 			listener.colorChanged(color);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
@@ -371,6 +371,8 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 
 	@Override
 	public void leaveTool() {
+		ColorPickerDialog.getInstance().removeOnColorPickedListener(mColor);
+		BrushPickerView.getInstance().removeBrushChangedListener(mStroke);
 	}
 
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
@@ -81,14 +81,6 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 
 		mShapeDrawType = ShapeDrawType.FILL;
 
-		mColor = new OnColorPickedListener() {
-			@Override
-			public void colorChanged(int color) {
-				changePaintColor(color);
-				createAndSetBitmap();
-			}
-		};
-
 		createAndSetBitmap();
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
@@ -38,7 +38,6 @@ import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.implementation.LayerCommand;
 import org.catrobat.paintroid.command.implementation.TextToolCommand;
 import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
 import org.catrobat.paintroid.listener.LayerListener;
 import org.catrobat.paintroid.listener.TextToolOptionsListener;
 import org.catrobat.paintroid.tools.Layer;
@@ -53,7 +52,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 	private static final boolean RESIZE_POINTS_VISIBLE = true;
 
 	private TextToolOptionsListener.OnTextToolOptionsChangedListener mOnTextToolOptionsChangedListener;
-	private ColorPickerDialog.OnColorPickedListener mOnColorPickedListener;
 	private View mTextToolOptionsView;
 	private String mText = "";
 	private String[] mMultilineText = {""};
@@ -76,13 +74,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 		setResizePointsVisible(RESIZE_POINTS_VISIBLE);
 
 		mPaintInitialized = initializePaint();
-		mOnColorPickedListener = new ColorPickerDialog.OnColorPickedListener() {
-			@Override
-			public void colorChanged(int color) {
-				changeTextColor();
-			}
-		};
-		ColorPickerDialog.getInstance().addOnColorPickedListener(mOnColorPickedListener);
 
 		createAndSetBitmap();
 		resetBoxPosition();
@@ -300,6 +291,12 @@ public class TextTool extends BaseToolWithRectangleShape {
 	public void setDrawPaint(Paint paint) {
 		super.setDrawPaint(paint);
 		mTextPaint.setColor(mCanvasPaint.getColor());
+	}
+
+	@Override
+	public void changePaintColor(int color) {
+		super.changePaintColor(color);
+		changeTextColor();
 	}
 
 }


### PR DESCRIPTION
* leaveTool() removes the created listener
* BrushPicker listeners get also removed now
* TextTool uses the color picker listener from base class