### PR TITLE
PAINT-244: Topbar palette icon has wrong tint on api < 21

### DIFF
--- a/Paintroid/src/main/res/layout-land/top_bar_elements.xml
+++ b/Paintroid/src/main/res/layout-land/top_bar_elements.xml
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-
+<!--
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/layout_top_bar"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -39,7 +57,7 @@
             android:background="@color/transparent"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
-        <ImageButton
+        <android.support.v7.widget.AppCompatImageButton
             android:id="@+id/btn_top_color_palette"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -47,7 +65,7 @@
             android:layout_marginTop="12dip"
             android:layout_marginLeft="5dip"
             android:background="@drawable/ic_icon_menu_color_palette"
-            android:backgroundTint="@color/color_chooser_white"
+            app:backgroundTint="@color/color_chooser_white"
             android:foreground="@color/color_chooser_white"
             android:foregroundTint="@color/color_chooser_white"
             android:clickable="false" />

--- a/Paintroid/src/main/res/layout/top_bar.xml
+++ b/Paintroid/src/main/res/layout/top_bar.xml
@@ -1,13 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
 <android.support.v7.widget.Toolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
     android:layout_height="@dimen/top_bar_height"
     android:background="@color/custom_background_color"
     android:elevation="4dp"
-    android:orientation="horizontal"
-    >
+    android:orientation="horizontal">
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/layout_top_bar"
@@ -46,7 +64,7 @@
                 android:background="@color/transparent"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
-            <ImageButton
+            <android.support.v7.widget.AppCompatImageButton
                 android:id="@+id/btn_top_color_palette"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -55,7 +73,7 @@
                 android:layout_marginLeft="5dip"
                 android:layout_gravity="center_horizontal"
                 android:background="@drawable/ic_icon_menu_color_palette"
-                android:backgroundTint="@color/color_chooser_white"
+                app:backgroundTint="@color/color_chooser_white"
                 android:foreground="@color/color_chooser_white"
                 android:foregroundTint="@color/color_chooser_white"
                 android:clickable="false" />


### PR DESCRIPTION
* Change `backgroundTint` attribute namespace to use appcompat attribute
* Change `ImageButton` to `AppCompatImageButton` for Intro
  Why: the intro doesn't use the whole layout and therefore the
  ImageButton won't get replaced to a AppCompatImageButton automatically
* Add Copyright notice