### PR TITLE
PAINT-250: Pipette doesn't update on undo / redo

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/PipetteToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/PipetteToolIntegrationTest.java
@@ -138,4 +138,46 @@ public class PipetteToolIntegrationTest {
 		int pipetteColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
 		assertEquals("Tool color should be black", colorAtFirstLayer, pipetteColor);
 	}
+
+	@Test
+	public void testPipetteAfterUndo() {
+		onView(isRoot())
+				.perform(touchAt(screenPoint));
+
+		selectTool(ToolType.PIPETTE);
+		onView(isRoot())
+				.perform(touchAt(screenPoint));
+		int pipetteColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals(Color.BLACK, pipetteColor);
+
+		onView(withId(R.id.btn_top_undo))
+				.perform(click());
+
+		onView(isRoot())
+				.perform(touchAt(screenPoint));
+		int newPipetteColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals(Color.TRANSPARENT, newPipetteColor);
+	}
+
+	@Test
+	public void testPipetteAfterRedo() {
+		onView(isRoot())
+				.perform(touchAt(screenPoint));
+
+		selectTool(ToolType.PIPETTE);
+		onView(isRoot())
+				.perform(touchAt(screenPoint));
+		int pipetteColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals(Color.BLACK, pipetteColor);
+
+		onView(withId(R.id.btn_top_undo))
+				.perform(click());
+		onView(withId(R.id.btn_top_redo))
+				.perform(click());
+
+		onView(isRoot())
+				.perform(touchAt(screenPoint));
+		int newPipetteColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		assertEquals(pipetteColor, newPipetteColor);
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
@@ -58,7 +58,7 @@ public class PipetteTool extends BaseTool {
 	}
 
 	protected boolean setColor(PointF coordinate) {
-		if (coordinate == null) {
+		if (coordinate == null || mSurfaceBitmap == null) {
 			return false;
 		}
 
@@ -80,6 +80,7 @@ public class PipetteTool extends BaseTool {
 
 	@Override
 	public void resetInternalState() {
+		updateSurfaceBitmap();
 	}
 
 	@Override


### PR DESCRIPTION
* Add two tests for undo / redo
* Update the cached bitmap on `resetInternalState`