### PR TITLE
PAINT-259: Text tool spinner dropdown cut off

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -113,9 +113,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:25.4.0'
     compile 'com.android.support:design:25.4.0'
-    compile 'com.jaredrummler:material-spinner:1.1.0'
     compile 'com.getkeepsafe.taptargetview:taptargetview:1.9.1'
 
     androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.6.3'

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
@@ -29,10 +29,8 @@ import android.support.test.espresso.IdlingResource;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.widget.EditText;
-import android.widget.ListView;
+import android.widget.Spinner;
 import android.widget.ToggleButton;
-
-import com.jaredrummler.materialspinner.MaterialSpinner;
 
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.PaintroidApplication;
@@ -60,6 +58,7 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.isPlatformPopup;
 import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
@@ -108,11 +107,11 @@ public class TextToolIntegrationTest {
 	private IdlingResource dialogWait;
 	private TextTool textTool;
 	private EditText textEditText;
-	private MaterialSpinner fontSpinner;
+	private Spinner fontSpinner;
 	private ToggleButton underlinedToggleButton;
 	private ToggleButton italicToggleButton;
 	private ToggleButton boldToggleButton;
-	private MaterialSpinner textSizeSpinner;
+	private Spinner textSizeSpinner;
 
 	@Before
 	public void setUp() {
@@ -130,11 +129,11 @@ public class TextToolIntegrationTest {
 		textTool = (TextTool) PaintroidApplication.currentTool;
 
 		textEditText = (EditText) activityHelper.findViewById(R.id.text_tool_dialog_input_text);
-		fontSpinner = (MaterialSpinner) activityHelper.findViewById(R.id.text_tool_dialog_spinner_font);
+		fontSpinner = (Spinner) activityHelper.findViewById(R.id.text_tool_dialog_spinner_font);
 		underlinedToggleButton = (ToggleButton) activityHelper.findViewById(R.id.text_tool_dialog_toggle_underlined);
 		italicToggleButton = (ToggleButton) activityHelper.findViewById(R.id.text_tool_dialog_toggle_italic);
 		boldToggleButton = (ToggleButton) activityHelper.findViewById(R.id.text_tool_dialog_toggle_bold);
-		textSizeSpinner = (MaterialSpinner) activityHelper.findViewById(R.id.text_tool_dialog_spinner_text_size);
+		textSizeSpinner = (Spinner) activityHelper.findViewById(R.id.text_tool_dialog_spinner_text_size);
 
 		textTool.resetBoxPosition();
 	}
@@ -163,7 +162,7 @@ public class TextToolIntegrationTest {
 		assertEquals("Wrong default input text", expectedText, actualText);
 
 		String expectedFont = getToolMemberFont();
-		String actualFont = getSelectedItemFromMaterialSpinner(fontSpinner);
+		String actualFont = (String) fontSpinner.getSelectedItem();
 		assertEquals("Wrong default font selected", expectedFont, actualFont);
 
 		boolean expectedUnderlined = getToolMemberUnderlined();
@@ -179,7 +178,7 @@ public class TextToolIntegrationTest {
 		assertEquals("Wrong checked status of bold button", expectedBold, actualBold);
 
 		int expectedTextSize = getToolMemberTextSize();
-		int actualTextSize = Integer.valueOf(getSelectedItemFromMaterialSpinner(textSizeSpinner));
+		int actualTextSize = Integer.valueOf((String) textSizeSpinner.getSelectedItem());
 		assertEquals("Wrong text size selected", expectedTextSize, actualTextSize);
 	}
 
@@ -190,7 +189,7 @@ public class TextToolIntegrationTest {
 
 		selectFormatting(FormattingOptions.SERIF);
 		assertEquals("Tool member has wrong value for font", FONT_SERIF, getToolMemberFont());
-		assertEquals("Wrong current item of font spinner", FONT_SERIF, getSelectedItemFromMaterialSpinner(fontSpinner));
+		assertEquals("Wrong current item of font spinner", FONT_SERIF, fontSpinner.getSelectedItem());
 
 		selectFormatting(FormattingOptions.UNDERLINE);
 		assertTrue("Tool member value for underlined should be true", getToolMemberUnderlined());
@@ -228,7 +227,7 @@ public class TextToolIntegrationTest {
 		selectFormatting(FormattingOptions.SIZE_30);
 		assertEquals("Tool member has wrong value for text size", TEXT_SIZE_30, getToolMemberTextSize());
 		assertEquals("Wrong current item of text size spinner",
-				String.valueOf(TEXT_SIZE_30), getSelectedItemFromMaterialSpinner(textSizeSpinner));
+				String.valueOf(TEXT_SIZE_30), textSizeSpinner.getSelectedItem());
 	}
 
 	@Test
@@ -252,12 +251,12 @@ public class TextToolIntegrationTest {
 		openToolOptionsForCurrentTool();
 
 		assertEquals("Wrong input text after reopen dialog", TEST_TEXT, textEditText.getText().toString());
-		assertEquals("Wrong font selected after reopen dialog", FONT_SANS_SERIF, getSelectedItemFromMaterialSpinner(fontSpinner));
+		assertEquals("Wrong font selected after reopen dialog", FONT_SANS_SERIF, fontSpinner.getSelectedItem());
 		assertEquals("Wrong underline status after reopen dialog", true, underlinedToggleButton.isChecked());
 		assertEquals("Wrong italic status after reopen dialog", true, italicToggleButton.isChecked());
 		assertEquals("Wrong bold status after reopen dialog", true, boldToggleButton.isChecked());
 		assertEquals("Wrong text size selected after reopen dialog",
-				String.valueOf(TEXT_SIZE_40), getSelectedItemFromMaterialSpinner(textSizeSpinner));
+				String.valueOf(TEXT_SIZE_40), textSizeSpinner.getSelectedItem());
 
 		checkTextBoxDimensions();
 		assertEquals("Wrong text box position after reopen dialog", newBoxPosition, getToolMemberBoxPosition());
@@ -517,8 +516,8 @@ public class TextToolIntegrationTest {
 
 		boolean italic = italicToggleButton.isChecked();
 
-		String font = getSelectedItemFromMaterialSpinner(fontSpinner);
-		float textSize = Float.valueOf(getSelectedItemFromMaterialSpinner(textSizeSpinner)) * textSizeMagnificationFactor;
+		String font = (String) fontSpinner.getSelectedItem();
+		float textSize = Float.valueOf((String) textSizeSpinner.getSelectedItem()) * textSizeMagnificationFactor;
 		Paint textPaint = new Paint();
 		textPaint.setAntiAlias(true);
 		textPaint.setTextSize(textSize);
@@ -616,7 +615,7 @@ public class TextToolIntegrationTest {
 			case DUBAI:
 				onView(withId(R.id.text_tool_dialog_spinner_font)).perform(click());
 				onData(allOf(is(instanceOf(String.class)), is(getFontString(format))))
-						.inAdapterView(allOf(withId(R.id.text_tool_dialog_spinner_font), instanceOf(ListView.class)))
+						.inRoot(isPlatformPopup())
 						.perform(click());
 				break;
 			case UNDERLINE:
@@ -630,7 +629,7 @@ public class TextToolIntegrationTest {
 			case SIZE_60:
 				onView(withId(R.id.text_tool_dialog_spinner_text_size)).perform(click());
 				onData(allOf(is(instanceOf(String.class)), is(getFontString(format))))
-						.inAdapterView(allOf(withId(R.id.text_tool_dialog_spinner_text_size), instanceOf(ListView.class)))
+						.inRoot(isPlatformPopup())
 						.perform(click());
 				break;
 			default:
@@ -734,10 +733,6 @@ public class TextToolIntegrationTest {
 
 	protected String[] getToolMemberMultilineText() throws NoSuchFieldException, IllegalAccessException {
 		return (String[]) PrivateAccess.getMemberValue(TextTool.class, textTool, "multilineText");
-	}
-
-	protected String getSelectedItemFromMaterialSpinner(MaterialSpinner materialSpinner) {
-		return materialSpinner.getItems().get(materialSpinner.getSelectedIndex()).toString();
 	}
 
 	private enum FormattingOptions {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/TextToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/integration/tools/TextToolIntegrationTest.java
@@ -33,8 +33,6 @@ import android.widget.Spinner;
 import android.widget.TableRow;
 import android.widget.ToggleButton;
 
-import com.jaredrummler.materialspinner.MaterialSpinner;
-
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.test.integration.BaseIntegrationTestClass;
@@ -73,11 +71,11 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 
 	private TextTool mTextTool;
 	private EditText mTextEditText;
-	private MaterialSpinner mFontSpinner;
+	private Spinner mFontSpinner;
 	private ToggleButton mUnderlinedToggleButton;
 	private ToggleButton mItalicToggleButton;
 	private ToggleButton mBoldToggleButton;
-	private MaterialSpinner mTextSizeSpinner;
+	private Spinner mTextSizeSpinner;
 
 	private enum FormattingOptions {
 		UNDERLINE, ITALIC, BOLD, MONOSPACE, SERIF, SANS_SERIF,ALARABIYA,DUBAI, SIZE_20, SIZE_30, SIZE_40, SIZE_60
@@ -124,7 +122,7 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		assertEquals("Wrong default input text", expectedText, actualText);
 
 		String expectedFont = getToolMemberFont();
-		String actualFont = getSelectedItemFromMaterialSpinner(mFontSpinner);
+		String actualFont = (String) mFontSpinner.getSelectedItem();
 		assertEquals("Wrong default font selected", expectedFont, actualFont);
 
 		boolean expectedUnderlined = getToolMemberUnderlined();
@@ -140,7 +138,7 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		assertEquals("Wrong checked status of bold button", expectedBold, actualBold);
 
 		int expectedTextSize = getToolMemberTextSize();
-		int actualTextSize = Integer.valueOf(getSelectedItemFromMaterialSpinner(mTextSizeSpinner));
+		int actualTextSize = Integer.valueOf((String) mTextSizeSpinner.getSelectedItem());
 		assertEquals("Wrong text size selected", expectedTextSize, actualTextSize);
 	}
 
@@ -153,7 +151,7 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 
 		selectFormatting(FormattingOptions.SERIF);
 		assertEquals("Tool member has wrong value for font", FONT_SERIF, getToolMemberFont());
-		assertEquals("Wrong current item of font spinner", FONT_SERIF, getSelectedItemFromMaterialSpinner(mFontSpinner));
+		assertEquals("Wrong current item of font spinner", FONT_SERIF, (String) mFontSpinner.getSelectedItem());
 
 		selectFormatting(FormattingOptions.UNDERLINE);
 		assertTrue("Tool member value for underlined should be true", getToolMemberUnderlined());
@@ -191,7 +189,7 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		selectFormatting(FormattingOptions.SIZE_30);
 		assertEquals("Tool member has wrong value for text size", TEXT_SIZE_30, getToolMemberTextSize());
 		assertEquals("Wrong current item of text size spinner",
-				String.valueOf(TEXT_SIZE_30), getSelectedItemFromMaterialSpinner(mTextSizeSpinner));
+				String.valueOf(TEXT_SIZE_30), (String) mTextSizeSpinner.getSelectedItem());
 	}
 
 	@Test
@@ -216,12 +214,12 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		openToolOptionsForCurrentTool();
 		mSolo.sleep(SLEEP_WAIT_FOR_DIALOG_UPDATE_AND_LISTENER);
 		assertEquals("Wrong input text after reopen dialog", TEST_TEXT, mTextEditText.getText().toString());
-		assertEquals("Wrong font selected after reopen dialog", FONT_SANS_SERIF, getSelectedItemFromMaterialSpinner(mFontSpinner));
+		assertEquals("Wrong font selected after reopen dialog", FONT_SANS_SERIF, (String) mFontSpinner.getSelectedItem());
 		assertEquals("Wrong underline status after reopen dialog", true, mUnderlinedToggleButton.isChecked());
 		assertEquals("Wrong italic status after reopen dialog", true, mItalicToggleButton.isChecked());
 		assertEquals("Wrong bold status after reopen dialog", true, mBoldToggleButton.isChecked());
 		assertEquals("Wrong text size selected after reopen dialog",
-				String.valueOf(TEXT_SIZE_40), getSelectedItemFromMaterialSpinner(mTextSizeSpinner));
+				String.valueOf(TEXT_SIZE_40), (String) mTextSizeSpinner.getSelectedItem());
 		checkTextBoxDimensions();
 		assertEquals("Wrong text box position after reopen dialog", newBoxPosition, getToolMemberBoxPosition());
 	}
@@ -235,7 +233,7 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		assertFalse("Italic button should not be pressed", mUnderlinedToggleButton.isChecked());
 		assertFalse("Bold button should not be pressed", mUnderlinedToggleButton.isChecked());
 
-		ArrayList<FormattingOptions> fonts = new ArrayList<FormattingOptions>();
+		ArrayList<FormattingOptions> fonts = new ArrayList<>();
 		fonts.add(FormattingOptions.SERIF);
 		fonts.add(FormattingOptions.SANS_SERIF);
 		fonts.add(FormattingOptions.MONOSPACE);
@@ -298,7 +296,7 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		assertFalse("Italic button should not be pressed", mUnderlinedToggleButton.isChecked());
 		assertFalse("Bold button should not be pressed", mUnderlinedToggleButton.isChecked());
 
-		ArrayList<FormattingOptions> fonts = new ArrayList<FormattingOptions>();
+		ArrayList<FormattingOptions> fonts = new ArrayList<>();
 		fonts.add(FormattingOptions.ALARABIYA);
 		fonts.add(FormattingOptions.DUBAI);
 
@@ -357,7 +355,7 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		selectTextTool();
 		enterTestText();
 
-		ArrayList<FormattingOptions> sizes = new ArrayList<FormattingOptions>();
+		ArrayList<FormattingOptions> sizes = new ArrayList<>();
 		sizes.add(FormattingOptions.SIZE_30);
 		sizes.add(FormattingOptions.SIZE_40);
 		sizes.add(FormattingOptions.SIZE_60);
@@ -484,8 +482,8 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		float actualBoxHeight = getToolMemberBoxHeight();
 
 		boolean italic = mItalicToggleButton.isChecked();
-		String font = getSelectedItemFromMaterialSpinner(mFontSpinner);
-		float textSize = Float.valueOf(getSelectedItemFromMaterialSpinner(mTextSizeSpinner)) * textSizeMagnificationFactor;
+		String font = (String) mFontSpinner.getSelectedItem();
+		float textSize = Float.valueOf((String) mTextSizeSpinner.getSelectedItem()) * textSizeMagnificationFactor;
 		Paint textPaint = new Paint();
 		textPaint.setAntiAlias(true);
 
@@ -559,11 +557,11 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 		mTextTool = (TextTool) PaintroidApplication.currentTool;
 
 		mTextEditText = (EditText)mSolo.getView(R.id.text_tool_dialog_input_text);
-		mFontSpinner = (MaterialSpinner)mSolo.getView(R.id.text_tool_dialog_spinner_font);
+		mFontSpinner = (Spinner)mSolo.getView(R.id.text_tool_dialog_spinner_font);
 		mUnderlinedToggleButton = (ToggleButton)mSolo.getView(R.id.text_tool_dialog_toggle_underlined);
 		mItalicToggleButton = (ToggleButton)mSolo.getView(R.id.text_tool_dialog_toggle_italic);
 		mBoldToggleButton = (ToggleButton)mSolo.getView(R.id.text_tool_dialog_toggle_bold);
-		mTextSizeSpinner = (MaterialSpinner)mSolo.getView(R.id.text_tool_dialog_spinner_text_size);
+		mTextSizeSpinner = (Spinner)mSolo.getView(R.id.text_tool_dialog_spinner_text_size);
 		mTextTool.resetBoxPosition();
 	}
 
@@ -705,9 +703,5 @@ public class TextToolIntegrationTest extends BaseIntegrationTestClass {
 	}
 	protected void setToolMemberBoxWidth(float width) throws NoSuchFieldException, IllegalAccessException {
 		PrivateAccess.setMemberValue(BaseToolWithRectangleShape.class, mTextTool, "boxWidth", width);
-	}
-
-	protected String getSelectedItemFromMaterialSpinner(MaterialSpinner materialSpinner) {
-		return materialSpinner.getItems().get(materialSpinner.getSelectedIndex()).toString();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/TextToolOptionsListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/TextToolOptionsListener.java
@@ -20,19 +20,20 @@
 package org.catrobat.paintroid.listener;
 
 import android.content.Context;
+import android.graphics.Paint;
 import android.text.Editable;
-import android.text.Html;
 import android.text.TextWatcher;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Checkable;
 import android.widget.EditText;
+import android.widget.Spinner;
 import android.widget.ToggleButton;
-
-import com.jaredrummler.materialspinner.MaterialSpinner;
 
 import org.catrobat.paintroid.R;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 public final class TextToolOptionsListener {
@@ -42,13 +43,8 @@ public final class TextToolOptionsListener {
 	private OnTextToolOptionsChangedListener onTextToolOptionsChangedListener;
 	private Context context;
 	private EditText textEditText;
-	private MaterialSpinner fontSpinner;
-	private ToggleButton underlinedToggleButton;
-	private ToggleButton italicToggleButton;
-	private ToggleButton boldToggleButton;
-	private MaterialSpinner textSizeSpinner;
 
-	public TextToolOptionsListener(Context context, View textToolOptionsView) {
+	private TextToolOptionsListener(Context context, View textToolOptionsView) {
 		this.context = context;
 		initializeListeners(textToolOptionsView);
 	}
@@ -92,61 +88,71 @@ public final class TextToolOptionsListener {
 			}
 		});
 
-		fontSpinner = (MaterialSpinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_font);
-		fontSpinner.setItems(new ArrayList<String>(Arrays.asList(context.getResources().getStringArray(R.array.text_tool_font_array))));
-
-		fontSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
+		Spinner fontSpinner = (Spinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_font);
+		ArrayAdapter<String> fontSpinnerAdapter = new ArrayAdapter<>(context,
+				android.R.layout.simple_list_item_activated_1,
+				Arrays.asList(context.getResources().getStringArray(R.array.text_tool_font_array)));
+		fontSpinner.setAdapter(fontSpinnerAdapter);
+		fontSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
 			@Override
-			public void onItemSelected(MaterialSpinner view, int position, long id, Object font) {
-				onTextToolOptionsChangedListener.setFont(font.toString());
+			public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+				String fontString = (String) parent.getItemAtPosition(position);
+				onTextToolOptionsChangedListener.setFont(fontString);
 				hideKeyboard();
+			}
+
+			@Override
+			public void onNothingSelected(AdapterView<?> parent) {
 			}
 		});
 
-		underlinedToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_underlined);
-		underlinedToggleButton.setTextOn(Html.fromHtml(
-				"<u>" + context.getResources().getString(R.string.text_tool_dialog_underline_shortcut) + "</u>"));
+		ToggleButton underlinedToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_underlined);
+		underlinedToggleButton.setPaintFlags(underlinedToggleButton.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
 		underlinedToggleButton.setOnClickListener(new ToggleButton.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				boolean underlined = underlinedToggleButton.isChecked();
+				boolean underlined = ((Checkable) v).isChecked();
 				onTextToolOptionsChangedListener.setUnderlined(underlined);
 				hideKeyboard();
 			}
 		});
 
