### PR TITLE
Paint-234: Shape tool doesn't remember chosen shape

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
@@ -32,7 +32,6 @@ import org.catrobat.paintroid.dialog.colorpicker.RgbSelectorView;
 import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -152,7 +151,6 @@ public class LandscapeIntegrationTest {
 		}
 	}
 
-	@Ignore("ignore until jenkins issues are resolved")
 	@Test
 	public void testCorrectSelectionInBothOrientations() {
 		for (ToolType toolType : ToolType.values()) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
@@ -19,7 +19,9 @@
 
 package org.catrobat.paintroid.test.espresso.tools;
 
+import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
+import android.graphics.PointF;
 import android.support.test.rule.ActivityTestRule;
 
 import org.catrobat.paintroid.MainActivity;
@@ -27,8 +29,8 @@ import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
 import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.tools.implementation.BaseToolWithShape;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,11 +40,14 @@ import java.util.Arrays;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.isSelected;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.runners.Parameterized.Parameter;
 import static org.junit.runners.Parameterized.Parameters;
@@ -76,13 +81,27 @@ public class ShapeToolIntegrationTest {
 				.performSelectTool(ToolType.SHAPE);
 	}
 
-	@Ignore("Enable with PAINT-234")
 	@Test
-	public void testRememberShapeAfterToolSwitch() {
+	public void testRememberPositionAfterOrientationChange() {
 		onView(withId(shape))
 				.perform(click());
+
+		PointF p = new PointF(0, 0);
+		((BaseToolWithShape) PaintroidApplication.currentTool).toolPosition.set(p);
+
+		activityTestRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+		assertEquals(p, ((BaseToolWithShape) PaintroidApplication.currentTool).toolPosition);
+	}
+
+	@Test
+	public void testRememberShapeAfterOrientationChange() {
+		onView(withId(shape))
+				.perform(click())
+				.check(matches(isSelected()));
 		onToolBarView()
 				.performCloseToolOptions();
+
 		onView(isRoot())
 				.perform(click());
 
@@ -90,15 +109,18 @@ public class ShapeToolIntegrationTest {
 
 		onTopBarView()
 				.performUndo();
+
+		activityTestRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+		onView(withId(shape))
+				.check(matches(isSelected()));
+
 		onToolBarView()
-				.performSelectTool(ToolType.BRUSH)
-				.performSelectTool(ToolType.SHAPE)
 				.performCloseToolOptions();
 
 		onView(isRoot())
 				.perform(click());
 
-		Bitmap actualBitmap = PaintroidApplication.drawingSurface.getBitmapCopy();
-		assertTrue(expectedBitmap.sameAs(actualBitmap));
+		assertTrue(expectedBitmap.sameAs(PaintroidApplication.drawingSurface.getBitmapCopy()));
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -89,6 +89,7 @@ public class MainActivity extends NavigationDrawerMenuActivity implements Naviga
 	private NavigationView layerSideNav;
 	private InputMethodManager inputMethodManager;
 	private boolean isKeyboardShown;
+	private Bundle toolBundle = new Bundle();
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -475,14 +476,26 @@ public class MainActivity extends NavigationDrawerMenuActivity implements Naviga
 	}
 
 	public synchronized void switchTool(Tool tool) {
-		Paint tempPaint = new Paint(PaintroidApplication.currentTool.getDrawPaint());
-		if (tool != null) {
-			PaintroidApplication.currentTool.leaveTool();
+		if (tool == null) {
+			return;
+		}
+
+		Tool currentTool = PaintroidApplication.currentTool;
+		Paint tempPaint = new Paint(currentTool.getDrawPaint());
+
+		currentTool.leaveTool();
+		if (currentTool.getToolType() == tool.getToolType()) {
+			currentTool.onSaveInstanceState(toolBundle);
+			PaintroidApplication.currentTool = tool;
+			bottomBar.setTool(tool);
+			tool.onRestoreInstanceState(toolBundle);
+		} else {
+			toolBundle = new Bundle();
 			bottomBar.setTool(tool);
 			PaintroidApplication.currentTool = tool;
-			tool.startTool();
-			PaintroidApplication.currentTool.setDrawPaint(tempPaint);
 		}
+		tool.startTool();
+		tool.setDrawPaint(tempPaint);
 	}
 
 	private void showSecurityQuestionBeforeExit() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/ShapeToolOptionsListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/ShapeToolOptionsListener.java
@@ -27,7 +27,6 @@ import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.implementation.GeometricFillTool;
 
 public class ShapeToolOptionsListener {
-	private GeometricFillTool.BaseShape shape;
 	private OnShapeToolOptionsChangedListener onShapeToolOptionsChangedListener;
 	private ImageButton squareButton;
 	private ImageButton circleButton;
@@ -36,7 +35,6 @@ public class ShapeToolOptionsListener {
 	private TextView shapeToolDialogTitle;
 
 	public ShapeToolOptionsListener(View shapeToolOptionsView) {
-		shape = GeometricFillTool.BaseShape.RECTANGLE;
 		squareButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.shapes_square_btn);
 		circleButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.shapes_circle_btn);
 		heartButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.shapes_heart_btn);
@@ -44,7 +42,7 @@ public class ShapeToolOptionsListener {
 		shapeToolDialogTitle = (TextView) shapeToolOptionsView.findViewById(R.id.shape_tool_dialog_title);
 
 		initializeListeners();
-		setShapeActivated(shape);
+		setShapeActivated(GeometricFillTool.BaseShape.RECTANGLE);
 	}
 
 	private void initializeListeners() {
@@ -75,12 +73,8 @@ public class ShapeToolOptionsListener {
 	}
 
 	private void onShapeClicked(GeometricFillTool.BaseShape shape) {
-		if (this.shape == shape) {
-			return;
-		}
 		onShapeToolOptionsChangedListener.setToolType(shape);
 		setShapeActivated(shape);
-		this.shape = shape;
 	}
 
 	private void resetShapeActivated() {
@@ -90,7 +84,7 @@ public class ShapeToolOptionsListener {
 		}
 	}
 
-	private void setShapeActivated(GeometricFillTool.BaseShape shape) {
+	public void setShapeActivated(GeometricFillTool.BaseShape shape) {
 		resetShapeActivated();
 		switch (shape) {
 			case RECTANGLE:

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.java
@@ -24,6 +24,7 @@ import android.graphics.Paint;
 import android.graphics.Paint.Cap;
 import android.graphics.Point;
 import android.graphics.PointF;
+import android.os.Bundle;
 
 public interface Tool {
 
@@ -60,6 +61,10 @@ public interface Tool {
 	void hide();
 
 	void toggleShowToolOptions();
+
+	void onSaveInstanceState(Bundle bundle);
+
+	void onRestoreInstanceState(Bundle bundle);
 
 	void setupToolOptions();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
@@ -37,6 +37,7 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Shader;
 import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
@@ -135,6 +136,14 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 		toolOptionsLayout = (LinearLayout) ((Activity) context).findViewById(R.id.layout_tool_options);
 		toolSpecificOptionsLayout = (LinearLayout) ((Activity) context).findViewById(R.id.layout_tool_specific_options);
 		resetAndInitializeToolOptions();
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle bundle) {
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle bundle) {
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
@@ -38,6 +38,7 @@ import android.graphics.PorterDuffXfermode;
 import android.graphics.Shader;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.support.annotation.ColorInt;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
@@ -147,7 +148,13 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 	}
 
 	@Override
-	public void changePaintColor(int color) {
+	public void changePaintColor(@ColorInt int color) {
+		setPaintColor(color);
+		super.setChanged();
+		super.notifyObservers();
+	}
+
+	void setPaintColor(@ColorInt int color) {
 		bitmapPaint.setColor(color);
 		if (Color.alpha(color) == 0x00) {
 			bitmapPaint.setXfermode(ERASE_XFERMODE);
@@ -164,8 +171,6 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 			bitmapPaint.setXfermode(null);
 			canvasPaint.set(bitmapPaint);
 		}
-		super.setChanged();
-		super.notifyObservers();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -287,6 +287,8 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		float boxRotation = this.boxRotation;
 		tempToolPosition.set(this.toolPosition.x, this.toolPosition.y);
 
+		canvas.save();
+
 		canvas.translate(tempToolPosition.x, tempToolPosition.y);
 		canvas.rotate(boxRotation);
 
@@ -315,6 +317,8 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		if (statusIconEnabled) {
 			drawStatus(canvas);
 		}
+
+		canvas.restore();
 	}
 
 	private void drawBackgroundShadow(Canvas canvas, float boxWidth, float boxHeight, float boxRotation, PointF toolPosition) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -34,6 +34,7 @@ import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.graphics.Region.Op;
+import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.support.annotation.ColorRes;
 import android.support.annotation.VisibleForTesting;
@@ -78,6 +79,10 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 	private static final int ROTATION_ARROW_OFFSET = getDensitySpecificValue(3);
 
 	private static final int CLICK_TIMEOUT_MILLIS = 150;
+
+	private static final String BUNDLE_BOX_WIDTH = "BOX_WIDTH";
+	private static final String BUNDLE_BOX_HEIGHT = "BOX_HEIGHT";
+	private static final String BUNDLE_BOX_ROTATION = "BOX_ROTATION";
 
 	@VisibleForTesting
 	public float boxWidth;
@@ -847,6 +852,22 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 					viewHeight);
 		}
 		return new Point(0, 0);
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle bundle) {
+		super.onSaveInstanceState(bundle);
+		bundle.putFloat(BUNDLE_BOX_WIDTH, boxWidth);
+		bundle.putFloat(BUNDLE_BOX_HEIGHT, boxHeight);
+		bundle.putFloat(BUNDLE_BOX_ROTATION, boxRotation);
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle bundle) {
+		super.onRestoreInstanceState(bundle);
+		boxWidth = bundle.getFloat(BUNDLE_BOX_WIDTH, boxWidth);
+		boxHeight = bundle.getFloat(BUNDLE_BOX_HEIGHT, boxHeight);
+		boxRotation = bundle.getFloat(BUNDLE_BOX_ROTATION, boxRotation);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
@@ -24,6 +24,7 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Point;
 import android.graphics.PointF;
+import android.os.Bundle;
 import android.support.annotation.VisibleForTesting;
 import android.util.DisplayMetrics;
 
@@ -43,6 +44,9 @@ public abstract class BaseToolWithShape extends BaseTool implements
 	protected int secondaryShapeColor = PaintroidApplication.applicationContext
 			.getResources().getColor(R.color.rectangle_secondary_color);
 	protected Paint linePaint;
+
+	private static final String BUNDLE_TOOL_POSITION_X = "TOOL_POSITION_X";
+	private static final String BUNDLE_TOOL_POSITION_Y = "TOOL_POSITION_Y";
 
 	public BaseToolWithShape(Context context, ToolType toolType) {
 		super(context, toolType);
@@ -75,6 +79,22 @@ public abstract class BaseToolWithShape extends BaseTool implements
 		float displayScale = context.getResources().getDisplayMetrics().density;
 		float applicationScale = PaintroidApplication.perspective.getScale();
 		return (defaultSize * displayScale) / applicationScale;
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle bundle) {
+		super.onSaveInstanceState(bundle);
+
+		bundle.putFloat(BUNDLE_TOOL_POSITION_X, toolPosition.x);
+		bundle.putFloat(BUNDLE_TOOL_POSITION_Y, toolPosition.y);
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle bundle) {
+		super.onRestoreInstanceState(bundle);
+
+		toolPosition.x = bundle.getFloat(BUNDLE_TOOL_POSITION_X, toolPosition.x);
+		toolPosition.y = bundle.getFloat(BUNDLE_TOOL_POSITION_Y, toolPosition.y);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
@@ -20,6 +20,7 @@
 package org.catrobat.paintroid.tools.implementation;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Point;
@@ -37,20 +38,26 @@ import org.catrobat.paintroid.tools.ToolWithShape;
 public abstract class BaseToolWithShape extends BaseTool implements
 		ToolWithShape {
 
-	@VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-	public PointF toolPosition;
-	protected int primaryShapeColor = PaintroidApplication.applicationContext
-			.getResources().getColor(R.color.rectangle_primary_color);
-	protected int secondaryShapeColor = PaintroidApplication.applicationContext
-			.getResources().getColor(R.color.rectangle_secondary_color);
-	protected Paint linePaint;
-
 	private static final String BUNDLE_TOOL_POSITION_X = "TOOL_POSITION_X";
 	private static final String BUNDLE_TOOL_POSITION_Y = "TOOL_POSITION_Y";
 
+	@VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+	public final PointF toolPosition;
+
+	int primaryShapeColor;
+	int secondaryShapeColor;
+
+	final Paint linePaint;
+	final DisplayMetrics metrics;
+
 	public BaseToolWithShape(Context context, ToolType toolType) {
 		super(context, toolType);
-		DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+
+		final Resources resources = context.getResources();
+		metrics = resources.getDisplayMetrics();
+
+		primaryShapeColor = resources.getColor(R.color.rectangle_primary_color);
+		secondaryShapeColor = resources.getColor(R.color.rectangle_secondary_color);
 		float actionBarHeight = NavigationDrawerMenuActivity.ACTION_BAR_HEIGHT * metrics.density;
 		PointF surfaceToolPosition = new PointF(metrics.widthPixels / 2f, metrics.heightPixels
 				/ 2f - actionBarHeight);
@@ -62,23 +69,15 @@ public abstract class BaseToolWithShape extends BaseTool implements
 	@Override
 	public abstract void drawShape(Canvas canvas);
 
-	protected float getStrokeWidthForZoom(float defaultStrokeWidth,
-			float minStrokeWidth, float maxStrokeWidth) {
-		float displayScale = context.getResources().getDisplayMetrics().density;
-		float strokeWidth = (defaultStrokeWidth * displayScale)
+	float getStrokeWidthForZoom(float defaultStrokeWidth, float minStrokeWidth, float maxStrokeWidth) {
+		float strokeWidth = (defaultStrokeWidth * metrics.density)
 				/ PaintroidApplication.perspective.getScale();
-		if (strokeWidth < minStrokeWidth) {
-			strokeWidth = minStrokeWidth;
-		} else if (strokeWidth > maxStrokeWidth) {
-			strokeWidth = maxStrokeWidth;
-		}
-		return strokeWidth;
+		return Math.min(maxStrokeWidth, Math.max(minStrokeWidth, strokeWidth));
 	}
 
-	protected float getInverselyProportionalSizeForZoom(float defaultSize) {
-		float displayScale = context.getResources().getDisplayMetrics().density;
+	float getInverselyProportionalSizeForZoom(float defaultSize) {
 		float applicationScale = PaintroidApplication.perspective.getScale();
-		return (defaultSize * displayScale) / applicationScale;
+		return (defaultSize * metrics.density) / applicationScale;
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
@@ -260,7 +260,7 @@ public class CursorTool extends BaseToolWithShape {
 
 	@Override
 	public void draw(Canvas canvas) {
-		changePaintColor(canvasPaint.getColor());
+		setPaintColor(canvasPaint.getColor());
 		if (toolInDrawMode) {
 			if (canvasPaint.getColor() == Color.TRANSPARENT) {
 				canvasPaint.setColor(Color.BLACK);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
@@ -262,6 +262,10 @@ public class CursorTool extends BaseToolWithShape {
 	public void draw(Canvas canvas) {
 		setPaintColor(canvasPaint.getColor());
 		if (toolInDrawMode) {
+			canvas.save();
+			canvas.clipRect(0, 0,
+					PaintroidApplication.drawingSurface.getBitmapWidth(),
+					PaintroidApplication.drawingSurface.getBitmapHeight());
 			if (canvasPaint.getColor() == Color.TRANSPARENT) {
 				canvasPaint.setColor(Color.BLACK);
 				canvas.drawPath(pathToDraw, canvasPaint);
@@ -269,6 +273,7 @@ public class CursorTool extends BaseToolWithShape {
 			} else {
 				canvas.drawPath(pathToDraw, bitmapPaint);
 			}
+			canvas.restore();
 		}
 		this.drawShape(canvas);
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
@@ -58,6 +58,10 @@ public class DrawTool extends BaseTool {
 			setPaintColor(Color.TRANSPARENT);
 		}
 
+		canvas.save();
+		canvas.clipRect(0, 0,
+				PaintroidApplication.drawingSurface.getBitmapWidth(),
+				PaintroidApplication.drawingSurface.getBitmapHeight());
 		if (canvasPaint.getColor() == Color.TRANSPARENT) {
 			canvasPaint.setColor(Color.BLACK);
 			canvas.drawPath(pathToDraw, canvasPaint);
@@ -65,6 +69,7 @@ public class DrawTool extends BaseTool {
 		} else {
 			canvas.drawPath(pathToDraw, bitmapPaint);
 		}
+		canvas.restore();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
@@ -51,11 +51,11 @@ public class DrawTool extends BaseTool {
 
 	@Override
 	public void draw(Canvas canvas) {
-		changePaintColor(canvasPaint.getColor());
+		setPaintColor(canvasPaint.getColor());
 
 		if (PaintroidApplication.currentTool.getToolType() == ToolType.ERASER
 				&& canvasPaint.getColor() != Color.TRANSPARENT) {
-			changePaintColor(Color.TRANSPARENT);
+			setPaintColor(Color.TRANSPARENT);
 		}
 
 		if (canvasPaint.getColor() == Color.TRANSPARENT) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
@@ -32,6 +32,7 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 
@@ -51,6 +52,9 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 	private static final boolean ROTATION_ENABLED = true;
 	private static final boolean RESPECT_IMAGE_BOUNDS = false;
 	private static final float SHAPE_OFFSET = 10f;
+
+	private static final String BUNDLE_BASE_SHAPE = "BASE_SHAPE";
+	private static final String BUNDLE_SHAPE_DRAW_TYPE = "SHAPE_DRAW_TYPE";
 
 	private BaseShape baseShape;
 	private ShapeDrawType shapeDrawType;
@@ -160,6 +164,31 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 
 		createOverlayButton();
 		setBitmap(bitmap);
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle bundle) {
+		super.onSaveInstanceState(bundle);
+
+		bundle.putSerializable(BUNDLE_BASE_SHAPE, baseShape);
+		bundle.putSerializable(BUNDLE_SHAPE_DRAW_TYPE, shapeDrawType);
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle bundle) {
+		super.onRestoreInstanceState(bundle);
+
+		BaseShape baseShape = (BaseShape) bundle.getSerializable(BUNDLE_BASE_SHAPE);
+		ShapeDrawType shapeDrawType = (ShapeDrawType) bundle.getSerializable(BUNDLE_SHAPE_DRAW_TYPE);
+
+		if (baseShape != null && shapeDrawType != null
+				&& (this.baseShape != baseShape || this.shapeDrawType != shapeDrawType)) {
+			this.baseShape = baseShape;
+			this.shapeDrawType = shapeDrawType;
+
+			shapeToolOptionsListener.setShapeActivated(baseShape);
+			createAndSetBitmap();
+		}
 	}
 
 	private void drawShape(Canvas drawCanvas, RectF shapeRect, Paint drawPaint, int drawableId) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
@@ -73,6 +73,7 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 
 		shapeDrawType = ShapeDrawType.FILL;
 
+		createOverlayBitmap();
 		createAndSetBitmap();
 	}
 
@@ -114,7 +115,7 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 
 		Paint drawPaint = new Paint();
 		drawPaint.setColor(canvasPaint.getColor());
-		drawPaint.setAntiAlias(DEFAULT_ANTIALISING_ON);
+		drawPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
 
 		switch (shapeDrawType) {
 			case FILL:
@@ -138,10 +139,10 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 			int colorWithMaxAlpha = Color.BLACK;
 			geometricFillCommandPaint.setColor(colorWithMaxAlpha);
 			geometricFillCommandPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_OUT));
-			geometricFillCommandPaint.setAntiAlias(DEFAULT_ANTIALISING_ON);
+			geometricFillCommandPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
 
 			drawPaint.reset();
-			drawPaint.setAntiAlias(DEFAULT_ANTIALISING_ON);
+			drawPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
 			drawPaint.setShader(CHECKERED_PATTERN.getShader());
 		}
 
@@ -162,7 +163,6 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 				break;
 		}
 
-		createOverlayButton();
 		setBitmap(bitmap);
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.java
@@ -13,7 +13,7 @@ public class ImportTool extends StampTool {
 		super(context, toolType);
 		readyForPaste = true;
 		longClickAllowed = false;
-		createOverlayButton();
+		createOverlayBitmap();
 	}
 
 	@Override
@@ -28,6 +28,5 @@ public class ImportTool extends StampTool {
 
 		boxWidth = Math.max(minimumSize, Math.min(maximumBorderRatioWidth, bitmap.getWidth()));
 		boxHeight = Math.max(minimumSize, Math.min(maximumBorderRatioHeight, bitmap.getHeight()));
-		createOverlayButton();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
@@ -49,7 +49,7 @@ public class LineTool extends BaseTool {
 			return;
 		}
 
-		changePaintColor(canvasPaint.getColor());
+		setPaintColor(canvasPaint.getColor());
 
 		if (canvasPaint.getAlpha() == 0x00) {
 			canvasPaint.setColor(Color.BLACK);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
@@ -51,6 +51,10 @@ public class LineTool extends BaseTool {
 
 		setPaintColor(canvasPaint.getColor());
 
+		canvas.save();
+		canvas.clipRect(0, 0,
+				PaintroidApplication.drawingSurface.getBitmapWidth(),
+				PaintroidApplication.drawingSurface.getBitmapHeight());
 		if (canvasPaint.getAlpha() == 0x00) {
 			canvasPaint.setColor(Color.BLACK);
 			canvas.drawLine(initialEventCoordinate.x,
@@ -62,6 +66,7 @@ public class LineTool extends BaseTool {
 					initialEventCoordinate.y, currentCoordinate.x,
 					currentCoordinate.y, bitmapPaint);
 		}
+		canvas.restore();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
@@ -65,7 +65,7 @@ public class StampTool extends BaseToolWithRectangleShape {
 				Config.ARGB_8888));
 
 		createAndSetBitmapAsync = new CreateAndSetBitmapAsyncTask();
-		createOverlayButton();
+		createOverlayBitmap();
 	}
 
 	public void setBitmapFromFile(Bitmap bitmap) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
@@ -74,13 +74,14 @@ public class TextTool extends BaseToolWithRectangleShape {
 
 		paintInitialized = initializePaint();
 
+		createOverlayBitmap();
 		createAndSetBitmap();
 		resetBoxPosition();
 	}
 
 	public boolean initializePaint() {
 		textPaint = new Paint();
-		textPaint.setAntiAlias(DEFAULT_ANTIALISING_ON);
+		textPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
 
 		textPaint.setColor(canvasPaint.getColor());
 		textPaint.setTextSize(textSize * textSizeMagnificationFactor);
@@ -117,7 +118,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 			drawCanvas.drawText(multilineText[i], boxOffset, boxOffset - textAscent + textHeight * i, textPaint);
 		}
 
-		createOverlayButton();
 		setBitmap(bitmap);
 	}
 
@@ -224,7 +224,7 @@ public class TextTool extends BaseToolWithRectangleShape {
 		PointF position = new PointF(toolPosition.x, toolPosition.y);
 		textPaint.setColor(canvasPaint.getColor());
 		createAndSetBitmap();
-		toolPosition = position;
+		toolPosition.set(position);
 		boxWidth = width;
 		boxHeight = height;
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBar.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomBar.java
@@ -27,6 +27,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
+import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.view.Gravity;
@@ -62,20 +63,25 @@ public class BottomBar implements View.OnClickListener, View.OnLongClickListener
 
 	public BottomBar(MainActivity mainActivity) {
 		this.mainActivity = mainActivity;
+		toolsLayout = (LinearLayout) mainActivity.findViewById(R.id.tools_layout);
 
+		Bundle bundle = new Bundle();
 		if (PaintroidApplication.currentTool == null) {
 			currentToolType = ToolType.BRUSH;
 			PaintroidApplication.currentTool = ToolFactory.createTool(mainActivity, currentToolType);
+			PaintroidApplication.currentTool.startTool();
 		} else {
 			currentToolType = PaintroidApplication.currentTool.getToolType();
 			Paint paint = PaintroidApplication.currentTool.getDrawPaint();
+			PaintroidApplication.currentTool.leaveTool();
+			PaintroidApplication.currentTool.onSaveInstanceState(bundle);
 			PaintroidApplication.currentTool = ToolFactory.createTool(mainActivity, currentToolType);
+			PaintroidApplication.currentTool.onRestoreInstanceState(bundle);
+			PaintroidApplication.currentTool.startTool();
 			PaintroidApplication.currentTool.setDrawPaint(paint);
 		}
 
 		getToolButtonByToolType(currentToolType).setSelected(true);
-		toolsLayout = (LinearLayout) mainActivity.findViewById(R.id.tools_layout);
-
 		setBottomBarListener();
 
 		if (ENABLE_START_SCROLL_ANIMATION) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.java
@@ -149,6 +149,14 @@ public class Perspective implements Serializable {
 		return new PointF(surfaceX, surfaceY);
 	}
 
+	public synchronized void setCanvasPointToSurfacePoint(PointF point) {
+		float surfaceX = (point.x + surfaceTranslationX - surfaceCenterX)
+				* surfaceScale + surfaceCenterX;
+		float surfaceY = (point.y + surfaceTranslationY - surfaceCenterY)
+				* surfaceScale + surfaceCenterY;
+		point.set(surfaceX, surfaceY);
+	}
+
 	public synchronized void applyToCanvas(Canvas canvas) {
 		canvas.scale(surfaceScale, surfaceScale, surfaceCenterX,
 				surfaceCenterY);


### PR DESCRIPTION
#### Save instance state
* Save tool instance state in a Bundle
* Works completely for `CursorTool`, `GeometricFillTool` and `TransformTool`
* Works partially for `TextTool`, `StampTool` and `ImportTool`
#### Optimize drawing
* Avoid object creation while drawing
* Optimize `drawOverlayBitmap`
  - Load bitmap only once at startup
  - Draw bitmap directly to canvas
* Avoid calling observers at every draw call in `DrawTool`, `LineTool` and `CursorTool`
* Add a `setCanvasPointToSurfacePoint` function in Perspective to avoid object creation
#### Restrict tool drawing to actual drawing surface bounds
* Set `clipRect` to drawing surface bounds for `DrawTool`, `LineTool` and `CursorTool`