### PR TITLE
PAINT-266: Correct translations

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.java
@@ -38,8 +38,8 @@ public enum ToolType {
 	ERASER(R.string.button_eraser, R.string.help_content_eraser, false, EnumSet.of(StateChange.ALL), R.id.tools_eraser),
 	SHAPE(R.string.button_shape, R.string.help_content_shape, true, EnumSet.of(StateChange.ALL), R.id.tools_rectangle),
 	TEXT(R.string.button_text, R.string.help_content_text, true, EnumSet.of(StateChange.ALL), R.id.tools_text),
-	LAYER(R.string.layers_title, R.string.layers_title, false, EnumSet.of(StateChange.ALL), R.id.btn_top_layers),
-	COLORCHOOSER(R.string.color_chooser_title, R.string.color_chooser_title, true, EnumSet.of(StateChange.ALL), R.id.btn_top_color);
+	LAYER(R.string.layers_title, R.string.help_content_layer, false, EnumSet.of(StateChange.ALL), R.id.btn_top_layers),
+	COLORCHOOSER(R.string.color_chooser_title, R.string.help_content_color_chooser, true, EnumSet.of(StateChange.ALL), R.id.btn_top_color);
 
 	private int nameResource;
 	private int helpTextResource;

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -17,9 +17,9 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <string name="app_name" tools:keep="@string/app_name">Pocket Paint</string>
+    <string name="app_name" tools:ignore="UnusedResources">Pocket Paint</string>
     <string name="button_brush">Brush</string>
     <string name="button_cursor">Cursor</string>
     <string name="button_pipette">Pipette</string>
@@ -41,7 +41,7 @@
     <string name="terms_of_use_and_service_link_template" translatable="false">&lt;a href=\"%1$s\">%2$s&lt;/a></string>
 
     <string name="about_title">About Pocket Paint…</string>
-    <string name="about_content">Pocket Paint is a picture editor that is part of the Catrobat project.\n\nCatrobat is a visual programming language and set of creativity tools for smartphones, tablets, and mobile browsers.\n\nThe source code of Pocket Paint is mainly licensed under the %s.\nFor precise details of the license see the link below.\n\n</string>
+    <string name="about_content">Pocket Paint is a picture editor that is part of the Catrobat project.\n\nCatrobat is a visual programming language and set of creativity tools for smartphones, tablets, and mobile browsers.\n\nThe source code of Pocket Paint is mainly licensed under the <xliff:g id="license" example="GNU Affero General Public License">%s</xliff:g>.\nFor precise details of the license see the link below.\n\n</string>
     <string name="about_license_url_text">Pocket Paint Source Code License</string>
     <string name="about_catroid_url_text">About Catrobat</string>
     <string name="about_link_template" translatable="false">&lt;a href=\"%1$s\">%2$s&lt;/a></string>
@@ -75,6 +75,8 @@
     <string name="help_content_line">Draw a straight line.</string>
     <string name="help_content_text">Write text and format it. Resize the text box afterwards. Tap to insert the text on the image.</string>
     <string name="help_content_shape">Choose a shape and tap it to insert the selected shape</string>
+    <string name="help_content_layer">Create new layers or modify existing ones</string>
+    <string name="help_content_color_chooser">Select or adjust a color</string>
     <string name="closing_security_question_title">Quit</string>
     <string name="closing_security_question">Save Changes?</string>
     <string name="closing_catroid_security_question_title">Back to Pocket Code</string>
@@ -96,7 +98,7 @@
     <string name="copy">Copy saved</string>
     <string name="menu_quit">Quit</string>
     <string name="save_button_text">Save</string>
-    <string name="discard_button_text">Discard</string>gi
+    <string name="discard_button_text">Discard</string>
 
     <string name="resize_to_resize_tap_text">to resize tap</string>
     <string name="resize_nothing_to_resize">nothing to resize</string>
@@ -104,9 +106,9 @@
 
     <string name="text_tool_dialog_input_title">Your text:</string>
     <string name="text_tool_dialog_format_options">Format options:</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
+    <string name="text_tool_dialog_underline_shortcut" translatable="false">U</string>
+    <string name="text_tool_dialog_italic_shortcut" translatable="false">I</string>
+    <string name="text_tool_dialog_bold_shortcut" translatable="false">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace" translatable="false">Monospace</string>
     <string name="text_tool_dialog_font_serif" translatable="false">Serif</string>
@@ -154,8 +156,8 @@
     <string name="dialog_loading_image_failed_title">Error on loading image</string>
     <string name="dialog_loading_image_failed_text">Not a valid image file</string>
 
-    <string name="drawer_open" tools:keep="@string/drawer_open">Open navigation drawer</string>
-    <string name="drawer_close" tools:keep="@string/drawer_close">Close navigation drawer</string>
+    <string name="drawer_open" tools:ignore="UnusedResources">Open navigation drawer</string>
+    <string name="drawer_close" tools:ignore="UnusedResources">Close navigation drawer</string>
     <string name="transform_info_text">Drag edges to their new position, then tap to enlarge or crop the image area.</string>
     <string name="cursor_draw_inactive">Pan to position, then tap to start painting.</string>
     <string name="cursor_draw_active">Pan to draw, then tap again to stop painting.</string>


### PR DESCRIPTION
* Add `xliff` annotation to give translators a hint on what they can expect in a `%s`
* Add tool help content for color chooser and layers button
* Use `tools:ignore` instead of `tools:keep`
* Change underline, italic and bold button text to not be translated