-		italicToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_italic);
-		italicToggleButton.setTextOn(Html.fromHtml(
-				"<i>" + context.getResources().getString(R.string.text_tool_dialog_italic_shortcut) + "</i>"));
+		ToggleButton italicToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_italic);
 		italicToggleButton.setOnClickListener(new ToggleButton.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				boolean italic = italicToggleButton.isChecked();
+				boolean italic = ((Checkable) v).isChecked();
 				onTextToolOptionsChangedListener.setItalic(italic);
 				hideKeyboard();
 			}
 		});
 
-		boldToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_bold);
-		boldToggleButton.setTextOn(Html.fromHtml(
-				"<b>" + context.getResources().getString(R.string.text_tool_dialog_bold_shortcut) + "</b>"));
+		ToggleButton boldToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_bold);
 		boldToggleButton.setOnClickListener(new ToggleButton.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				boolean bold = boldToggleButton.isChecked();
+				boolean bold = ((Checkable) v).isChecked();
 				onTextToolOptionsChangedListener.setBold(bold);
 				hideKeyboard();
 			}
 		});
 
-		textSizeSpinner = (MaterialSpinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_text_size);
-		textSizeSpinner.setItems(new ArrayList<String>(Arrays.asList(context.getResources().getStringArray(R.array.text_tool_size_array))));
+		Spinner textSizeSpinner = (Spinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_text_size);
+		ArrayAdapter<String> textSizeArrayAdapter = new ArrayAdapter<>(context,
+				android.R.layout.simple_list_item_activated_1,
+				Arrays.asList(context.getResources().getStringArray(R.array.text_tool_size_array)));
+		textSizeSpinner.setAdapter(textSizeArrayAdapter);
 
