### PR TITLE
PAINT-273: Remove string constants from resources

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ActivityOpenedFromPocketCodeNewImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ActivityOpenedFromPocketCodeNewImageTest.java
@@ -28,6 +28,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.NavigationDrawerMenuActivity;
 import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.test.espresso.util.ActivityHelper;
 import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
 import org.catrobat.paintroid.tools.ToolType;
@@ -49,8 +50,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.EXTRA_CATROID_PICTURE_NAME_NAME;
-import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.EXTRA_CATROID_PICTURE_PATH_NAME;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.openNavigationDrawer;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.selectTool;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
@@ -76,8 +75,8 @@ public class ActivityOpenedFromPocketCodeNewImageTest {
 	@Before
 	public void setUp() {
 		Intent extras = new Intent();
-		extras.putExtra(EXTRA_CATROID_PICTURE_PATH_NAME, "");
-		extras.putExtra(EXTRA_CATROID_PICTURE_NAME_NAME, IMAGE_NAME);
+		extras.putExtra(Constants.PAINTROID_PICTURE_PATH, "");
+		extras.putExtra(Constants.PAINTROID_PICTURE_NAME, IMAGE_NAME);
 
 		launchActivityRule.launchActivity(extras);
 
@@ -119,7 +118,7 @@ public class ActivityOpenedFromPocketCodeNewImageTest {
 
 	private File getImageFile(String filename) {
 		return new File(Environment.getExternalStorageDirectory(), File.separatorChar
-				+ activityHelper.getString(R.string.ext_storage_directory_name)
+				+ Constants.EXT_STORAGE_DIRECTORY_NAME
 				+ File.separatorChar + filename + ".png");
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ActivityOpenedFromPocketCodeTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ActivityOpenedFromPocketCodeTest.java
@@ -30,6 +30,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.NavigationDrawerMenuActivity;
 import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.test.espresso.util.ActivityHelper;
 import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
 import org.catrobat.paintroid.tools.ToolType;
@@ -54,7 +55,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.EXTRA_CATROID_PICTURE_PATH_NAME;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.openNavigationDrawer;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.selectTool;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
@@ -84,7 +84,7 @@ public class ActivityOpenedFromPocketCodeTest {
 		imageFile = createImageFile("testFile");
 
 		Intent extras = new Intent();
-		extras.putExtra(EXTRA_CATROID_PICTURE_PATH_NAME, imageFile.getAbsolutePath());
+		extras.putExtra(Constants.PAINTROID_PICTURE_PATH, imageFile.getAbsolutePath());
 		launchActivityRule.launchActivity(extras);
 
 		activityHelper = new ActivityHelper(launchActivityRule.getActivity());

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedTests.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedTests.java
@@ -32,6 +32,7 @@ import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.NavigationDrawerMenuActivity;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.test.utils.SystemAnimationsRule;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.After;
@@ -221,7 +222,7 @@ public class ToolOnBackPressedTests {
 
 		String pathToFile = launchActivityRule.getActivity().getApplicationContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES)
 				+ File.separator
-				+ launchActivityRule.getActivity().getString(R.string.temp_picture_name)
+				+ Constants.TEMP_PICTURE_NAME
 				+ FILE_ENDING;
 
 		saveFile = new File(pathToFile);
@@ -281,9 +282,9 @@ public class ToolOnBackPressedTests {
 
 		String pathToFile =
 				Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator
-						+ launchActivityRule.getActivity().getString(R.string.ext_storage_directory_name)
+						+ Constants.EXT_STORAGE_DIRECTORY_NAME
 						+ File.separator
-						+ launchActivityRule.getActivity().getString(R.string.temp_picture_name)
+						+ Constants.TEMP_PICTURE_NAME
 						+ FILE_ENDING;
 
 		saveFile = new File(pathToFile);
@@ -314,7 +315,7 @@ public class ToolOnBackPressedTests {
 
 		String pathToFile = launchActivityRule.getActivity().getApplicationContext().getExternalFilesDir(Environment.DIRECTORY_PICTURES)
 				+ File.separator
-				+ launchActivityRule.getActivity().getString(R.string.temp_picture_name)
+				+ Constants.TEMP_PICTURE_NAME
 				+ FILE_ENDING;
 
 		saveFile = new File(pathToFile);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
@@ -81,11 +81,6 @@ public final class EspressoUtils {
 	public static final Paint.Cap DEFAULT_STROKE_CAP = Paint.Cap.ROUND;
 
 	public static final int DEFAULT_STROKE_WIDTH = 25;
-
-	public static final String EXTRA_CATROID_PICTURE_PATH_NAME = "org.catrobat.extra.PAINTROID_PICTURE_PATH";
-
-	public static final String EXTRA_CATROID_PICTURE_NAME_NAME = "org.catrobat.extra.PAINTROID_PICTURE_NAME";
-
 	public static final int COLOR_CHOOSER_PRESET_BLACK_BUTTON_ID = 16;
 
 	public static final int GREEN_COLOR_PICKER_BUTTON_POSITION = 2;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -30,6 +30,8 @@ import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
+import org.catrobat.paintroid.common.Constants;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -54,7 +56,7 @@ public abstract class FileIO {
 	}
 
 	static boolean saveBitmap(Context context, Bitmap bitmap, @Nullable String path, boolean saveCopy) {
-		if (!initialisePaintroidMediaDirectory(context)) {
+		if (!initialisePaintroidMediaDirectory()) {
 			return false;
 		}
 
@@ -74,7 +76,7 @@ public abstract class FileIO {
 				outputStream = context.getContentResolver().openOutputStream(
 						NavigationDrawerMenuActivity.savedPictureUri);
 			} else {
-				file = createNewEmptyPictureFile(context);
+				file = createNewEmptyPictureFile();
 				outputStream = new FileOutputStream(file);
 			}
 		} catch (FileNotFoundException e) {
@@ -113,8 +115,8 @@ public abstract class FileIO {
 		return simpleDateFormat.format(new Date()) + ENDING;
 	}
 
-	static File createNewEmptyPictureFile(Context context, String filename) {
-		if (initialisePaintroidMediaDirectory(context)) {
+	static File createNewEmptyPictureFile(String filename) {
+		if (initialisePaintroidMediaDirectory()) {
 			if (!filename.toLowerCase(Locale.US).endsWith(ENDING.toLowerCase(Locale.US))) {
 				filename += ENDING;
 			}
@@ -124,16 +126,16 @@ public abstract class FileIO {
 		}
 	}
 
-	private static File createNewEmptyPictureFile(Context context) {
-		return createNewEmptyPictureFile(context, getDefaultFileName());
+	private static File createNewEmptyPictureFile() {
+		return createNewEmptyPictureFile(getDefaultFileName());
 	}
 
-	private static boolean initialisePaintroidMediaDirectory(Context context) {
+	private static boolean initialisePaintroidMediaDirectory() {
 		if (Environment.getExternalStorageState().equals(
 				Environment.MEDIA_MOUNTED)) {
 			paintroidMediaFile = new File(
 					Environment.getExternalStorageDirectory(), File.separatorChar
-					+ context.getString(R.string.ext_storage_directory_name) + File.separatorChar);
+					+ Constants.EXT_STORAGE_DIRECTORY_NAME + File.separatorChar);
 		} else {
 			return false;
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -56,6 +56,7 @@ import org.catrobat.paintroid.command.UndoRedoManager;
 import org.catrobat.paintroid.command.implementation.CommandManagerImplementation;
 import org.catrobat.paintroid.command.implementation.LayerCommand;
 import org.catrobat.paintroid.command.implementation.LoadCommand;
+import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.dialog.CustomAlertDialogBuilder;
 import org.catrobat.paintroid.dialog.DialogAbout;
 import org.catrobat.paintroid.dialog.DialogTermsOfUseAndService;
@@ -75,6 +76,9 @@ import org.catrobat.paintroid.ui.TopBar;
 import org.catrobat.paintroid.ui.button.LayersAdapter;
 
 import java.io.File;
+
+import static org.catrobat.paintroid.common.Constants.PAINTROID_PICTURE_PATH;
+import static org.catrobat.paintroid.common.Constants.TEMP_PICTURE_NAME;
 
 public class MainActivity extends NavigationDrawerMenuActivity implements NavigationView.OnNavigationItemSelectedListener {
 	private static final String TAG = MainActivity.class.getSimpleName();
@@ -113,7 +117,7 @@ public class MainActivity extends NavigationDrawerMenuActivity implements Naviga
 		String tempPicturePath = null;
 		Bundle extras = getIntent().getExtras();
 		if (extras != null) {
-			tempPicturePath = extras.getString(getString(R.string.extra_picture_path_catroid));
+			tempPicturePath = extras.getString(PAINTROID_PICTURE_PATH);
 			Log.d(TAG, "catroidPicturePath: " + tempPicturePath);
 		}
 		if (tempPicturePath != null) {
@@ -530,22 +534,20 @@ public class MainActivity extends NavigationDrawerMenuActivity implements Naviga
 	}
 
 	private void exitToCatroid() {
-		String pictureFileName = getString(R.string.temp_picture_name);
+		String pictureFileName = TEMP_PICTURE_NAME;
 
 		if (catroidPicturePath != null) {
 			pictureFileName = catroidPicturePath;
 		} else {
 			Bundle extras = getIntent().getExtras();
 			if (extras != null) {
-				String catroidPictureName = extras
-						.getString(getString(R.string.extra_picture_name_catroid));
+				String catroidPictureName = extras.getString(Constants.PAINTROID_PICTURE_NAME);
 				if (catroidPictureName != null
 						&& catroidPictureName.length() > 0) {
 					pictureFileName = catroidPictureName;
 				}
 			}
-			pictureFileName = FileIO.createNewEmptyPictureFile(this, pictureFileName)
-					.getAbsolutePath();
+			pictureFileName = FileIO.createNewEmptyPictureFile(pictureFileName).getAbsolutePath();
 		}
 
 		Intent resultIntent = new Intent();
@@ -554,8 +556,7 @@ public class MainActivity extends NavigationDrawerMenuActivity implements Naviga
 				LayerListener.getInstance().getBitmapOfAllLayersToSave(),
 				pictureFileName, saveCopy)) {
 			Bundle bundle = new Bundle();
-			bundle.putString(getString(R.string.extra_picture_path_catroid),
-					pictureFileName);
+			bundle.putString(Constants.PAINTROID_PICTURE_PATH, pictureFileName);
 			resultIntent.putExtras(bundle);
 			setResult(RESULT_OK, resultIntent);
 		} else {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/NavigationDrawerMenuActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/NavigationDrawerMenuActivity.java
@@ -230,7 +230,7 @@ public abstract class NavigationDrawerMenuActivity extends AppCompatActivity {
 	}
 
 	protected void takePhoto() {
-		File tempFile = FileIO.createNewEmptyPictureFile(this, FileIO.getDefaultFileName());
+		File tempFile = FileIO.createNewEmptyPictureFile(FileIO.getDefaultFileName());
 		if (tempFile != null) {
 			cameraImageUri = Uri.fromFile(tempFile);
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
@@ -1,0 +1,31 @@
+/**
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.common;
+
+public final class Constants {
+	public static final String PAINTROID_PICTURE_PATH = "org.catrobat.extra.PAINTROID_PICTURE_PATH";
+	public static final String PAINTROID_PICTURE_NAME = "org.catrobat.extra.PAINTROID_PICTURE_NAME";
+
+	public static final String EXT_STORAGE_DIRECTORY_NAME = "Pocket Paint";
+	public static final String TEMP_PICTURE_NAME = "catroidTemp";
+
+	private Constants() {
+	}
+}

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -135,14 +135,6 @@
     <string name="layer_invisible">All layers invisible</string>
     <string name="layer_merged">Layers merged</string>
 
-    <!-- Extras -->
-    <string name="ext_storage_directory_name" translatable="false">Pocket Paint</string>
-    <string name="extra_picture_path_catroid" translatable="false">org.catrobat.extra.PAINTROID_PICTURE_PATH</string>
-    <string name="extra_picture_name_catroid" translatable="false">org.catrobat.extra.PAINTROID_PICTURE_NAME</string>
-    <string name="extra_x_value" translatable="false" tools:ignore="UnusedResources">org.catrobat.extra.PAINTROID_X</string>
-    <string name="extra_y_value" translatable="false" tools:ignore="UnusedResources">org.catrobat.extra.PAINTROID_Y</string>
-    <!-- Return to Catroid -->
-    <string name="temp_picture_name" translatable="false">catroidTemp</string>
     <string name="license_url" translatable="false">http://developer.catrobat.org/licenses</string>
 
     <string name="terms_of_use_and_service_url" translatable="false">http://developer.catrobat.org/terms_of_use_and_service</string>


### PR DESCRIPTION
* Create new class `Constants` and put common string constants there
* Move string constants from `values/string.xml` to `Constants`
* Adapt functions and remove unnecessary `Context` argument
* Remove unused strings