### PR TITLE
PAINT-246: Bottombar fills whole screen in landscape

### DIFF
--- a/Paintroid/src/main/res/layout-land/main.xml
+++ b/Paintroid/src/main/res/layout-land/main.xml
@@ -78,7 +78,6 @@
             android:layout_height="match_parent"
             android:background="@color/custom_background_color"
             android:orientation="vertical"
-            android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true">
 
             <include layout="@layout/bottom_bar"/>


### PR DESCRIPTION
* Remove legacy attribute as it lead to unwanted behaviour on API 17