-		textSizeSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
+		textSizeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
 			@Override
-			public void onItemSelected(MaterialSpinner view, int position, long id, Object size) {
-				onTextToolOptionsChangedListener.setTextSize(Integer.valueOf(size.toString()));
+			public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+				int textSize = Integer.valueOf((String) parent.getItemAtPosition(position));
+				onTextToolOptionsChangedListener.setTextSize(textSize);
 				hideKeyboard();
+			}
+
+			@Override
+			public void onNothingSelected(AdapterView<?> parent) {
 			}
 		});
 	}

--- a/Paintroid/src/main/res/layout/dialog_text_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_text_tool.xml
@@ -18,7 +18,6 @@
  -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/layout_text_tool_dialog"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -31,104 +30,88 @@
         android:fadeScrollbars="false">
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical"
             android:clickable="true"
+            android:focusable="true"
             android:focusableInTouchMode="true">
 
             <TextView
                 android:id="@+id/text_tool_dialog_input_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                android:layout_marginLeft="24dip"
-                android:layout_marginRight="16dp"
+                android:layout_marginStart="24dp"
+                android:layout_marginEnd="16dp"
                 android:layout_marginTop="0dp"
+                android:layout_marginBottom="4dp"
                 android:text="@string/text_tool_dialog_input_title"
                 android:textAllCaps="true"
                 android:textColor="@color/dialog_subtitle"
