### PR TITLE
PAINT-241: arrows overlapping tool icons

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
@@ -70,7 +70,7 @@ public class ToolSelectionIntegrationTest {
 	protected LinearLayout mToolsLayout;
 
 	static private int start = R.id.tools_brush;
-	static private int middle = R.id.tools_fill;
+	static private int middle = R.id.tools_pipette;
 	static private int end = R.id.tools_text;
 
 	protected HorizontalScrollView mScrollView;
@@ -245,33 +245,44 @@ public class ToolSelectionIntegrationTest {
 
 	@Test
 	public void nextDisplayOnStartTest() {
-		onView(withId(R.id.bottom_next)).check(matches(isCompletelyDisplayed()));
+		onView(withId(R.id.bottom_next))
+				.check(matches(isCompletelyDisplayed()));
 	}
 
 	@Test
 	public void previousNotDisplayOnStartTest() {
-		onView(withId(R.id.bottom_previous)).check(matches(not(isDisplayed())));
+		onView(withId(R.id.bottom_previous))
+				.check(matches(not(isDisplayed())));
 	}
 
 
 	@Test
-	public void previousDisplayedOnEnd() {
-		onView(withId(end)).perform(scrollTo());
-		onView(withId(R.id.bottom_previous)).check(matches(isCompletelyDisplayed()));
+	public void previousDisplayedOnScrollToEnd() {
+		onView(withId(end))
+				.perform(scrollTo());
+		onView(withId(R.id.bottom_previous))
+				.check(matches(isCompletelyDisplayed()));
+		onView(withId(R.id.bottom_next))
+				.check(matches(not(isDisplayed())));
 	}
 
 	@Test
-	public void nextNotDisplayedOnEnd() {
-		onView(withId(R.id.tools_text)).perform(scrollTo());
-		onView(withId(R.id.bottom_next)).check(matches(not(isDisplayed())));
+	public void nextDisplayedOnScrollToStart() {
+		onView(withId(start))
+				.perform(scrollTo());
+		onView(withId(R.id.bottom_previous))
+				.check(matches(not(isDisplayed())));
+		onView(withId(R.id.bottom_next))
+				.check(matches(isCompletelyDisplayed()));
 	}
 
 	@Test
-	public void previousAndNextDisplayed() {
-		onView(withId(middle)).perform(scrollTo());
-		onView(withId(start)).check(matches(not(isDisplayed())));
-		onView(withId(end)).check(matches(not(isDisplayed())));
-		onView(withId(R.id.bottom_previous)).check(matches(isCompletelyDisplayed()));
-		onView(withId(R.id.bottom_next)).check(matches(isCompletelyDisplayed()));
+	public void previousAndNextDisplayedOnScrollToMiddle() {
+		onView(withId(middle))
+				.perform(scrollTo());
+		onView(withId(R.id.bottom_previous))
+				.check(matches(isCompletelyDisplayed()));
+		onView(withId(R.id.bottom_next))
+				.check(matches(isCompletelyDisplayed()));
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
@@ -69,6 +69,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.catrobat.paintroid.MultilingualActivity.updateLocale;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.selectViewPagerPage;
+import static org.catrobat.paintroid.test.espresso.util.UiInteractions.unconstrainedScrollTo;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.hasTablePosition;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anything;
@@ -331,7 +332,7 @@ public final class EspressoUtils {
 						hasTablePosition(colorButtonRowPosition, colorButtonColPosition)
 				)
 		).perform(
-				scrollTo()
+				unconstrainedScrollTo()
 		).check(
 				matches(isDisplayed())
 		).perform(

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/UiInteractions.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/UiInteractions.java
@@ -28,9 +28,11 @@ import android.support.test.espresso.action.GeneralLocation;
 import android.support.test.espresso.action.GeneralSwipeAction;
 import android.support.test.espresso.action.MotionEvents;
 import android.support.test.espresso.action.Press;
+import android.support.test.espresso.action.ScrollToAction;
 import android.support.test.espresso.action.Swipe;
 import android.support.test.espresso.action.Tap;
 import android.support.test.espresso.action.Tapper;
+import android.support.test.espresso.matcher.ViewMatchers;
 import android.support.v4.view.ViewPager;
 import android.view.InputDevice;
 import android.view.MotionEvent;
@@ -42,6 +44,7 @@ import org.hamcrest.Matcher;
 import static android.support.test.espresso.action.ViewActions.actionWithAssertions;
 import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 
 public final class UiInteractions {
 
@@ -49,6 +52,28 @@ public final class UiInteractions {
 
     }
 
+    public static ViewAction unconstrainedScrollTo() {
+        return actionWithAssertions(new UnconstrainedScrollToAction());
+    }
+
+    private static class UnconstrainedScrollToAction implements ViewAction {
+        private ViewAction action = new ScrollToAction();
+
+        @Override
+        public Matcher<View> getConstraints() {
+            return withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE);
+        }
+
+        @Override
+        public String getDescription() {
+            return action.getDescription();
+        }
+
+        @Override
+        public void perform(UiController uiController, View view) {
+            action.perform(uiController, view);
+        }
+    }
 
     public static ViewAction waitFor(final long millis) {
         return new ViewAction() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/intro/TapTargetBase.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/intro/TapTargetBase.java
@@ -23,7 +23,6 @@ import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import com.getkeepsafe.taptargetview.TapTarget;
@@ -72,12 +71,12 @@ public abstract class TapTargetBase {
         view.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                performClick(view, toolType);
+                performClick(toolType);
             }
         });
     }
 
-    private void performClick(View view, ToolType toolType) {
+    private void performClick(ToolType toolType) {
         fadeOut(fadeView);
         TapTarget tapTarget = tapTargetMap.get(toolType);
 
@@ -124,14 +123,14 @@ public abstract class TapTargetBase {
         startBottomBarAnimation();
     }
 
-    protected void setBottomBarListener() {
-        final ImageView previous = (ImageView) bottomBarView.findViewById(R.id.bottom_previous);
-        final ImageView next = (ImageView) bottomBarView.findViewById(R.id.bottom_next);
+    private void setBottomBarListener() {
+        final View previous = bottomBarView.findViewById(R.id.bottom_previous);
+        final View next = bottomBarView.findViewById(R.id.bottom_next);
         bottomScrollBar.setScrollStateListener(new BottomBarScrollListener(previous, next));
 
     }
 
-    protected void startBottomBarAnimation() {
+    private void startBottomBarAnimation() {
         bottomScrollBar.post(new Runnable() {
             public void run() {
                 bottomScrollBar.setScrollX(bottomScrollBar.getChildAt(0).getRight());
@@ -139,7 +138,6 @@ public abstract class TapTargetBase {
             }
         });
     }
-
 
     private TapTarget createTapTarget(ToolType toolType, View targetView) {
         return TapTarget

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBar.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBar.java
@@ -32,7 +32,6 @@ import android.view.View;
 import android.view.animation.LinearInterpolator;
 import android.widget.HorizontalScrollView;
 import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.Toast;
@@ -161,8 +160,8 @@ public class BottomBar implements View.OnClickListener, View.OnLongClickListener
 	}
 
 	private void setBottomBarScrollerListener() {
-		final ImageView next = (ImageView) mMainActivity.findViewById(R.id.bottom_next);
-		final ImageView previous = (ImageView) mMainActivity.findViewById(R.id.bottom_previous);
+		final View next = mMainActivity.findViewById(R.id.bottom_next);
+		final View previous = mMainActivity.findViewById(R.id.bottom_previous);
 
 		BottomBarHorizontalScrollView mScrollView = ((BottomBarHorizontalScrollView) mMainActivity.findViewById(R.id.bottom_bar_scroll_view));
 		if(mScrollView == null )

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBarHorizontalScrollView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBarHorizontalScrollView.java
@@ -1,3 +1,22 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.catrobat.paintroid.ui;
 
 import android.content.Context;
@@ -5,9 +24,6 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.HorizontalScrollView;
 
-/**
- * Created by Clemens on 28.12.2016.
- */
 public class BottomBarHorizontalScrollView extends HorizontalScrollView {
 
     private IScrollStateListener scrollStateListener;
@@ -74,6 +90,4 @@ public class BottomBarHorizontalScrollView extends HorizontalScrollView {
 
         void onScrollFromMostRight();
     }
-
-
 }

--- a/Paintroid/src/main/res/drawable/ic_action_next_item_background.xml
+++ b/Paintroid/src/main/res/drawable/ic_action_next_item_background.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:startColor="@color/custom_background_color_transparent"
+                android:centerColor="@color/custom_background_color"
+                android:endColor="@color/custom_background_color"
+                android:centerX="50%"
+                android:type="linear"/>
+        </shape>
+    </item>
+</selector>

--- a/Paintroid/src/main/res/drawable/ic_action_previous_item_background.xml
+++ b/Paintroid/src/main/res/drawable/ic_action_previous_item_background.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:startColor="@color/custom_background_color"
+                android:centerColor="@color/custom_background_color"
+                android:endColor="@color/custom_background_color_transparent"
+                android:centerX="50%"
+                android:type="linear"/>
+        </shape>
+    </item>
+</selector>

--- a/Paintroid/src/main/res/layout-land/bottom_bar.xml
+++ b/Paintroid/src/main/res/layout-land/bottom_bar.xml
@@ -89,14 +89,14 @@
                 android:layout_width="@dimen/bottom_bar_landscape_button_width"
                 android:layout_height="@dimen/bottom_bar_landscape_button_height"
                 android:background="@color/transparent"
-                android:src="@drawable/icon_menu_pipette"></ImageButton>
+                android:src="@drawable/icon_menu_pipette"/>
 
             <ImageButton
                 android:id="@+id/tools_stamp"
                 android:layout_width="@dimen/bottom_bar_landscape_button_width"
                 android:layout_height="@dimen/bottom_bar_landscape_button_height"
                 android:background="@color/transparent"
-                android:src="@drawable/icon_menu_stamp" />
+                android:src="@drawable/icon_menu_stamp"/>
 
             <ImageButton
                 android:id="@+id/tools_import"

--- a/Paintroid/src/main/res/layout/bottom_bar.xml
+++ b/Paintroid/src/main/res/layout/bottom_bar.xml
@@ -24,13 +24,11 @@
                 android:layout_height="50dp"
                 android:orientation="horizontal">
 
-
     <org.catrobat.paintroid.ui.BottomBarHorizontalScrollView
         android:id="@+id/bottom_bar_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true"
-        android:requiresFadingEdge="horizontal"
         android:scrollbars="none">
 
         <LinearLayout
@@ -120,19 +118,30 @@
     </org.catrobat.paintroid.ui.BottomBarHorizontalScrollView>
 
 
-    <ImageView
+    <FrameLayout
         android:id="@+id/bottom_previous"
-        android:layout_width="wrap_content"
+        android:layout_width="@dimen/bottom_bar_button_width"
         android:layout_height="match_parent"
         android:layout_alignParentLeft="true"
-        android:layout_centerVertical="true"
-        android:src="@drawable/ic_action_previous_item"/>
+        android:background="@drawable/ic_action_previous_item_background">
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="left"
+            android:src="@drawable/ic_action_previous_item"/>
+    </FrameLayout>
 
-    <ImageView
+    <FrameLayout
         android:id="@+id/bottom_next"
-        android:layout_width="wrap_content"
+        android:layout_width="@dimen/bottom_bar_button_width"
         android:layout_height="match_parent"
         android:layout_alignParentRight="true"
-        android:layout_centerVertical="true"
-        android:src="@drawable/ic_action_next_item"/>
+        android:background="@drawable/ic_action_next_item_background">
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="right"
+            android:src="@drawable/ic_action_next_item"/>
+    </FrameLayout>
+
 </RelativeLayout>

--- a/Paintroid/src/main/res/values/colors.xml
+++ b/Paintroid/src/main/res/values/colors.xml
@@ -25,6 +25,7 @@
     <color name="tools_text_color">#33B5E5</color>
     <color name="transparent">#00000000</color>
     <color name="custom_background_color">#0097A7</color>
+    <color name="custom_background_color_transparent">#000097A7</color>
     <color name="text_color">@android:color/white</color>
     <color name="text_color_link">#E68B00</color>
     <color name="rectangle_secondary_color">#33B5E5</color>

--- a/Paintroid/src/main/res/values/dimens.xml
+++ b/Paintroid/src/main/res/values/dimens.xml
@@ -32,11 +32,11 @@
     <dimen name="intro_margin_side">50dp</dimen>
     <dimen name="intro_margin_top">100dp</dimen>
     <dimen name="intro_margin_top_text">25dp</dimen>
-    <dimen name="bottom_bar_button_width">75dp</dimen>
+    <dimen name="bottom_bar_button_width">65dp</dimen>
     <dimen name="bottom_bar_height">50dp</dimen>
     <dimen name="top_bar_height">50dp</dimen>
     <dimen name="bottom_bar_landscape_button_width">50dp</dimen>
-    <dimen name="bottom_bar_landscape_button_height">65dip</dimen>
+    <dimen name="bottom_bar_landscape_button_height">65dp</dimen>
 
     <!--MultilingualActivity Activity dimens -->
     <dimen name="language_name_text">22sp</dimen>


### PR DESCRIPTION
* Fix tests in `ToolSelectionIntegrationTest`
* Put bottom bar arrows in a container to only scale background
* Add two drawables for gradient background
* Set button width to `65dp` from `75dp` to show at least 4 buttons
* Add transparent color to fade to from `custom_background_color`
* Use an unconstrained `scrollTo` action for colorpicker to fix tests failing from color selection