### PR TITLE
PAINT-239: Set correction aspect ratio to images in import tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
@@ -1,0 +1,96 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.junit.tools;
+
+import android.graphics.Bitmap;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.PaintroidApplication;
+import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.tools.implementation.ImportTool;
+import org.catrobat.paintroid.ui.DrawingSurface;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class ImportToolTest {
+
+	@Rule
+	public ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class);
+
+	private int drawingSurfaceWidth;
+	private int drawingSurfaceHeight;
+
+	private ImportTool tool;
+
+	@UiThreadTest
+	@Before
+	public void setUp() throws Exception {
+		tool = new ImportTool(activityTestRule.getActivity(), ToolType.IMPORTPNG);
+
+		DrawingSurface drawingSurface = PaintroidApplication.drawingSurface;
+		drawingSurfaceWidth = drawingSurface.getBitmapWidth();
+		drawingSurfaceHeight = drawingSurface.getBitmapHeight();
+	}
+
+	@Test
+	public void testImport() {
+		final int width = drawingSurfaceWidth;
+		final int height = drawingSurfaceHeight;
+
+		Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+		tool.setBitmapFromFile(bitmap);
+
+		assertEquals(width, tool.mBoxWidth, Float.MIN_VALUE);
+		assertEquals(height, tool.mBoxHeight, Float.MIN_VALUE);
+	}
+
+	@Test
+	public void testImportTooSmall() {
+		final int width = 1;
+		final int height = 1;
+		final int minSize = ImportTool.DEFAULT_BOX_RESIZE_MARGIN;
+
+		Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+		tool.setBitmapFromFile(bitmap);
+
+		assertEquals(minSize, tool.mBoxWidth, Float.MIN_VALUE);
+		assertEquals(minSize, tool.mBoxHeight, Float.MIN_VALUE);
+	}
+
+	@Test
+	public void testImportTooLarge() {
+		final int width = (int) (drawingSurfaceWidth * ImportTool.MAXIMUM_BORDER_RATIO);
+		final int height = (int) (drawingSurfaceHeight * ImportTool.MAXIMUM_BORDER_RATIO);
+
+		Bitmap bitmap = Bitmap.createBitmap(width + 1, height + 1, Bitmap.Config.ARGB_8888);
+		tool.setBitmapFromFile(bitmap);
+
+		assertEquals(width, tool.mBoxWidth, Float.MIN_VALUE);
+		assertEquals(height, tool.mBoxHeight, Float.MIN_VALUE);
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.java
@@ -1,18 +1,33 @@
 package org.catrobat.paintroid.tools.implementation;
 
-import android.app.Activity;
+import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.Canvas;
 
+import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.ui.DrawingSurface;
 
 public class ImportTool extends StampTool {
 
-	public ImportTool(Activity activity, ToolType toolType) {
-		super(activity, toolType);
+	public ImportTool(Context context, ToolType toolType) {
+		super(context, toolType);
 		mReadyForPaste = true;
-		setOnLongClickAllowed(false);
+		mLongClickAllowed = false;
 		createOverlayButton();
 	}
 
+	@Override
+	public void setBitmapFromFile(Bitmap bitmap) {
+		super.setBitmapFromFile(bitmap);
+
+		final DrawingSurface drawingSurface = PaintroidApplication.drawingSurface;
+		final float maximumBorderRatioWidth = MAXIMUM_BORDER_RATIO * drawingSurface.getBitmapWidth();
+		final float maximumBorderRatioHeight = MAXIMUM_BORDER_RATIO * drawingSurface.getBitmapHeight();
+
+		final float minimumSize = DEFAULT_BOX_RESIZE_MARGIN;
+
+		mBoxWidth = Math.max(minimumSize, Math.min(maximumBorderRatioWidth, bitmap.getWidth()));
+		mBoxHeight = Math.max(minimumSize, Math.min(maximumBorderRatioHeight, bitmap.getHeight()));
+		createOverlayButton();
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
@@ -19,10 +19,9 @@
 
 package org.catrobat.paintroid.tools.implementation;
 
-import android.app.Activity;
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
-import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Point;
@@ -39,7 +38,6 @@ import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.implementation.LayerCommand;
 import org.catrobat.paintroid.command.implementation.StampCommand;
 import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
-import org.catrobat.paintroid.dialog.LayersDialog;
 import org.catrobat.paintroid.listener.LayerListener;
 import org.catrobat.paintroid.tools.Layer;
 import org.catrobat.paintroid.tools.ToolType;
@@ -60,8 +58,8 @@ public class StampTool extends BaseToolWithRectangleShape {
 	private CountDownTimer mDownTimer;
 	private boolean mLongClickPerformed = false;
 
-	public StampTool(Activity activity, ToolType toolType) {
-		super(activity, toolType);
+	public StampTool(Context context, ToolType toolType) {
+		super(context, toolType);
 		mReadyForPaste = false;
 		setRotationEnabled(ROTATION_ENABLED);
 		setRespectImageBounds(RESPECT_IMAGE_BOUNDS);
@@ -360,10 +358,6 @@ public class StampTool extends BaseToolWithRectangleShape {
 			IndeterminateProgressDialog.getInstance().dismiss();
 		}
 
-	}
-
-	protected void setOnLongClickAllowed(boolean longClickAllowed) {
-		mLongClickAllowed = longClickAllowed;
 	}
 
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
@@ -34,10 +34,6 @@ import android.view.Display;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import org.catrobat.paintroid.PaintroidApplication;
@@ -73,7 +69,6 @@ public class TransformTool extends BaseToolWithRectangleShape {
 	private float mResizeBoundHeightYBottom = 0;
 
 	private boolean mCropRunFinished = false;
-	private boolean mResizeInformationAlreadyShown = false;
 	private boolean mMaxImageResolutionInformationAlreadyShown = false;
 
 	private View mTransformToolOptionView;
@@ -96,9 +91,6 @@ public class TransformTool extends BaseToolWithRectangleShape {
 		resetScaleAndTranslation();
 
 		mCropRunFinished = true;
-
-		DisplayResizeInformationAsyncTask displayResizeInformation = new DisplayResizeInformationAsyncTask();
-		displayResizeInformation.execute();
 
 		Display display = ((Activity) mContext).getWindowManager().getDefaultDisplay();
 		Point displaySize = new Point();
@@ -172,24 +164,7 @@ public class TransformTool extends BaseToolWithRectangleShape {
 	}
 
 	protected void displayToastInformation(int stringID) {
-		LayoutInflater inflater = (LayoutInflater) mContext
-				.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-		LinearLayout layout = (LinearLayout) inflater.inflate(
-				R.layout.image_toast_layout, (ViewGroup) ((Activity) mContext)
-						.findViewById(R.id.image_toast_layout_root));
-
-		if (stringID != R.string.resize_to_resize_tap_text) {
-			ImageView toastImage = (ImageView) layout.findViewById(R.id.toast_image);
-			toastImage.setVisibility(View.GONE);
-
-			TextView text = (TextView) layout.findViewById(R.id.toast_text);
-			text.setText(mContext.getText(stringID));
-		}
-
-		Toast toast = new Toast(mContext);
-		toast.setDuration(Toast.LENGTH_SHORT);
-		toast.setView(layout);
-		toast.show();
+		Toast.makeText(mContext, stringID, Toast.LENGTH_SHORT).show();
 	}
 
 	protected void executeResizeCommand() {
@@ -369,23 +344,6 @@ public class TransformTool extends BaseToolWithRectangleShape {
 						mResizeBoundHeightYTop, mResizeBoundWidthXRight,
 						mResizeBoundHeightYBottom));
 				mCropRunFinished = true;
-			}
-		}
-	}
-
-	protected class DisplayResizeInformationAsyncTask extends
-			AsyncTask<Void, Integer, Void> {
-
-		@Override
-		protected Void doInBackground(Void... params) {
-			return null;
-		}
-
-		@Override
-		protected void onPostExecute(Void nothing) {
-			if (!mResizeInformationAlreadyShown) {
-				//displayToastInformation(R.string.resize_to_resize_tap_text);
-				mResizeInformationAlreadyShown = true;
 			}
 		}
 	}


### PR DESCRIPTION
* Add new `ImportToolTest` instrumented unit test
* Refactor `BaseToolWithRectangleShape` to improve readability
  * Improve readability of `resize` method
  * Remove unused functions
  * Annotate certain static variables with `@VisibleForTesting`
* Overload `setBitmapFromFile` in `ImportTool`
  * Set `mBox` size to bitmap size
  * Clamp `mBox` size within `BaseToolWithRectangleShape` bounds
* Refactor `ImportTool` and `StampTool` to use `Context` instead of `Activity`
* Refactor TransformTool
  * Remove dead code `DisplayResizeInformationAsyncTask`
  * Refactor custom styled toasts to default toasts