-                android:textStyle="bold"
-                android:layout_marginStart="24dip"
-                android:layout_marginEnd="16dp" />
+                android:textStyle="bold" />
 
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
-                android:background="@color/dialog_subtitle_border"
                 android:layout_marginStart="16dp"
-                android:layout_marginEnd="16dp" />
+                android:layout_marginEnd="16dp"
+                android:background="@color/dialog_subtitle_border" />
 
-            <EditText android:id="@+id/text_tool_dialog_input_text"
+            <EditText
+                android:id="@+id/text_tool_dialog_input_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:inputType="textMultiLine"
-                android:layout_marginBottom="4dp"
-                android:layout_marginLeft="30dp"
-                android:layout_marginRight="30dp"
-                android:layout_marginTop="10dp"
-                android:textCursorDrawable="@null"
-                android:textColor="@android:color/black"
-                android:textColorHint="@color/color_chooser_gray"
-                android:hint="@string/text_tool_dialog_input_hint"
-                android:layout_marginEnd="30dp"
                 android:layout_marginStart="30dp"
+                android:layout_marginEnd="30dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="4dp"
+                android:textCursorDrawable="@null"
+                android:hint="@string/text_tool_dialog_input_hint"
                 android:imeOptions="flagNoExtractUi"/>
 
             <TextView
                 android:id="@+id/text_tool_dialog_format_options_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                android:layout_marginLeft="24dip"
