### PR TITLE
PAINT-243: Stamp image lost when switching orientation

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
@@ -19,6 +19,7 @@
 
 package org.catrobat.paintroid.test.espresso.tools;
 
+import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PointF;
@@ -33,6 +34,7 @@ import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.test.espresso.util.UiInteractions;
 import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
 import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
 import org.catrobat.paintroid.tools.implementation.StampTool;
 import org.junit.Before;
 import org.junit.Rule;
@@ -43,9 +45,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.convertFromCanvasToScreen;
@@ -63,8 +67,11 @@ import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.waitMillis
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchLongAt;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.isToast;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class StampToolIntegrationTest {
@@ -246,6 +253,33 @@ public class StampToolIntegrationTest {
 		onView(withText(R.string.stamp_tool_copy_hint))
 				.inRoot(isToast())
 				.check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testBitmapSavedOnOrientationChange() throws NoSuchFieldException, IllegalAccessException {
+		onView(withId(R.id.drawingSurfaceView))
+				.perform(click());
+
+		onToolBarView()
+				.performSelectTool(ToolType.STAMP);
+
+		Bitmap emptyBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
+				PaintroidApplication.currentTool).drawingBitmap);
+
+		clickInStampBox(tapStampLong);
+
+		Bitmap expectedBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
+				PaintroidApplication.currentTool).drawingBitmap);
+
+		assertFalse(expectedBitmap.sameAs(emptyBitmap));
+
+		launchActivityRule.getActivity()
+				.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+		Bitmap actualBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
+				PaintroidApplication.currentTool).drawingBitmap);
+
+		assertTrue(expectedBitmap.sameAs(actualBitmap));
 	}
 
 	private void invokeCreateAndSetBitmap(Object object) throws NoSuchMethodException, IllegalArgumentException, IllegalAccessException, InvocationTargetException {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
@@ -28,6 +28,7 @@ import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.Rect;
 import android.os.AsyncTask;
+import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.widget.Toast;
 
@@ -43,9 +44,11 @@ import org.catrobat.paintroid.tools.ToolType;
 
 public class StampTool extends BaseToolWithRectangleShape {
 
-	protected static final boolean ROTATION_ENABLED = true;
-	protected static final boolean RESPECT_IMAGE_BOUNDS = false;
+	private static final boolean ROTATION_ENABLED = true;
+	private static final boolean RESPECT_IMAGE_BOUNDS = false;
 	private static final long LONG_CLICK_THRESHOLD_MILLIS = 1000;
+	private static final String BUNDLE_TOOL_DRAWING_BITMAP = "BUNDLE_TOOL_DRAWING_BITMAP";
+	public static final String BUNDLE_TOOL_READY_FOR_PASTE = "BUNDLE_TOOL_READY_FOR_PASTE";
 
 	protected static CreateAndSetBitmapAsyncTask createAndSetBitmapAsync = null;
 	protected boolean readyForPaste = false;
@@ -242,6 +245,23 @@ public class StampTool extends BaseToolWithRectangleShape {
 
 	@Override
 	public void resetInternalState() {
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle bundle) {
+		super.onSaveInstanceState(bundle);
+		bundle.putParcelable(BUNDLE_TOOL_DRAWING_BITMAP, drawingBitmap);
+		bundle.putBoolean(BUNDLE_TOOL_READY_FOR_PASTE, readyForPaste);
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle bundle) {
+		super.onRestoreInstanceState(bundle);
+		readyForPaste = bundle.getBoolean(BUNDLE_TOOL_READY_FOR_PASTE, readyForPaste);
+		Bitmap bitmap = bundle.getParcelable(BUNDLE_TOOL_DRAWING_BITMAP);
+		if (bitmap != null) {
+			drawingBitmap = bitmap;
+		}
 	}
 
 	private boolean canUseOldDrawingBitmap() {


### PR DESCRIPTION
* Save/restore bitmap to/from bundle on orientation change
* Add espresso test for stamp tool