### PR TITLE
PAINT-253: Language not set correctly on API >= 25

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/util/WelcomeActivityIntentsTestRule.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/util/WelcomeActivityIntentsTestRule.java
@@ -24,6 +24,8 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 import android.util.LayoutDirection;
 
+import org.catrobat.paintroid.MultilingualActivity;
+import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.Session;
 import org.catrobat.paintroid.WelcomeActivity;
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
@@ -84,10 +86,15 @@ public class WelcomeActivityIntentsTestRule extends IntentsTestRule<WelcomeActiv
 
 		try {
 			EspressoUtils.shouldStartSequence(startSequence);
-			EspressoUtils.setRtl(rtl);
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}
+
+		String languageTagKey = rtl ? "ar" : "";
+		PaintroidApplication.languageSharedPreferences
+				.edit()
+				.putString(MultilingualActivity.LANGUAGE_TAG_KEY, languageTagKey)
+				.commit();
 
 		Session session = new Session(InstrumentationRegistry.getTargetContext());
 		session.setFirstTimeLaunch(true);
@@ -109,8 +116,9 @@ public class WelcomeActivityIntentsTestRule extends IntentsTestRule<WelcomeActiv
 	protected void afterActivityFinished() {
 		super.afterActivityFinished();
 
-		if (rtl) {
-			EspressoUtils.setRtl(false);
-		}
+		PaintroidApplication.languageSharedPreferences
+				.edit()
+				.remove(MultilingualActivity.LANGUAGE_TAG_KEY)
+				.commit();
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/rtl/util/RtlActivityTestRule.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/rtl/util/RtlActivityTestRule.java
@@ -20,12 +20,10 @@
 package org.catrobat.paintroid.test.espresso.rtl.util;
 
 import android.app.Activity;
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ActivityTestRule;
 
 import org.catrobat.paintroid.MultilingualActivity;
+import org.catrobat.paintroid.PaintroidApplication;
 
 public class RtlActivityTestRule<T extends Activity> extends ActivityTestRule<T> {
 	public RtlActivityTestRule(Class<T> activityClass) {
@@ -36,11 +34,9 @@ public class RtlActivityTestRule<T extends Activity> extends ActivityTestRule<T>
 	protected void afterActivityFinished() {
 		super.afterActivityFinished();
 
-		SharedPreferences sharedPreferences = InstrumentationRegistry.getTargetContext().getSharedPreferences("For_language", Context.MODE_PRIVATE);
-		SharedPreferences.Editor editor = sharedPreferences.edit();
-		editor.putString(MultilingualActivity.LANGUAGE_TAG_KEY, "");
-		editor.commit();
-
-		MultilingualActivity.updateLocale(getActivity(), "", "");
+		PaintroidApplication.languageSharedPreferences
+				.edit()
+				.remove(MultilingualActivity.LANGUAGE_TAG_KEY)
+				.commit();
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
@@ -70,7 +70,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-import static org.catrobat.paintroid.MultilingualActivity.updateLocale;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.selectViewPagerPage;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.unconstrainedScrollTo;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.hasTablePosition;
@@ -410,15 +409,6 @@ public final class EspressoUtils {
 
 	public static void shouldStartSequence(TapTargetTopBar topBar, boolean start) throws NoSuchFieldException, IllegalAccessException {
 		PrivateAccess.setMemberValue(TapTargetTopBar.class, topBar, "firsTimeSequence", start);
-	}
-
-	public static void setRtl(boolean rtl) {
-		Context context = InstrumentationRegistry.getTargetContext();
-		if (rtl) {
-			updateLocale(context, "he", null);
-		} else {
-			updateLocale(context, "", null);
-		}
 	}
 
 	/**

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -660,6 +660,6 @@ public class MainActivity extends NavigationDrawerMenuActivity implements Naviga
 	}
 
 	private void initLocaleConfiguration() {
-		PaintroidApplication.updateToChosenLanguage();
+		MultilingualActivity.setToChosenLanguage(this);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MultilingualActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MultilingualActivity.java
@@ -19,10 +19,12 @@
 
 package org.catrobat.paintroid;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
@@ -33,55 +35,33 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import static org.catrobat.paintroid.PaintroidApplication.defaultSystemLanguage;
 import static org.catrobat.paintroid.PaintroidApplication.languageSharedPreferences;
 
 public class MultilingualActivity extends AppCompatActivity {
 	public static final String LANGUAGE_TAG_KEY = "applicationLanguage";
-	public static final String[] LANGUAGE_CODE = {"az", "bs", "ca", "cs", "sr-rCS", "sr-rSP", "da", "de", "en-rAU", "en-rCA",
-			"en-rGB", "en", "es", "fr", "gl", "hr", "in", "it", "sw", "hu", "mk", "ms", "nl", "no", "pl", "pt-rBR", "pt", "ru",
-			"ro", "sq", "sl", "sk", "sv", "vi", "tr", "ml", "ta", "te", "th", "gu", "hi", "ja", "ko", "zh-rCN", "zh-rTW", "ar",
-			"ur", "fa", "ps", "sd", "iw"};
-
-	public static void updateLocale(Context context, String languageTag, String countryTag) {
-		Locale mLocale;
-		if (countryTag == null) {
-			mLocale = new Locale(languageTag);
-		} else {
-			mLocale = new Locale(languageTag, countryTag);
-		}
-		Resources resources = context.getResources();
-		DisplayMetrics displayMetrics = resources.getDisplayMetrics();
-		Configuration conf = resources.getConfiguration();
-		conf.setLocale(mLocale);
-		Locale.setDefault(mLocale);
-		conf.setLayoutDirection(mLocale);
-		resources.updateConfiguration(conf, displayMetrics);
-	}
+	public static final String[] LANGUAGE_CODE = {"az", "bg-BG", "bs", "ca", "cs", "sr-CS", "sr-SP",
+			"da", "de", "el", "en-AU", "en-CA", "en-GB", "en", "es", "fr", "gl", "hr", "in", "it",
+			"sw", "hu", "mk", "ms", "nl", "no", "pl", "pt-BR", "pt", "ru", "ro", "sq", "sl", "sk",
+			"sv", "vi", "tr", "ml", "ta", "te", "th", "gu", "hi", "ja", "ko", "lt-LT", "zh-CN",
+			"zh-TW", "ar", "ur", "fa", "ps", "sd", "iw"};
 
 	@Override
 	protected void onCreate(@Nullable Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		setToChosenLanguage(this);
+
 		setContentView(R.layout.activity_multilingual);
 		setTitle(R.string.menu_language);
 		ListView listview = (ListView) findViewById(R.id.list_languages);
 		final List<String> languagesNames = new ArrayList<>();
 		languagesNames.add(getResources().getString(R.string.device_language));
 		for (String aLanguageCode : LANGUAGE_CODE) {
-			if (aLanguageCode.length() == 2 && !aLanguageCode.equals("sd")) {
-				languagesNames.add(new Locale(aLanguageCode).getDisplayName(new Locale(aLanguageCode)));
-				// the output text of' new Locale("sd").getDisplayName(new Locale("sd")));' is "Sindhi" which is wrong
-				// the correct name of the sindhi language in Sindhi is "سنڌي"
-			} else if (aLanguageCode.length() == 2 && aLanguageCode.equals("sd")) {
-				languagesNames.add("سنڌي");
-			} else {
-				String language = aLanguageCode.substring(0, 2);
-				String country = aLanguageCode.substring(4);
-				languagesNames.add(new Locale(language, country).getDisplayName(new Locale(language, country)));
-			}
+			Locale locale = getLocaleFromLanguageTag(aLanguageCode);
+			languagesNames.add(getDisplayName(locale));
 		}
 		ArrayAdapter<String> adapter = new ArrayAdapter<>(this, R.layout.multilingual_name_text, R.id.lang_text, languagesNames);
 		listview.setAdapter(adapter);
@@ -89,26 +69,59 @@ public class MultilingualActivity extends AppCompatActivity {
 			@Override
 			public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
 
-				if (position == 0) {
-					setLanguageSharedPreference(null);
-					setNewLocale(defaultSystemLanguage, null);
-				} else if (LANGUAGE_CODE[position - 1].length() == 2) {
-					setLanguageSharedPreference(LANGUAGE_CODE[position - 1]);
-					setNewLocale(LANGUAGE_CODE[position - 1], null);
-				} else if (LANGUAGE_CODE[position - 1].length() == 6) {
-					setLanguageSharedPreference(LANGUAGE_CODE[position - 1]);
-					String language = LANGUAGE_CODE[position - 1].substring(0, 2);
-					String country = LANGUAGE_CODE[position - 1].substring(4);
-					setNewLocale(language, country);
-				}
+				String localeString = getLocaleStringFromPosition(position);
+				setLanguageSharedPreference(localeString);
+				setResult(RESULT_OK);
+				finish();
 			}
 		});
 	}
 
-	private void setNewLocale(String languageTag, String countryTag) {
-		updateLocale(this, languageTag, countryTag);
-		setResult(RESULT_OK);
-		finish();
+	private String getDisplayName(Locale locale) {
+		String language = locale.getLanguage();
+		// the output text of 'locale.getDisplayName(locale)' for "sd" is "Sindhi" which is wrong
+		// the correct name of the sindhi language in Sindhi is "سنڌي"
+		if (language.equals("sd")) {
+			return "سنڌي";
+		} else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
+				&& language.equals("ps")) {
+			return "پښتو";
+		} else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
+				&& language.equals("ur")) {
+			return "اردو";
+		}
+		return locale.getDisplayName(locale);
+	}
+
+	public static void setToChosenLanguage(Activity activity) {
+		String languageTag = languageSharedPreferences.getString(LANGUAGE_TAG_KEY, "");
+		Locale locale = Arrays.asList(LANGUAGE_CODE).contains(languageTag)
+				? getLocaleFromLanguageTag(languageTag)
+				: new Locale(PaintroidApplication.defaultSystemLanguage);
+
+		Locale.setDefault(locale);
+		setLocale(activity, locale);
+		setLocale(activity.getApplicationContext(), locale);
+	}
+
+	private static void setLocale(Context context, Locale locale) {
+		Resources resources = context.getResources();
+		DisplayMetrics displayMetrics = resources.getDisplayMetrics();
+		Configuration conf = resources.getConfiguration();
+		conf.setLocale(locale);
+		resources.updateConfiguration(conf, displayMetrics);
+	}
+
+	private static Locale getLocaleFromLanguageTag(String languageTag) {
+		if (languageTag.contains("-")) {
+			String[] tags = languageTag.split("-");
+			return new Locale(tags[0], tags[1]);
+		}
+		return new Locale(languageTag);
+	}
+
+	private String getLocaleStringFromPosition(int position) {
+		return position > 0 ? LANGUAGE_CODE[position - 1] : null;
 	}
 
 	private void setLanguageSharedPreference(String value) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplication.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplication.java
@@ -39,12 +39,8 @@ import org.catrobat.paintroid.ui.DrawingSurface;
 import org.catrobat.paintroid.ui.Perspective;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Locale;
-
-import static org.catrobat.paintroid.MultilingualActivity.LANGUAGE_CODE;
-import static org.catrobat.paintroid.MultilingualActivity.LANGUAGE_TAG_KEY;
 
 public class PaintroidApplication extends Application {
 	public static final String TAG = "PAINTROID";
@@ -71,21 +67,6 @@ public class PaintroidApplication extends Application {
 	public static String defaultSystemLanguage;
 	public static SharedPreferences languageSharedPreferences;
 
-	public static void updateToChosenLanguage() {
-		String languageTag = languageSharedPreferences.getString(LANGUAGE_TAG_KEY, "");
-		if (Arrays.asList(LANGUAGE_CODE).contains(languageTag)) {
-			if (languageTag.length() == 2) {
-				MultilingualActivity.updateLocale(applicationContext, languageTag, null);
-			} else {
-				String language = languageTag.substring(0, 2);
-				String country = languageTag.substring(4);
-				MultilingualActivity.updateLocale(applicationContext, language, country);
-			}
-		} else {
-			MultilingualActivity.updateLocale(applicationContext, defaultSystemLanguage, null);
-		}
-	}
-
 	public static String getVersionName(Context context) {
 		String versionName = "unknown";
 		try {
@@ -108,6 +89,5 @@ public class PaintroidApplication extends Application {
 
 		defaultSystemLanguage = Locale.getDefault().getLanguage();
 		languageSharedPreferences = getSharedPreferences("For_language", Context.MODE_PRIVATE);
-		updateToChosenLanguage();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
@@ -123,6 +123,7 @@ public class WelcomeActivity extends AppCompatActivity {
 					| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
 		}
 
+		MultilingualActivity.setToChosenLanguage(this);
 		setContentView(R.layout.activity_welcome);
 
 		viewPager = (ViewPager) findViewById(R.id.view_pager);

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -198,7 +198,7 @@
     <string name="dialog_shape_text">Shape</string>
     <string name="dialog_loading_image_failed_title">Error on loading image</string>
     <string name="dialog_loading_image_failed_text">Not a valid image file</string>
-    <string name="dialog_please_wait">Please wait...</string>
+    <string name="dialog_please_wait">Please wait…</string>
 
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>


### PR DESCRIPTION
* Remove EspressoUtils setRtl helper function
  Instead set shared preferences before activity start and after
  activity end.
* Move `updateToChosenLanguage` to `setToChosenLanguage` in
  `MultilingualActivity`
* Add missing locales to `LANGUAGE_CODE` array
* Rework String <-> locale conversion code
* Add hardcoded strings for Pashto and Urdu for API < 21
* Set all activites to chosen language before setting content view