-                android:layout_marginRight="16dp"
+                android:layout_marginStart="24dip"
+                android:layout_marginEnd="16dp"
                 android:layout_marginTop="24dp"
+                android:layout_marginBottom="4dp"
                 android:text="@string/text_tool_dialog_format_options"
                 android:textAllCaps="true"
                 android:textColor="@color/dialog_subtitle"
-                android:textStyle="bold"
-                android:layout_marginStart="24dip"
-                android:layout_marginEnd="16dp" />
+                android:textStyle="bold" />
 
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="2dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
-                android:background="@color/dialog_subtitle_border"
+                android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
-                android:layout_marginStart="16dp" />
+                android:background="@color/dialog_subtitle_border" />
 
             <LinearLayout
                 android:orientation="horizontal"
                 android:layout_width="match_parent"
                 android:weightSum="5"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:layout_marginLeft="25dp"
-                android:layout_marginRight="25dp"
-                android:layout_marginBottom="10dp"
                 android:layout_marginStart="25dp"
                 android:layout_marginEnd="25dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="10dp"
                 android:gravity="center">
 
-                <com.jaredrummler.materialspinner.MaterialSpinner
+                <Spinner
                     android:id="@+id/text_tool_dialog_spinner_font"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:ms_background_color="@android:color/white"
