### PR TITLE
PAINT-247: fix broken bottombar layout

### DIFF
--- a/Paintroid/src/main/res/layout/bottom_bar.xml
+++ b/Paintroid/src/main/res/layout/bottom_bar.xml
@@ -33,6 +33,7 @@
 
         <LinearLayout
             android:id="@+id/tools_layout"
+            android:layout_gravity="fill"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 


### PR DESCRIPTION
* Added `fill` attribute to `LinearLayout` gravity