### PR TITLE
PAINT-249: Indeterminate Progress dialog fills too much vertical space

### DIFF
--- a/Paintroid/src/main/res/layout/custom_progress_dialog.xml
+++ b/Paintroid/src/main/res/layout/custom_progress_dialog.xml
@@ -17,18 +17,14 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:background="@android:color/transparent"
-    android:layout_gravity="center">
+    android:layout_height="wrap_content">
 
     <ProgressBar
         android:id="@+id/progressBar"
         style="@style/Widget.AppCompat.ProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:indeterminate="true"
-        android:background="@android:color/transparent"/>
-</RelativeLayout>
+        android:indeterminate="true"/>
+</FrameLayout>


### PR DESCRIPTION
* Use a `FrameLayout` instead of a `RelativeLayout`
* Remove unecessary attributes