### PR TITLE
PAINT-268: Add a launch screen

### DIFF
--- a/Paintroid/src/main/AndroidManifest.xml
+++ b/Paintroid/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:configChanges="orientation|locale"
             android:label="${appName}"
             android:screenOrientation="portrait"
-            android:theme="@style/WelcomeActivityTheme">
+            android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
@@ -108,6 +108,7 @@ public class WelcomeActivity extends AppCompatActivity {
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
+		setTheme(R.style.WelcomeActivityTheme);
 		super.onCreate(savedInstanceState);
 
 		session = new Session(this);

--- a/Paintroid/src/main/res/drawable/launch.xml
+++ b/Paintroid/src/main/res/drawable/launch.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@android:color/white" />
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/ic_pocket_paint_logo" />
+    </item>
+</layer-list>

--- a/Paintroid/src/main/res/values-v19/style.xml
+++ b/Paintroid/src/main/res/values-v19/style.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch</item>
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+    </style>
+</resources>

--- a/Paintroid/src/main/res/values/style.xml
+++ b/Paintroid/src/main/res/values/style.xml
@@ -36,6 +36,10 @@
         <item name="android:windowMinWidthMinor">0%</item>
     </style>
 
+    <style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch</item>
+    </style>
+
     <style name="MyMaterialTheme" parent="MyMaterialTheme.Base" />
 
     <style name="MyMaterialTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">


### PR DESCRIPTION
Current implementation looks like this: https://streamable.com/voxes

There is no overhead in any way, it simply sets a picture as windowBackground and overrides it once the app is started (Same loading time as before).