### PR TITLE
PAINT-267: Resolve rectangle tool drawing jitter

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -22,7 +22,6 @@ package org.catrobat.paintroid.test.junit.tools;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
-import android.graphics.Canvas;
 import android.graphics.PointF;
 import android.support.test.annotation.UiThreadTest;
 
@@ -601,10 +600,6 @@ public class BaseToolWithRectangleShapeToolTest extends BaseToolTest {
 		@Override
 		protected void onClickInBox() {
 			drawingBitmap = Bitmap.createBitmap(1, 1, Config.ALPHA_8);
-		}
-
-		@Override
-		protected void drawToolSpecifics(Canvas canvas) {
 		}
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -262,37 +262,42 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 	public void drawShape(Canvas canvas) {
 		initScaleDependedValues();
 
+		float boxWidth = this.boxWidth;
+		float boxHeight = this.boxHeight;
+		float boxRotation = this.boxRotation;
+		PointF toolPosition = new PointF(this.toolPosition.x, this.toolPosition.y);
+
 		canvas.translate(toolPosition.x, toolPosition.y);
 		canvas.rotate(boxRotation);
 
 		if (backgroundShadowEnabled) {
-			drawBackgroundShadow(canvas);
+			drawBackgroundShadow(canvas, boxWidth, boxHeight, boxRotation, toolPosition);
 		}
 
 		if (resizePointsVisible) {
-			drawResizePoints(canvas);
+			drawResizePoints(canvas, boxWidth, boxHeight);
 		}
 
 		if (drawingBitmap != null && rotationEnabled) {
-			drawRotationArrows(canvas);
+			drawRotationArrows(canvas, boxWidth, boxHeight);
 		}
 
 		if (drawingBitmap != null) {
-			drawBitmap(canvas);
+			drawBitmap(canvas, boxWidth, boxHeight);
 		}
 		if (overlayBitmap != null) {
-			drawOverlayBitmap(canvas);
+			drawOverlayBitmap(canvas, boxWidth, boxHeight);
 		}
 
-		drawRectangle(canvas);
-		drawToolSpecifics(canvas);
+		drawRectangle(canvas, boxWidth, boxHeight);
+		drawToolSpecifics(canvas, boxWidth, boxHeight);
 
 		if (statusIconEnabled) {
 			drawStatus(canvas);
 		}
 	}
 
-	private void drawBackgroundShadow(Canvas canvas) {
+	private void drawBackgroundShadow(Canvas canvas, float boxWidth, float boxHeight, float boxRotation, PointF toolPosition) {
 
 		Paint backgroundPaint = new Paint();
 		backgroundPaint.setColor(Color.argb(128, 0, 0, 0));
@@ -312,7 +317,7 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		canvas.rotate(boxRotation);
 	}
 
-	private void drawResizePoints(Canvas canvas) {
+	private void drawResizePoints(Canvas canvas, float boxWidth, float boxHeight) {
 		float circleRadius = getInverselyProportionalSizeForZoom(RESIZE_CIRCLE_SIZE);
 		Paint circlePaint = new Paint();
 		circlePaint.setAntiAlias(true);
@@ -332,7 +337,7 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 				circlePaint);
 	}
 
-	private void drawRotationArrows(Canvas canvas) {
+	private void drawRotationArrows(Canvas canvas, float boxWidth, float boxHeight) {
 		float arcStrokeWidth = getInverselyProportionalSizeForZoom(ROTATION_ARROW_ARC_STROKE_WIDTH);
 		float arcRadius = getInverselyProportionalSizeForZoom(ROTATION_ARROW_ARC_RADIUS);
 		float arrowSize = getInverselyProportionalSizeForZoom(ROTATION_ARROW_HEAD_SIZE);
@@ -383,8 +388,7 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		}
 	}
 
-	protected void drawBitmap(Canvas canvas) {
-
+	protected void drawBitmap(Canvas canvas, float boxWidth, float boxHeight) {
 		Paint bitmapPaint = new Paint(Paint.DITHER_FLAG);
 		canvas.save();
 
@@ -394,15 +398,14 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 				boxWidth / 2, boxHeight / 2), bitmapPaint);
 	}
 
-	private void drawOverlayBitmap(Canvas canvas) {
-
+	private void drawOverlayBitmap(Canvas canvas, float boxWidth, float boxHeight) {
 		Paint bitmapPaint = new Paint(Paint.DITHER_FLAG);
 
 		canvas.drawBitmap(overlayBitmap, null, new RectF(-boxWidth / 2, -boxHeight / 2,
 				boxWidth / 2, boxHeight / 2), bitmapPaint);
 	}
 
-	private void drawRectangle(Canvas canvas) {
+	private void drawRectangle(Canvas canvas, float boxWidth, float boxHeight) {
 		linePaint.setStrokeWidth(toolStrokeWidth);
 		linePaint.setColor(secondaryShapeColor);
 		canvas.drawRect(new RectF(-boxWidth / 2, -boxHeight / 2,
@@ -774,7 +777,8 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 
 	protected abstract void onClickInBox();
 
-	protected abstract void drawToolSpecifics(Canvas canvas);
+	protected void drawToolSpecifics(Canvas canvas, float boxWidth, float boxHeight) {
+	}
 
 	protected void preventThatBoxGetsTooLarge(float oldWidth, float oldHeight,
 			float oldPosX, float oldPosY) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
@@ -204,11 +204,6 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 	}
 
 	@Override
-	protected void drawToolSpecifics(Canvas canvas) {
-		// TODO Auto-generated method stub
-	}
-
-	@Override
 	public void resetInternalState() {
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
@@ -252,10 +252,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 		toolPosition.y = boxHeight / 2.0f + marginTop;
 	}
 
-	@Override
-	protected void drawToolSpecifics(Canvas canvas) {
-	}
-
 	@SuppressLint("InflateParams")
 	@Override
 	public void setupToolOptions() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
@@ -302,14 +302,12 @@ public class TransformTool extends BaseToolWithRectangleShape {
 	}
 
 	@Override
-	protected void drawToolSpecifics(Canvas canvas) {
+	protected void drawToolSpecifics(Canvas canvas, float boxWidth, float boxHeight) {
 		if (cropRunFinished) {
 			linePaint.setColor(primaryShapeColor);
 			linePaint.setStrokeWidth(toolStrokeWidth * 2);
 
 			PointF rightTopPoint = new PointF(-boxWidth / 2, -boxHeight / 2);
-
-			float tempWidth = boxWidth;
 
 			for (int lines = 0; lines < 4; lines++) {
 				float resizeLineLengthHeight = boxHeight / 10;
@@ -335,7 +333,6 @@ public class TransformTool extends BaseToolWithRectangleShape {
 				boxHeight = boxWidth;
 				boxWidth = tempHeight;
 			}
-			boxWidth = tempWidth;
 		}
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -28,6 +28,7 @@ import android.graphics.PointF;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
+import android.graphics.Region;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
@@ -100,16 +101,17 @@ public class DrawingSurface extends SurfaceView implements
 			}
 
 			PaintroidApplication.perspective.applyToCanvas(surfaceViewCanvas);
+			surfaceViewCanvas.save();
+			surfaceViewCanvas.clipRect(workingBitmapRect, Region.Op.DIFFERENCE);
 			surfaceViewCanvas.drawColor(BACKGROUND_COLOR);
-			surfaceViewCanvas.drawRect(workingBitmapRect,
-					BaseTool.CHECKERED_PATTERN);
+			surfaceViewCanvas.restore();
+			surfaceViewCanvas.drawRect(workingBitmapRect, BaseTool.CHECKERED_PATTERN);
 			surfaceViewCanvas.drawRect(workingBitmapRect, framePaint);
 
 			if (workingBitmap != null && !workingBitmap.isRecycled()
 					&& surfaceCanBeUsed) {
 
 				ArrayList<Layer> layers = LayerListener.getInstance().getAdapter().getLayers();
-				opacityPaint = new Paint();
 
 				for (int i = layers.size() - 1; i >= 0; i--) {
 					surfaceViewCanvas.drawBitmap(layers.get(i).getImage(), 0, 0, opacityPaint);


### PR DESCRIPTION
* Use same box values for one full draw call in `BaseToolWithRectangleShape`
* Reduce surfaceview overdraw
* Reduce the madness going on in `StampTool`
* Fix the `StampTool` not showing a highlight box on copying
  