### PR TITLE
PAINT-291: Imported images have wrong bitmap format

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -202,7 +202,7 @@ public abstract class FileIO {
 		options.inJustDecodeBounds = false;
 		options.inSampleSize = sampleSize;
 
-		return decodeBitmapFromUri(context, bitmapUri, options);
+		return enableAlpha(decodeBitmapFromUri(context, bitmapUri, options));
 	}
 
 	public static Bitmap getBitmapFromFile(File bitmapFile, int maxWidth, int maxHeight) {
@@ -225,6 +225,14 @@ public abstract class FileIO {
 		options.inJustDecodeBounds = false;
 		options.inSampleSize = sampleSize;
 
-		return BitmapFactory.decodeFile(bitmapFile.getAbsolutePath(), options);
+		return enableAlpha(BitmapFactory.decodeFile(bitmapFile.getAbsolutePath(), options));
+	}
+
+	private static Bitmap enableAlpha(Bitmap bitmap) {
+		if (bitmap == null) {
+			return null;
+		}
+		bitmap.setHasAlpha(true);
+		return bitmap;
 	}
 }


### PR DESCRIPTION
* Fix images not loaded with enabled alpha channel
* Add a test to verify that loaded images have a transparency channel