-                    app:ms_text_color="@android:color/black"/>
+                    android:layout_height="wrap_content" />
 
-                <com.jaredrummler.materialspinner.MaterialSpinner
+                <Spinner
                     android:id="@+id/text_tool_dialog_spinner_text_size"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="5dp"
                     android:layout_marginEnd="5dp"
-                    android:layout_weight="2"
-                    app:ms_background_color="@android:color/white"
-                    app:ms_text_color="@android:color/black" />
+                    android:layout_weight="2" />
             </LinearLayout>
 
             <LinearLayout
@@ -136,20 +119,19 @@
                 android:layout_width="match_parent"
                 android:weightSum="5"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:layout_marginLeft="25dp"
-                android:layout_marginRight="25dp"
-                android:layout_marginBottom="10dp"
                 android:layout_marginStart="25dp"
                 android:layout_marginEnd="25dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="10dp"
                 android:gravity="center">
 
                 <ToggleButton
                     android:id="@+id/text_tool_dialog_toggle_underlined"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
-                    android:textOff="@string/text_tool_dialog_underline_shortcut"
                     android:textStyle="normal"
+                    android:textOn="@string/text_tool_dialog_underline_shortcut"
+                    android:textOff="@string/text_tool_dialog_underline_shortcut"
                     android:layout_weight="1"/>
 
                 <ToggleButton
@@ -157,6 +139,7 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:textStyle="italic"
+                    android:textOn="@string/text_tool_dialog_italic_shortcut"
                     android:textOff="@string/text_tool_dialog_italic_shortcut"
                     android:layout_weight="1" />
 
@@ -165,6 +148,7 @@
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
                     android:textStyle="bold"
+                    android:textOn="@string/text_tool_dialog_bold_shortcut"
                     android:textOff="@string/text_tool_dialog_bold_shortcut"
                     android:layout_weight="1" />
             </LinearLayout>

--- a/Paintroid/src/main/res/values/style.xml
+++ b/Paintroid/src/main/res/values/style.xml
@@ -43,7 +43,6 @@
         <item name="windowActionBar">false</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="android:colorBackground">@color/custom_background_color</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="drawerArrowStyle">@style/WhiteDrawerIconStyle</item>
     </style>


### PR DESCRIPTION
* Remove thirdparty material spinner and replace with stock spinner
* Adapt tests to stock spinner
* Improve layout xml by grouping entries consistently
* Remove unecessary background color in theme