### PR TITLE
Paint 226 back to pocket code after activity switch

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Intent;
 import android.database.Cursor;
+import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PointF;
 import android.net.Uri;
@@ -35,6 +36,7 @@ import org.catrobat.paintroid.Multilingual;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.WelcomeActivity;
+import org.catrobat.paintroid.listener.LayerListener;
 import org.catrobat.paintroid.test.espresso.util.ActivityHelper;
 import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
 import org.catrobat.paintroid.tools.ToolType;
@@ -200,43 +202,35 @@ public class MenuFileActivityIntegrationTest {
 	}
 
 	@Test
-	public void testWarningDialogOnLanguageDiscard() {
+	public void testImageUnchangedAfterLanguageChange() {
 		onView(isRoot()).perform(touchAt(screenPoint.x, screenPoint.y));
+
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		openNavigationDrawer();
 		onView(withText(R.string.menu_language)).perform(click());
-		onView(withText(R.string.dialog_save_title)).check(matches(isDisplayed()));
-
-		onView(withText(R.string.discard_button_text)).perform(click());
 		intended(hasComponent(hasClassName(Multilingual.class.getName())));
-		assertFalse(PaintroidApplication.isSaved);
+		onView(withText("Device Language")).perform(click());
+
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 
 	@Test
-	public void testWarningDialogOnLanguageAbort() {
+	public void testImageUnchangedAfterLanguageAbort() {
 		onView(isRoot()).perform(touchAt(screenPoint.x, screenPoint.y));
+
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		openNavigationDrawer();
 		onView(withText(R.string.menu_language)).perform(click());
-		onView(withText(R.string.dialog_save_title)).check(matches(isDisplayed()));
-
+		intended(hasComponent(hasClassName(Multilingual.class.getName())));
 		pressBack();
-		onView(withText(R.string.dialog_save_title)).check(doesNotExist());
-		onView(withId(R.id.drawer_layout)).check(matches(isDisplayed()));
-		assertFalse(PaintroidApplication.isSaved);
-	}
 
-	@Test
-	public void testWarningDialogOnLanguageSave() {
-		onView(isRoot()).perform(touchAt(screenPoint.x, screenPoint.y));
-
-		openNavigationDrawer();
-		onView(withText(R.string.menu_language)).perform(click());
-		onView(withText(R.string.dialog_save_title)).check(matches(isDisplayed()));
-
-		onView(withText(R.string.save_button_text)).perform(click());
-		intended(hasComponent(hasClassName(Multilingual.class.getName())));
-		assertTrue(PaintroidApplication.isSaved);
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 
 	@Test
@@ -247,43 +241,35 @@ public class MenuFileActivityIntegrationTest {
 	}
 
 	@Test
-	public void testWarningDialogOnHelpDiscard() {
+	public void testImageUnchangedAfterHelpSkip() {
 		onView(isRoot()).perform(touchAt(screenPoint.x, screenPoint.y));
+
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		openNavigationDrawer();
 		onView(withText(R.string.help_title)).perform(click());
-		onView(withText(R.string.dialog_save_title)).check(matches(isDisplayed()));
-
-		onView(withText(R.string.discard_button_text)).perform(click());
 		intended(hasComponent(hasClassName(WelcomeActivity.class.getName())));
-		assertFalse(PaintroidApplication.isSaved);
+		onView(withText(R.string.skip)).perform(click());
+
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 
 	@Test
-	public void testWarningDialogOnHelpAbort() {
+	public void testImageUnchangedAfterHelpAbort() {
 		onView(isRoot()).perform(touchAt(screenPoint.x, screenPoint.y));
+
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		openNavigationDrawer();
 		onView(withText(R.string.help_title)).perform(click());
-		onView(withText(R.string.dialog_save_title)).check(matches(isDisplayed()));
-
+		intended(hasComponent(hasClassName(WelcomeActivity.class.getName())));
 		pressBack();
-		onView(withText(R.string.dialog_save_title)).check(doesNotExist());
-		onView(withId(R.id.drawer_layout)).check(matches(isDisplayed()));
-		assertFalse(PaintroidApplication.isSaved);
-	}
 
-	@Test
-	public void testWarningDialogOnHelpSave() {
-		onView(isRoot()).perform(touchAt(screenPoint.x, screenPoint.y));
-
-		openNavigationDrawer();
-		onView(withText(R.string.help_title)).perform(click());
-		onView(withText(R.string.dialog_save_title)).check(matches(isDisplayed()));
-
-		onView(withText(R.string.save_button_text)).perform(click());
-		intended(hasComponent(hasClassName(WelcomeActivity.class.getName())));
-		assertTrue(PaintroidApplication.isSaved);
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 
 	@Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -368,7 +368,7 @@ public class MainActivity extends NavigationDrawerMenuActivity implements  Navig
 			case R.id.nav_help:
 				Intent intent = new Intent(this, WelcomeActivity.class);
 				intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-				showSecurityQuestionBeforeStartingActivity(intent);
+				startActivity(intent);
 				break;
 			case R.id.nav_about:
 				DialogAbout about = new DialogAbout();
@@ -376,7 +376,7 @@ public class MainActivity extends NavigationDrawerMenuActivity implements  Navig
 				break;
 			case R.id.nav_lang:
 				Intent language = new Intent(this, Multilingual.class);
-				showSecurityQuestionBeforeStartingActivity(language);
+				startActivityForResult(language, REQUEST_CODE_LANGUAGE);
 				break;
 		}
 
@@ -433,6 +433,10 @@ public class MainActivity extends NavigationDrawerMenuActivity implements  Navig
 			case REQUEST_CODE_FINISH:
 				finish();
 				break;
+			case REQUEST_CODE_LANGUAGE:
+				onConfigurationChanged(getResources().getConfiguration());
+				break;
+
 			default:
 				super.onActivityResult(requestCode, resultCode, data);
 		}
@@ -467,37 +471,6 @@ public class MainActivity extends NavigationDrawerMenuActivity implements  Navig
 			tool.startTool();
 			PaintroidApplication.currentTool.setDrawPaint(tempPaint);
 		}
-	}
-
-	private void showSecurityQuestionBeforeStartingActivity(final Intent intent) {
-		if (!imageHasBeenModified() || imageHasBeenSaved()) {
-			startActivity(intent);
-			finish();
-			return;
-		}
-
-		AlertDialog.Builder builder = new CustomAlertDialogBuilder(this);
-		builder.setTitle(R.string.dialog_save_title);
-		builder.setMessage(R.string.dialog_warning_new_image);
-		builder.setPositiveButton(R.string.save_button_text,
-			new DialogInterface.OnClickListener() {
-				@Override
-				public void onClick(DialogInterface dialog, int id) {
-					saveFile();
-					startActivity(intent);
-					finish();
-				}
-			});
-		builder.setNegativeButton(R.string.discard_button_text,
-			new DialogInterface.OnClickListener() {
-				@Override
-				public void onClick(DialogInterface dialog, int which) {
-					startActivity(intent);
-					finish();
-				}
-		});
-		builder.setCancelable(true);
-		builder.show();
 	}
 
 	private void showSecurityQuestionBeforeExit() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -290,12 +290,20 @@ public class MainActivity extends NavigationDrawerMenuActivity implements  Navig
 
 		ColorPickerDialog.getInstance().dismiss();
 		ColorPickerDialog.init(this);
+
+		boolean isShowing = IndeterminateProgressDialog.getInstance().isShowing();
+		IndeterminateProgressDialog.getInstance().dismiss();
 		IndeterminateProgressDialog.init(this);
+		if (isShowing) {
+			IndeterminateProgressDialog.getInstance().show();
+		}
+
 		BrushPickerView.init(this);
 
 		setContentView(R.layout.main);
 		initActionBar();
-		mInputMethodManager =  (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
+		mInputMethodManager = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
+		hideKeyboard();
 
 		PaintroidApplication.orientation = getResources().getConfiguration().orientation;
 		PaintroidApplication.drawingSurface = (DrawingSurface) findViewById(R.id.drawingSurfaceView);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/Multilingual.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/Multilingual.java
@@ -1,7 +1,6 @@
 package org.catrobat.paintroid;
 
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -66,9 +65,8 @@ public class Multilingual extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        Intent i = new Intent(this, MainActivity.class);
-        startActivity(i);
-        finishAffinity();
+        setResult(RESULT_CANCELED);
+        finish();
         super.onBackPressed();
     }
 
@@ -81,13 +79,11 @@ public class Multilingual extends AppCompatActivity {
         Language.setDefault(Language);
         conf.setLayoutDirection(Language);
         resources.updateConfiguration(conf, displayMetrics);
-
     }
 
     public void setLocale(String lang) {
         setContextLocale(this, lang);
-        Intent intent = new Intent(Multilingual.this, MainActivity.class);
-        startActivity(intent);
-        finishAffinity();
+        setResult(RESULT_OK);
+        finish();
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/NavigationDrawerMenuActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/NavigationDrawerMenuActivity.java
@@ -55,6 +55,7 @@ public abstract class NavigationDrawerMenuActivity extends AppCompatActivity {
 	protected static final int REQUEST_CODE_LOAD_PICTURE = 2;
 	protected static final int REQUEST_CODE_FINISH = 3;
 	protected static final int REQUEST_CODE_TAKE_PICTURE = 4;
+	protected static final int REQUEST_CODE_LANGUAGE = 5;
 
 	public static final float ACTION_BAR_HEIGHT = 50.0f;
 	protected boolean loadBitmapFailed = false;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
@@ -65,7 +65,6 @@ public class WelcomeActivity extends AppCompatActivity {
         session = new Session(this);
        if (!session.isFirstTimeLaunch() && getIntent().getFlags() != Intent.FLAG_GRANT_READ_URI_PERMISSION) {
             launchHomeScreen();
-            finish();
         }
         getIntent().setFlags(0);
 
@@ -174,7 +173,9 @@ public class WelcomeActivity extends AppCompatActivity {
 
     private void launchHomeScreen() {
         session.setFirstTimeLaunch(false);
-        startActivity(new Intent(WelcomeActivity.this, MainActivity.class));
+        Intent mainActivityIntent = new Intent(WelcomeActivity.this, MainActivity.class);
+        mainActivityIntent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        startActivity(mainActivityIntent);
         finish();
     }
 


### PR DESCRIPTION
- image is not lost anymore when an other activity is started
- therefore reoved save dialog before help and language activity
- IndeterminateProgressDialog is restartet on orientation change
- keyboard gets closed on orientation change (at least for some APIs)