### PR TITLE
PAINT-269: Save and restore text tool settings on orientation change

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/TextToolOptionsListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/TextToolOptionsListener.java
@@ -19,6 +19,7 @@
 
 package org.catrobat.paintroid.listener;
 
+import android.app.Fragment;
 import android.content.Context;
 import android.graphics.Paint;
 import android.text.Editable;
@@ -41,32 +42,37 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-public final class TextToolOptionsListener {
-	private static final String NOT_INITIALIZED_ERROR_MESSAGE = "TextToolDialog has not been initialized. Call init() first!";
-
-	private static TextToolOptionsListener instance;
+public final class TextToolOptionsListener extends Fragment {
 	private OnTextToolOptionsChangedListener onTextToolOptionsChangedListener;
 	private Context context;
-	private EditText textEditText;
+	private final EditText textEditText;
+	private final Spinner fontSpinner;
+	private final ToggleButton underlinedToggleButton;
+	private final ToggleButton italicToggleButton;
+	private final ToggleButton boldToggleButton;
+	private final Spinner textSizeSpinner;
+	private final List<String> sizes;
+	private final List<String> fonts;
+	private final NumberFormat localeNumberFormat;
 
-	private TextToolOptionsListener(Context context, View textToolOptionsView) {
+	public TextToolOptionsListener(Context context, View textToolOptionsView) {
 		this.context = context;
-		initializeListeners(textToolOptionsView);
-	}
 
-	public static TextToolOptionsListener getInstance() {
-		if (instance == null) {
-			throw new IllegalStateException(NOT_INITIALIZED_ERROR_MESSAGE);
-		}
-		return instance;
-	}
-
-	public static void init(Context context, View textToolOptionsView) {
-		instance = new TextToolOptionsListener(context, textToolOptionsView);
-	}
-
-	private void initializeListeners(View textToolOptionsView) {
 		textEditText = (EditText) textToolOptionsView.findViewById(R.id.text_tool_dialog_input_text);
+		fontSpinner = (Spinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_font);
+		underlinedToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_underlined);
+		italicToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_italic);
+		boldToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_bold);
+		textSizeSpinner = (Spinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_text_size);
+
+		fonts = Arrays.asList(context.getResources().getStringArray(R.array.text_tool_font_array));
+		sizes = new ArrayList<>();
+		localeNumberFormat = NumberFormat.getNumberInstance(Locale.getDefault());
+
+		initializeListeners();
+	}
+
+	private void initializeListeners() {
 		textEditText.addTextChangedListener(new TextWatcher() {
 			@Override
 			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
@@ -82,8 +88,8 @@ public final class TextToolOptionsListener {
 				onTextToolOptionsChangedListener.setText(text);
 			}
 		});
-		textEditText.requestFocus();
 
+		textEditText.requestFocus();
 		textEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
 			@Override
 			public void onFocusChange(View v, boolean hasFocus) {
@@ -93,10 +99,8 @@ public final class TextToolOptionsListener {
 			}
 		});
 
-		Spinner fontSpinner = (Spinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_font);
 		FontArrayAdapter fontSpinnerAdapter = new FontArrayAdapter(context,
-				android.R.layout.simple_list_item_activated_1,
-				Arrays.asList(context.getResources().getStringArray(R.array.text_tool_font_array)));
+				android.R.layout.simple_list_item_activated_1, fonts);
 		fontSpinner.setAdapter(fontSpinnerAdapter);
 		fontSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
 			@Override
@@ -111,7 +115,6 @@ public final class TextToolOptionsListener {
 			}
 		});
 
-		ToggleButton underlinedToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_underlined);
 		underlinedToggleButton.setPaintFlags(underlinedToggleButton.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
 		underlinedToggleButton.setOnClickListener(new ToggleButton.OnClickListener() {
 			@Override
@@ -122,7 +125,6 @@ public final class TextToolOptionsListener {
 			}
 		});
 
-		ToggleButton italicToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_italic);
 		italicToggleButton.setOnClickListener(new ToggleButton.OnClickListener() {
 			@Override
 			public void onClick(View v) {
@@ -132,7 +134,6 @@ public final class TextToolOptionsListener {
 			}
 		});
 
-		ToggleButton boldToggleButton = (ToggleButton) textToolOptionsView.findViewById(R.id.text_tool_dialog_toggle_bold);
 		boldToggleButton.setOnClickListener(new ToggleButton.OnClickListener() {
 			@Override
 			public void onClick(View v) {
@@ -142,15 +143,12 @@ public final class TextToolOptionsListener {
 			}
 		});
 
-		Spinner textSizeSpinner = (Spinner) textToolOptionsView.findViewById(R.id.text_tool_dialog_spinner_text_size);
-		final List<String> textToolSizeArray = new ArrayList<>();
-		int[] valuesOfSizeArray = context.getResources().getIntArray(R.array.text_tool_size_array);
-		NumberFormat localeNumberFormat = NumberFormat.getNumberInstance(Locale.getDefault());
-		for (int value :valuesOfSizeArray) {
-			textToolSizeArray.add(localeNumberFormat.format(value));
+		int[] intSizes = context.getResources().getIntArray(R.array.text_tool_size_array);
+		for (int value : intSizes) {
+			sizes.add(localeNumberFormat.format(value));
 		}
 		ArrayAdapter<String> textSizeArrayAdapter = new ArrayAdapter<>(context,
-				android.R.layout.simple_list_item_activated_1, textToolSizeArray);
+				android.R.layout.simple_list_item_activated_1, sizes);
 		textSizeSpinner.setAdapter(textSizeArrayAdapter);
 
 		textSizeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -167,9 +165,20 @@ public final class TextToolOptionsListener {
 		});
 	}
 
+	public void setState(boolean bold, boolean italic, boolean underlined, String text, int textSize, String font) {
+		boldToggleButton.setChecked(bold);
+		italicToggleButton.setChecked(italic);
+		underlinedToggleButton.setChecked(underlined);
+		textEditText.setText(text);
+		textSizeSpinner.setSelection(sizes.indexOf(localeNumberFormat.format(textSize)));
+		fontSpinner.setSelection(fonts.indexOf(font));
+	}
+
 	public void hideKeyboard() {
 		InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-		imm.hideSoftInputFromWindow(textEditText.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+		if (imm != null) {
+			imm.hideSoftInputFromWindow(textEditText.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+		}
 	}
 
 	public void setOnTextToolOptionsChangedListener(OnTextToolOptionsChangedListener listener) {


### PR DESCRIPTION
* Refactor `TextToolOptionsListener` to a regular class (less singletons)
* Save `TextTool` state in bundle and restore on load
* Add `testStateRestoredAfterOrientationChange` espresso test