### PR TITLE
JENKINS-101: Run build inside a docker container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,22 @@
 #!groovy
 
 pipeline {
-	agent none
+	agent {
+		docker {
+			image 'redeamer/jenkins-android-helper:latest'
+			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings -v /var/local/container_shared/analytics.settings:/analytics.settings"
+		}
+	}
 
 	environment {
-		ANDROID_SDK_ROOT = "/home/catroid/android-sdk-tools"
-		ANDROID_SDK_HOME = "/home/catroid"
+		ANDROID_SDK_ROOT = "/usr/local/android-sdk"
+		ANDROID_SDK_HOME = "/"
+		// This is important, as we want the keep our gradle cache, but we can't share it between containers
+		// the cache could only be shared if the gradle instances could comunicate with each other
+		// imho keeping the cache per executor will have the least space impact
+		GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
+		// Otherwise user.home returns ? for java applications
+		JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
 		ANDROID_EMULATOR_IMAGE = "system-images;android-24;default;x86_64"
 
 		// modulename
@@ -22,107 +33,73 @@ pipeline {
 		ANDROID_EMULATOR_HELPER_DEBUG = ""
 		// Needed for compatibiliby to current Jenkins-wide Envs
 		// Can be removed, once all builds are migrated to Pipeline
-		ANDROID_HOME = ""
-		ANDROID_SDK_LOCATION = ""
+		ANDROID_HOME = "/usr/local/android-sdk"
+		ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
 		ANDROID_NDK = ""
 	}
 
 	options {
-		timeout(time: 1, unit: 'HOURS')
+		timeout(time: 2, unit: 'HOURS')
 		timestamps()
 	}
 
 	stages {
 		stage('Setup Android SDK') {
 			steps {
-				// Install Android SDK on all possible Android SDK slaves
-				lock('update-android-sdk') {
-					script {
-						onAllAndroidSdkSlaves {
-							checkout scm
-							sh "jenkins_android_sdk_installer -g ${WORKSPACE}/${env.GRADLE_PROJECT_MODULE_NAME}/build.gradle -s '${ANDROID_EMULATOR_IMAGE}'"
-						}
-					}
+				// Install Android SDK
+				lock("update-android-sdk-on-${env.NODE_NAME}") {
+					sh "jenkins_android_sdk_installer -g '${WORKSPACE}/${env.GRADLE_PROJECT_MODULE_NAME}/build.gradle' -s '${ANDROID_EMULATOR_IMAGE}'"
 				}
 			}
 		}
 
-		stage('Run Tests') {
-			parallel {
-				stage('Static Analysis') {
-					agent {
-						label 'NoDevice'
-					}
+		stage('Static Analysis') {
+			steps {
+				sh "./gradlew pmd checkstyle lint"
+			}
 
-					steps {
-						checkout scm
-
-						sh "./gradlew pmd checkstyle lint"
-
-						pmd         canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/pmd.xml",        unHealthy: '', unstableTotalAll: '0'
-						checkstyle  canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/checkstyle.xml", unHealthy: '', unstableTotalAll: '0'
-						androidLint canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/lint*.xml",      unHealthy: '', unstableTotalAll: '0'
-					}
+			post {
+				always {
+					pmd         canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/pmd.xml",        unHealthy: '', unstableTotalAll: '0'
+					checkstyle  canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/checkstyle.xml", unHealthy: '', unstableTotalAll: '0'
+					androidLint canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/lint*.xml",      unHealthy: '', unstableTotalAll: '0'
 				}
+			}
+		}
 
-				stage('Unit and Device tests') {
-					agent {
-						label 'Emulator'
-					}
+		stage('Unit and Device tests') {
+			steps {
+				// create emulator
+				sh "jenkins_android_emulator_helper -C -P 'hw.ramSize:800' -P 'vm.heapSize:128' -i '${ANDROID_EMULATOR_IMAGE}' -s xhdpi"
+				// start emulator
+				sh "jenkins_android_emulator_helper -S -r 768x1280 -l en_US -c '-gpu swiftshader_indirect -no-boot-anim -noaudio'"
+				// wait for emulator startup
+				sh "jenkins_android_emulator_helper -W"
+				// Run Unit and device tests
+				sh "jenkins_android_cmd_wrapper -I ./gradlew adbDisableAnimationsGlobally connectedDebugAndroidTest -Pjenkins"
+				// stop emulator
+				sh "jenkins_android_emulator_helper -K"
+			}
 
-					steps {
-						checkout scm
+			post {
+				always {
+					junit '**/*TEST*.xml'
 
-						wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
-							// create emulator
-							sh """
-								jenkins_android_emulator_helper -C \
-									-P 'hw.ramSize:800' -P 'vm.heapSize:128' \
-									-i '${ANDROID_EMULATOR_IMAGE}' \
-									-s xhdpi
-							"""
-							// start emulator
-							sh "jenkins_android_emulator_helper -S -r 768x1280 -l en_US -c '-no-boot-anim -noaudio -qemu -m 800 -enable-kvm'"
-							// wait for emulator startup
-							sh "jenkins_android_emulator_helper -W"
-							// Run Unit and device tests
-							sh "jenkins_android_cmd_wrapper -I ./gradlew adbDisableAnimationsGlobally connectedDebugAndroidTest -Pjenkins"
-							// stop emulator
-							sh "jenkins_android_emulator_helper -K"
-						}
-					}
-
-					post {
-						always {
-							junit '**/*TEST*.xml'
-
-							// kill emulator
-							sh "jenkins_android_emulator_helper -K"
-						}
-					}
+					// kill emulator
+					sh "jenkins_android_emulator_helper -K"
 				}
+			}
+		}
 
-				stage('Build APK') {
-					agent {
-						label 'NoDevice'
-					}
-
-					steps {
-						checkout scm
-
-						sh "./gradlew assembleDebug"
-						stash name: "debug-apk", includes: "${env.APK_LOCATION_DEBUG}"
-						archiveArtifacts "${env.APK_LOCATION_DEBUG}"
-					}
-				}
+		stage('Build Debug-APK') {
+			steps {
+				sh "./gradlew assembleDebug"
+				stash name: "debug-apk", includes: "${env.APK_LOCATION_DEBUG}"
+				archiveArtifacts "${env.APK_LOCATION_DEBUG}"
 			}
 		}
 
 		stage('Upload to share') {
-			agent {
-				label 'NoDevice'
-			}
-
 			when {
 				branch "${env.CATROBAT_SHARE_UPLOAD_BRANCH}"
 			}


### PR DESCRIPTION
Run build inside docker container for better isolation of PR builds.
Removed the parallelism due to additional wait times, as the SDK needed to be updated on all slaves.