### PR TITLE
[JENKINS-208] Move build steps to scripts, which run on Jenkins like on the local machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ local.properties
 build/
 .gradle/
 .externalNativeBuild/
+
+# Cache for build scripts
+__pycache__

--- a/buildScripts/build_helper_functions.py
+++ b/buildScripts/build_helper_functions.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import re
+import subprocess
+import datetime
+
+running_on_jenkins = True
+
+CUSTOM_PROPERTIES_FILE = 'emulator_config.ini'
+CUSTOM_PROPERTIES_IMAGE_KEY = 'system_image'
+CUSTOM_PROPERTIES_AVD_CONFIG_PREFIX = 'prop.'
+CUSTOM_PROPERTIES_SCREEN_DENSITY = 'screen.density'
+CUSTOM_PROPERTIES_SCREEN_RESOLUTION = 'screen.resolution'
+CUSTOM_PROPERTIES_SDCARD_SIZE = 'sdcard.size'
+CUSTOM_PROPERTIES_LANGUAGE = 'device.language'
+
+def check_environment():
+	## Check for the existance of the android helper
+    if not 'SCRIPT_DIR' in os.environ:
+        print("Environment-variable SCRIPT_DIR needs to be set to the directory of this script! Abort!")
+        sys.exit(2)
+
+    if not 'REPO_DIR' in os.environ:
+        print("Environment-variable REPO_DIR needs to be set to the repository root! Abort!")
+        sys.exit(2)
+
+def set_jenkins_variables_if_running_locally():
+    global running_on_jenkins
+
+    ## if no WORKSPACE is set, set to repository root directory
+    if not 'WORKSPACE' in os.environ:
+        os.environ['WORKSPACE'] = os.environ["REPO_DIR"]
+
+        print("ENV: Setting unspecified WORKSPACE to repository root [%s]!" % os.environ['WORKSPACE'])
+        running_on_jenkins = False
+
+    ## define a build number
+    if not 'BUILD_NUMBER' in os.environ:
+        os.environ['BUILD_NUMBER'] = datetime.date.today().strftime("%Y%m%d")
+
+        print("ENV: Setting unspecified BUILD_NUMBER to current date [%s]" % os.environ['BUILD_NUMBER'])
+        running_on_jenkins = False
+
+    ## do some more checks
+    if not 'JENKINS_URL' in os.environ:
+        running_on_jenkins = False
+
+    if not running_on_jenkins:
+        print("INFO: It seems that the script runs outside Jenkins!")
+
+
+def setup_android_sdk():
+    sdk_installer_cmd = get_jenkins_android_helper_executable('jenkins_android_sdk_installer') + [ '-d' ]
+
+    system_image = get_emulator_image_from_properties()
+    if system_image is not None and system_image != "":
+        sdk_installer_cmd = sdk_installer_cmd + [ '-s', system_image ]
+
+    print("Installing the SDK: " + " ".join(sdk_installer_cmd))
+    subprocess.run( sdk_installer_cmd, check=True )
+
+def check_number_of_parameters(valid_param_count=-1, valid_param_count_min=-1, valid_param_count_max=-1, usage_func=None):
+    number_of_parameters = len(sys.argv) - 1
+
+    if valid_param_count >= 0:
+        valid_param_count_min = valid_param_count
+        valid_param_count_max = valid_param_count
+
+    if (valid_param_count_min >= 0 and number_of_parameters < valid_param_count_min) or (valid_param_count_max >= 0 and number_of_parameters > valid_param_count_max):
+        if usage_func is None:
+            print("Invalid number of parameters: {}, excpected MIN: {}, MAX: {}".format(number_of_parameters, valid_param_count_min, valid_param_count_max))
+        else:
+            usage_func()
+        sys.exit(1)
+
+def get_relative_gradle_name():
+    if sys.platform == "linux" or sys.platform == "darwin":
+        return "./gradlew"
+    elif sys.platform == "win32" or sys.platform == "cygwin":
+        return "gradlew.bat"
+    else:
+        raise Exception("Unsupported platform: " + sys.platform)
+
+def __get_full_script_path_executable(name, subdir=None):
+    path = os.environ['SCRIPT_DIR']
+    if subdir is not None and subdir != "":
+        path = os.path.join(path, subdir)
+    path = os.path.join(path, name)
+
+    ## on windows, check if it has a python shebang and call with python interpreter
+    cmd = [ path ]
+    if sys.platform == "win32" or sys.platform == "cygwin":
+        try:
+            with open(path) as f:
+                firstline = f.readline()
+                if firstline.startswith("#!") and "python" in firstline:
+                    cmd = [ 'python' ] + cmd
+        except:
+            pass
+
+    return cmd
+
+def get_build_scripts_executable(name):
+    return __get_full_script_path_executable(name)
+
+def get_jenkins_android_helper_executable(name):
+    return __get_full_script_path_executable(name, subdir="jenkins-android-helper")
+
+### Properties handling
+def read_custom_emulator_properties():
+    global CUSTOM_PROPERTIES_FILE
+    global CUSTOM_PROPERTIES_IMAGE_KEY
+
+    properties_dict = {}
+
+    props_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), CUSTOM_PROPERTIES_FILE)
+    with open(props_filename) as properties:
+        for prop in properties:
+            if prop.strip().startswith('#') or "=" not in prop:
+                continue
+
+            prop_split = prop.split("=", maxsplit=1)
+            properties_dict[prop_split[0].strip()] = prop_split[1].strip()
+
+    return properties_dict
+
+def get_value_for_properties(key, default=None):
+    global CUSTOM_PROPERTIES_FILE
+    properties = read_custom_emulator_properties()
+
+    if key in properties:
+        return properties[key]
+    elif default is not None:
+        return default
+    else:
+        raise Exception('{} needs to be defined in {}'.format(key, CUSTOM_PROPERTIES_FILE))
+
+def get_emulator_image_from_properties():
+    global CUSTOM_PROPERTIES_IMAGE_KEY
+    return get_value_for_properties(CUSTOM_PROPERTIES_IMAGE_KEY)
+
+def get_screen_density_from_properties():
+    global CUSTOM_PROPERTIES_SCREEN_DENSITY
+    return get_value_for_properties(CUSTOM_PROPERTIES_SCREEN_DENSITY, '')
+
+def get_screen_resolution_from_properties():
+    global CUSTOM_PROPERTIES_SCREEN_RESOLUTION
+    return get_value_for_properties(CUSTOM_PROPERTIES_SCREEN_RESOLUTION, '')
+
+def get_sdcard_size_from_properties():
+    global CUSTOM_PROPERTIES_SDCARD_SIZE
+    return get_value_for_properties(CUSTOM_PROPERTIES_SDCARD_SIZE, '')
+
+def get_device_language_from_properties():
+    global CUSTOM_PROPERTIES_LANGUAGE
+    return get_value_for_properties(CUSTOM_PROPERTIES_LANGUAGE, '')
+
+# return list with entries in form <key:value>
+def get_avd_config_values_from_properties():
+    global CUSTOM_PROPERTIES_FILE
+    global CUSTOM_PROPERTIES_AVD_CONFIG_PREFIX
+
+    config_properties = []
+    properties = read_custom_emulator_properties()
+    for prop_key, prop_value in properties.items():
+        if prop_key.startswith(CUSTOM_PROPERTIES_AVD_CONFIG_PREFIX):
+            config_properties = config_properties + [ re.sub('^' + CUSTOM_PROPERTIES_AVD_CONFIG_PREFIX, '', prop_key) + ':' + prop_value ]
+
+    return config_properties
+
+### Emulator handling
+def create_emulator():
+    create_emulator_cmd = get_jenkins_android_helper_executable('jenkins_android_emulator_helper') + [ '-C' ]
+    avd_properties = get_avd_config_values_from_properties()
+    if len(avd_properties) > 0:
+        create_emulator_cmd = create_emulator_cmd + [ '-p' ] + avd_properties
+
+    create_emulator_cmd = create_emulator_cmd + [ '-i', get_emulator_image_from_properties() ]
+
+    density = get_screen_density_from_properties()
+    if density is not None and density != '':
+        create_emulator_cmd = create_emulator_cmd + [ '-s', density ]
+    else:
+        print('No screen density given!')
+
+    sdcard_size = get_sdcard_size_from_properties()
+    if sdcard_size is not None and sdcard_size != '':
+        create_emulator_cmd = create_emulator_cmd + [ '-z', sdcard_size ]
+
+    print("Create AVD: " + " ".join(create_emulator_cmd))
+    subprocess.run( create_emulator_cmd, check=True )
+
+def start_emulator():
+    global running_on_jenkins
+
+    start_emulator_cmd = get_jenkins_android_helper_executable('jenkins_android_emulator_helper') + [ '-S' ]
+
+    resolution = get_screen_resolution_from_properties()
+    if resolution is not None and resolution != '':
+        start_emulator_cmd = start_emulator_cmd + [ '-r', resolution ]
+    else:
+        print('No screen resolution given!')
+
+    language = get_device_language_from_properties()
+    if language is not None and language != '':
+        start_emulator_cmd = start_emulator_cmd + [ '-l', language ]
+    else:
+        print('No device language given!')
+
+    start_emulator_cmd = start_emulator_cmd + [ '-c', '-gpu swiftshader_indirect -no-boot-anim -noaudio' ]
+
+    if not running_on_jenkins:
+        start_emulator_cmd = start_emulator_cmd + [ '-w' ]
+
+    print("Starting the emulator: " + " ".join(start_emulator_cmd))
+    subprocess.run( start_emulator_cmd, check=True )
+
+def kill_emulator():
+    kill_emulator_cmd = get_jenkins_android_helper_executable('jenkins_android_emulator_helper') + ['-K' ]
+    print("Stopping the emulator: " + " ".join(kill_emulator_cmd))
+    subprocess.run( kill_emulator_cmd, check=True )
+
+def bring_emulator_in_running_state():
+    emulator_state = subprocess.run(get_jenkins_android_helper_executable('jenkins_android_emulator_helper') + [ '-W' ]).returncode
+
+    if emulator_state == 0:
+        print("Emulator already running, nothing to do")
+        return
+    elif emulator_state == 1:
+        print("Emulator is not created")
+        create_emulator()
+        start_emulator()
+    elif emulator_state == 2:
+        print("Emulator is created, but not started")
+        start_emulator()
+    elif emulator_state > 2:
+        print("Emulator partly running, kill and restart")
+        kill_emulator()
+        start_emulator()
+    else:
+        print("Unknown state %d" % emulator_state)
+
+    return subprocess.run(get_jenkins_android_helper_executable('jenkins_android_emulator_helper') + [ '-W' ]).returncode
+
+### Default calls
+check_environment()
+set_jenkins_variables_if_running_locally()

--- a/buildScripts/build_helper_run_tests_on_emulator
+++ b/buildScripts/build_helper_run_tests_on_emulator
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """ <class_or_package>
+
+This scripts runs all the tests on an emulator. The emulator is configured
+in 'emulator_config.ini'. A single class or package to test can be passed
+as single command line argument.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.
+
+Be aware that Jenkins cleans the workspace before every build, this can
+be partly replicated by './gradlew clean'.""")
+
+def detect_class_or_package(class_or_package):
+    if class_or_package is None or class_or_package == "":
+        return ""
+
+    package_candidate_dir = os.path.join(os.environ['REPO_DIR'], 'catroid', 'src', 'androidTest', 'java', class_or_package.replace('.', os.path.sep))
+    class_candidate_file = package_candidate_dir + ".java"
+
+    if os.path.isdir(package_candidate_dir):
+        return "-Pandroid.testInstrumentationRunnerArguments.package=" + class_or_package
+    elif os.path.isfile(class_candidate_file):
+        return "-Pandroid.testInstrumentationRunnerArguments.class=" + class_or_package
+    else:
+        print("The given test runner argument [{}] neither matches a package [{}] nor a class/java-file [{}], abort".format(class_or_package, package_candidate_dir, class_candidate_file))
+        sys.exit(1)
+
+build_helper_functions.check_number_of_parameters(valid_param_count_min=0, valid_param_count_max=1, usage_func=usage)
+
+## detect if package or class is given
+test_runner_arg = ""
+if len(sys.argv) > 1:
+    test_runner_arg = detect_class_or_package(sys.argv[1])
+
+build_helper_functions.bring_emulator_in_running_state()
+
+## RUN tests
+test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), 'clean', 'adbDisableAnimationsGlobally', 'connectedDebugAndroidTest', '-Pjenkins' ]
+if test_runner_arg is not None and test_runner_arg != "":
+    test_runner_cmd = test_runner_cmd + [ test_runner_arg ]
+
+print("Calling: " + " ".join(test_runner_cmd))
+return_code = subprocess.run( test_runner_cmd, cwd=os.environ['REPO_DIR'] ).returncode
+sys.exit(return_code)

--- a/buildScripts/build_helper_start_emulator
+++ b/buildScripts/build_helper_start_emulator
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+Start the emulator, if none exists, create on.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.
+
+Be aware that Jenkins cleans the workspace before every build, this can
+be partly replicated by './gradlew clean'.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+return_code = build_helper_functions.bring_emulator_in_running_state()
+
+sys.exit(return_code)

--- a/buildScripts/build_helper_stop_emulator
+++ b/buildScripts/build_helper_stop_emulator
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+Stop the emulator which was started by the helper scripts.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.
+
+Be aware that Jenkins cleans the workspace before every build, this can
+be partly replicated by './gradlew clean'.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+stop_emulator_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_emulator_helper') + [ '-K' ]
+
+print("Calling: " + " ".join(stop_emulator_cmd))
+subprocess.run( stop_emulator_cmd, cwd=os.environ['REPO_DIR'] )

--- a/buildScripts/build_step_create_debug_apk
+++ b/buildScripts/build_step_create_debug_apk
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+Build the 'Debug-APK'.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.
+
+Be aware that Jenkins cleans the workspace before every build, this can
+be partly replicated by './gradlew clean'.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+create_apk_cmd = [ build_helper_functions.get_relative_gradle_name(), 'clean', 'assembleDebug' ]
+print("Calling: " + " ".join(create_apk_cmd))
+return_code = subprocess.run( create_apk_cmd, cwd=os.environ['REPO_DIR'] ).returncode
+sys.exit(return_code)

--- a/buildScripts/build_step_install_android_sdk
+++ b/buildScripts/build_step_install_android_sdk
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+Validates and if neccessary installs the Android SDK in ANDROID_SDK_ROOT.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.
+
+Be aware that Jenkins cleans the workspace before every build, this can
+be partly replicated by './gradlew clean'.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+build_helper_functions.setup_android_sdk()

--- a/buildScripts/build_step_run_static_analysis
+++ b/buildScripts/build_step_run_static_analysis
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+Executes the Static Analyisis steps PMD/CheckStyle/Lint.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.
+
+Be aware that Jenkins cleans the workspace before every build, this can
+be partly replicated by './gradlew clean'.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+run_static_analysis_cmd = [ build_helper_functions.get_relative_gradle_name(), 'clean', 'pmd', 'checkstyle', 'lint' ]
+print("Calling: " + " ".join(run_static_analysis_cmd))
+return_code = subprocess.run( run_static_analysis_cmd, cwd=os.environ['REPO_DIR'] ).returncode
+sys.exit(return_code)

--- a/buildScripts/build_step_run_tests_on_emulator__all_tests
+++ b/buildScripts/build_step_run_tests_on_emulator__all_tests
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+This script is a simple wrapper for the build_helper_run_tests_on_emulator which
+allows to build a specific class or package, but currently all tests are run.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.
+
+Be aware that Jenkins cleans the workspace before every build, this can
+be partly replicated by './gradlew clean'.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+# Run Unit and device tests for all tests
+test_runner_cmd = build_helper_functions.get_build_scripts_executable('build_helper_run_tests_on_emulator')
+
+print("Calling: " + " ".join(test_runner_cmd))
+return_code = subprocess.run( test_runner_cmd ).returncode
+sys.exit(return_code)

--- a/buildScripts/emulator_config.ini
+++ b/buildScripts/emulator_config.ini
@@ -1,0 +1,12 @@
+# AVD creation
+system_image=system-images;android-24;default;x86_64
+## properties written to the avd config, prefix here with prop, so the script knows where to use them
+prop.hw.ramSize=800
+prop.vm.heapSize=128
+## dpi
+screen.density=xhdpi
+## sdcard
+sdcard.size=200M
+## AVD startup
+screen.resolution=768x1280
+device.language=en_US

--- a/buildScripts/jenkins-android-helper/LICENSE
+++ b/buildScripts/jenkins-android-helper/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/buildScripts/jenkins-android-helper/README
+++ b/buildScripts/jenkins-android-helper/README
@@ -1,0 +1,5 @@
+# jenkins-android-helper
+Helper scripts to be able to run the android emulator within Jenkins Pipelines.
+
+The files in this folder are retrieved from https://github.com/redeamer/jenkins-android-helper, if you
+fix a bug or add a feature, please get the change into upstream and keep this folder in sync with upstream.

--- a/buildScripts/jenkins-android-helper/android_emulator_helper_functions.py
+++ b/buildScripts/jenkins-android-helper/android_emulator_helper_functions.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+# This file is part of Jenkins-Android-Emulator Helper.
+#    Copyright (C) 2018  Michael Musenbrock
+#
+# Jenkins-Android-Helper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Jenkins-Android-Helper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Jenkins-Android-Helper.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import re
+import subprocess
+import time
+
+ANDROID_ADB_PORTS_RANGE_START = 5554
+ANDROID_ADB_PORTS_RANGE_END = 5584
+
+## return codes
+ERROR_CODE_WAIT_NO_AVD_CREATED = 1
+ERROR_CODE_WAIT_AVD_CREATED_BUT_NOT_RUNNING = 2
+ERROR_CODE_WAIT_EMULATOR_RUNNING_UNKNOWN_SERIAL = 3
+ERROR_CODE_WAIT_EMULATOR_RUNNING_STARTUP_TIMEOUT = 4
+
+def get_open_ports_for_process(pid_to_check):
+    open_ports = []
+
+    if pid_to_check <= 0:
+        return open_ports
+
+    output = ""
+    if sys.platform == "linux" or sys.platform == "darwin":
+        header = True
+        output = subprocess.run([ 'lsof', '-sTCP:LISTEN', '-i4', '-P', '-p', str(pid_to_check), '-a' ], stdout=subprocess.PIPE).stdout.decode(sys.stdout.encoding)
+        for entry in output.splitlines():
+            if header:
+                header = False
+                continue
+
+            splitted = re.sub("\s+", " ", entry.strip()).split(' ')
+            if len(splitted) >= 9:
+                open_ports = open_ports + [ splitted[8].split(':')[1] ]
+
+    elif sys.platform == "win32" or sys.platform == "cygwin":
+        output = subprocess.run([ 'netstat', '-aon' ], stdout=subprocess.PIPE).stdout.decode(sys.stdout.encoding)
+        for entry in output.splitlines():
+            splitted = re.sub("\s+", " ", entry.strip()).split(' ')
+            if len(splitted) == 5 and splitted[0] == 'TCP' and splitted[4] == str(pid_to_check) and not re.search('\[', splitted[1]):
+                open_ports = open_ports + [ splitted[1].split(':')[1] ]
+
+    return open_ports
+
+def android_emulator_get_pid_from_avd_name(avd_name):
+    if avd_name is None or avd_name == "":
+        return ""
+
+    emulator_pid = 0
+
+    if sys.platform == "linux" or sys.platform == "darwin":
+        output = subprocess.run([ 'pgrep', '-f', 'qemu.*-avd ' + avd_name + ''], stdout=subprocess.PIPE).stdout.decode(sys.stdout.encoding)
+        try:
+            emulator_pid = int(output)
+        except:
+            emulator_pid = 0
+    elif sys.platform == "win32" or sys.platform == "cygwin":
+        output = subprocess.run([ 'WMIC', 'path', 'win32_process', 'get', 'Caption,Processid,Commandline' ], stdout=subprocess.PIPE).stdout.decode(sys.stdout.encoding)
+        for entry in output.splitlines():
+            entry = entry.strip()
+            if re.search('qemu.*-avd ' + avd_name, entry):
+                entry = re.sub("^.* ", "", entry).strip()
+                try:
+                    emulator_pid = int(entry)
+                except:
+                    emulator_pid = 0
+
+    return emulator_pid
+
+def android_emulator_detect_used_adb_port_by_pid(pid_to_check):
+    for pos_port in range(ANDROID_ADB_PORTS_RANGE_START, ANDROID_ADB_PORTS_RANGE_END, 2):
+        pos_port2 = pos_port + 1
+
+        ports_used_by_pid = get_open_ports_for_process(pid_to_check)
+        if str(pos_port) in ports_used_by_pid and str(pos_port2) in ports_used_by_pid:
+            return pos_port
+
+    # not found
+    return -1
+
+def android_emulator_serial_via_port_from_used_avd_name_single_run(avd_name):
+    if avd_name is None or avd_name == "":
+        return ""
+
+    emulator_pid = android_emulator_get_pid_from_avd_name(avd_name)
+    if emulator_pid <= 0:
+        return ""
+
+    android_adb_port_even = android_emulator_detect_used_adb_port_by_pid(emulator_pid)
+
+    if android_adb_port_even >= 0:
+        return "emulator-" + str(android_adb_port_even)
+    else:
+        return ""
+
+
+def android_emulator_serial_via_port_from_used_avd_name(avd_name):
+    if avd_name is None or avd_name == "":
+        return ""
+
+    RETRIES = 10
+    for i in range(1, RETRIES):
+        emulator_serial = android_emulator_serial_via_port_from_used_avd_name_single_run(avd_name)
+        if emulator_serial is not None and emulator_serial != "":
+            return emulator_serial
+
+        time.sleep(3)
+
+    return ""

--- a/buildScripts/jenkins-android-helper/ini_helper_functions.py
+++ b/buildScripts/jenkins-android-helper/ini_helper_functions.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# This file is part of Jenkins-Android-Emulator Helper.
+#    Copyright (C) 2018  Michael Musenbrock
+#
+# Jenkins-Android-Helper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Jenkins-Android-Helper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Jenkins-Android-Helper.  If not, see <http://www.gnu.org/licenses/>.
+
+import re, os
+from pathlib import Path
+
+def ini_file_helper_check_key_for_value(ini_file_name, ini_key, ini_val_expect):
+
+    if not Path(ini_file_name).is_file():
+        return False
+
+    if ini_key is None or ini_key == "":
+        return False
+
+    with open(ini_file_name, 'r') as ini_file:
+        for ini_file_line in ini_file:
+            try:
+                ini_val = ini_file_line.split("=", maxsplit=1)[1].strip()
+                if ini_val_expect == ini_val:
+                    return True
+            except:
+                pass
+
+    return False
+
+def ini_file_helper_add_or_update_key_value(ini_file_name, ini_key_val_pair):
+
+    if not Path(ini_file_name).is_file():
+        return False
+
+    if ini_key_val_pair is None or ini_key_val_pair == "":
+        return False
+
+    ini_key_val_pair_splitted = ini_key_val_pair.split(":", maxsplit=1)
+    key_to_replace = ini_key_val_pair_splitted[0]
+    val_to_replace = ini_key_val_pair_splitted[1]
+
+    ## remove 'old' key
+    ini_out_file_name = ini_file_name + ".tmpout"
+    with open(ini_file_name, 'r') as ini_file:
+        with open(ini_out_file_name, 'w') as out_file:
+            for ini_file_line in ini_file:
+                if not re.match("^" + key_to_replace + "=", ini_file_line):
+                    out_file.write(ini_file_line)
+
+    ## append to end
+    with open(ini_out_file_name, 'a') as out_file:
+        print(key_to_replace + "=" + val_to_replace, file=out_file)
+
+    os.replace(ini_out_file_name, ini_file_name)
+
+    return True

--- a/buildScripts/jenkins-android-helper/jenkins_android_cmd_wrapper
+++ b/buildScripts/jenkins-android-helper/jenkins_android_cmd_wrapper
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# This file is part of Jenkins-Android-Emulator Helper.
+#    Copyright (C) 2018  Michael Musenbrock
+#
+# Jenkins-Android-Helper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Jenkins-Android-Helper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Jenkins-Android-Helper.  If not, see <http://www.gnu.org/licenses/>.
+
+## ANDROID_SDK_ROOT needs to be set to the Android SDK
+
+import os
+import sys
+import subprocess
+import traceback
+
+from jenkins_android_sdk import AndroidSDK
+import ini_helper_functions
+import android_emulator_helper_functions
+
+_OPWD = os.getcwd()
+
+### assume that the script runs locally
+if not 'WORKSPACE' in os.environ:
+    print("It seems that the script runs outside Jenkins. WORKSPACE will be set to PWD [" + _OPWD + "]!")
+    os.environ["WORKSPACE"] = _OPWD
+
+## Make sure the avd is installed in the current workspace
+os.environ["ANDROID_AVD_HOME"] = os.environ["WORKSPACE"]
+
+android_sdk = AndroidSDK()
+
+ignore_return_code = False
+return_code = 0
+
+def usage():
+    print("""`basename $0` [ -I ] <command>
+
+This is a simple wrapper for arbitrary command calls, which sets the proper ANDROID_SERIAL.
+If the -I option is given, the return value of the command is overwritten and the script
+exits always with 0.
+
+OPTIONS:
+  -I               Ignore the return value of the <command>, script will always return 0
+  <command>        The command with parameters to execute. Having ANDROID_SERIAL set to the emulator started with this toolset
+""")
+    sys.exit(1)
+
+run_command = sys.argv[1:]
+
+# If first parameter is '-I' ignore the return code of the executed command
+if len(run_command) > 0 and run_command[0] == "-I":
+    ignore_return_code = True
+    run_command = run_command[1:]
+
+# Print usage if no parameter is given
+if run_command is None or len(run_command) == 0:
+    usage
+    sys.exit(0)
+
+try:
+    return_code = android_sdk.run_command_with_android_serial_set(run_command, cwd=_OPWD)
+except:
+    return_code = 100
+    traceback.print_exc()
+
+if ignore_return_code and return_code != 0:
+    print("Overwriting return code [%d] with 0" % (return_code))
+    return_code = 0
+
+sys.exit(return_code)

--- a/buildScripts/jenkins-android-helper/jenkins_android_emulator_helper
+++ b/buildScripts/jenkins-android-helper/jenkins_android_emulator_helper
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+# This file is part of Jenkins-Android-Emulator Helper.
+#    Copyright (C) 2018  Michael Musenbrock
+#
+# Jenkins-Android-Helper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Jenkins-Android-Helper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Jenkins-Android-Helper.  If not, see <http://www.gnu.org/licenses/>.
+
+## ANDROID_SDK_ROOT needs to be set to the Android SDK
+
+import os
+import sys
+import re
+import argparse
+import traceback
+
+from jenkins_android_sdk import AndroidSDK
+import ini_helper_functions
+import android_emulator_helper_functions
+
+_OPWD = os.getcwd()
+
+### assume that the script runs locally
+if not 'WORKSPACE' in os.environ:
+    print("It seems that the script runs outside Jenkins. WORKSPACE will be set to PWD [" + _OPWD + "]!")
+    os.environ["WORKSPACE"] = _OPWD
+
+## Make sure the avd is installed in the current workspace
+os.environ["ANDROID_AVD_HOME"] = os.environ["WORKSPACE"]
+
+android_sdk = AndroidSDK()
+
+SCRIPT_RUN_MODE_UNKNOWN = 0
+SCRIPT_RUN_MODE_CREATE_AVD_WITH_UNIQUE_NAME = 1
+SCRIPT_RUN_MODE_START_EMULATOR = 2
+SCRIPT_RUN_MODE_WAIT_FOR_AVD_STARTUP = 3
+SCRIPT_RUN_MODE_KILL_AVD_AND_CLEANUP = 4
+
+SCRIPT_RUN_MODE = SCRIPT_RUN_MODE_UNKNOWN
+
+ANDROID_AVD_HW_PROPS_SCREEN_DENSITY_PROP_NAME = "hw.lcd.density"
+
+ANDROID_AVD_HW_PROPS_LIST = []
+
+### error codes
+ERROR_CODE_SUCCESS = 0
+ERROR_CODE_ADB_NO_FREE_PORT = 1
+ERROR_CODE_NO_ANDROID_SERIAL = 2
+ERROR_CODE_SDK_ENVVAR_NOT_SET = 3
+ERROR_CODE_SDK_ROOT_DOES_NOT_EXIST = 6
+
+def android_emulator_cfg_dpi_for_density(density):
+    if density == "ldpi":
+        return "120"
+    elif density == "mdpi":
+        return "160"
+    elif density == "tvdpi":
+        return "213"
+    elif density == "hdpi":
+        return "240"
+    elif density == "xhdpi":
+        return "320"
+    elif density == "xxhdpi":
+        return "480"
+    elif density == "xxxhdpi":
+        return "640"
+    ## is a number
+    elif re.match("^[0-9]+", density):
+        return density
+    ## not a number
+    else:
+        return ""
+
+## Prior the python port multiple -p/-P values could be given, now we only support '-p <key:val> <key:val> ...' format
+def __convert_sysargv_from_legacy_to_new_format(argv):
+    # try to keep the order, if the legacy -p/-P options where scattered, use the first position to add the 'new' values
+    # so split the list into the part before the first -p/-P, the properties itself and the rest
+    # if something with a new format -p <xxx> <xxx> comes in, the mechanism still works
+    argv_before_properties = []
+    argv_properties = []
+    argv_after_properties = []
+
+    first_found = False
+    idx = 0
+    while idx < len(argv):
+        arg = argv[idx]
+        if arg == '-P' or arg == '-p':
+             try:
+                 argv_properties = argv_properties + [ argv[idx + 1] ]
+                 idx = idx + 1
+             except IndexError:
+                 pass
+        else:
+             # not yet found
+             if len(argv_properties) == 0:
+                 argv_before_properties = argv_before_properties + [ arg ]
+             else:
+                 argv_after_properties = argv_after_properties + [ arg ]
+
+        idx = idx + 1
+
+    return argv_before_properties + [ '-p' ] + argv_properties + argv_after_properties
+
+
+sys.argv = __convert_sysargv_from_legacy_to_new_format(sys.argv)
+
+parser = argparse.ArgumentParser(description="""The environment variable ANDROID_SDK_ROOT needs to be set to the Android SDK.
+The environment variable ANDROID_AVD_HOME will be set to the current WORKSPACE.
+Additionally the WORKSPACE variable needs to be set to store the avd name to be later referenced by
+subsequent calls.
+Additionally it's curucial that the device creation/startup is not done concurrently on a node, otherwise
+there will be a race-condition on retrieving a free port the the emulator.
+
+ATTENTION: wasn't able to properly configure usage groups and exclusive groups as needed, shoud look like this:
+jenkins_android_emulator_helper -C -i <emulator image path> [ { -p <hwkey>:<hwprop> } ] [ -s <screen density> ] [ -z <sdcard size> ]
+jenkins_android_emulator_helper -S -r <screen resolution> -l <language> [-w] [-k] [ -c <additional CLI options> ]
+jenkins_android_emulator_helper -W
+jenkins_android_emulator_helper -D
+jenkins_android_emulator_helper -K
+
+""", formatter_class=argparse.RawTextHelpFormatter)
+
+parser.add_argument('-C', action='store_true', dest='mode_create', help='Create a new AVD in the WORKSPACE with a unique name')
+parser.add_argument('-S', action='store_true', dest='mode_start', help='Start the previously created android emulator. The emulator will be started in background. By default no window is shown and the user data is wiped')
+parser.add_argument('-W', action='store_true', dest='mode_wait', help='Wait for the android emulator to startup properly, if this call succeeds, you can be sure that the emulator has started up')
+parser.add_argument('-D', action='store_true', dest='mode_disableanim', help='Disable animations on the running emulator')
+parser.add_argument('-K', action='store_true', dest='mode_kill', help='Kill the android emulator, first try to send \'emu kill\' via adb, then send SIGTERM and then SIGKILL')
+parser.add_argument('-i', type=str, metavar='emulator image', dest='emulator_image', help='Emulator image to use in form of eg: system-images;android-24;default;x86_64')
+parser.add_argument('-p', type=str, metavar='hwkey:hwprop', nargs='*', dest='hwprops', help='Multiple occurances allowed, a list of key:value pairs of hardware parameters for the AVD')
+parser.add_argument('-s', type=str, metavar='screen density', dest='screen_density', help='The screen density for the emulator, either dpi or a string representation (xhdpi)')
+parser.add_argument('-r', type=str, metavar='screen resolution', dest='screen_resolution', help='The resolution to use on emulator start')
+parser.add_argument('-l', type=str, metavar='language', dest='device_lang', help='Set the properties persist.sys.language and persist.sys.country given of a locale in form of eg en_US')
+parser.add_argument('-w', action='store_true', dest='show_window', help='Display emulator window, by default it is not shown')
+parser.add_argument('-k', action='store_true', dest='keep_user_data', help='Keep the user-data, default is to wipe on every start')
+parser.add_argument('-z', type=str, metavar='sdcard size', dest='sdcard_size', help='Size of the SD-Card of the AVD')
+parser.add_argument('-c', type=str, metavar='emulator cli opts', dest='emulator_cli_opts', help='Set additional CLI parameters for the emulator call')
+args = parser.parse_args()
+
+if args.hwprops is not None:
+    for hwprop in args.hwprops:
+        ANDROID_AVD_HW_PROPS_LIST.append(hwprop)
+
+if args.screen_density is not None and args.screen_density != "":
+    android_emulator_screen_density = android_emulator_cfg_dpi_for_density(args.screen_density)
+
+    if android_emulator_screen_density is not None and android_emulator_screen_density != "":
+        ANDROID_AVD_HW_PROPS_LIST.append(ANDROID_AVD_HW_PROPS_SCREEN_DENSITY_PROP_NAME + ":" + android_emulator_screen_density)
+
+if args.device_lang is not None and args.device_lang != "":
+    try:
+        dev_lang_split = args.device_lang.strip().split("_")
+        ANDROID_DEVICE_LANG = dev_lang_split[0]
+        ANDROID_DEVICE_COUNTRY = dev_lang_split[1]
+    except:
+        print("Given device language [" + args.device_lang + "]not in form of <LANG>_<COUNTRY>")
+        ANDROID_DEVICE_LANG = ""
+        ANDROID_DEVICE_COUNTRY = ""
+
+sdcard_size = "default"
+if args.sdcard_size is not None:
+    sdcard_size = args.sdcard_size
+
+additional_emulator_cli_options = []
+if args.emulator_cli_opts is not None and args.emulator_cli_opts != "":
+    additional_emulator_cli_options = args.emulator_cli_opts.strip().split(" ")
+
+exit_code = 0
+
+try:
+    if args.mode_create:
+        exit_code = android_sdk.create_avd(args.emulator_image, sdcard_size=sdcard_size, additional_properties=ANDROID_AVD_HW_PROPS_LIST)
+    elif args.mode_start:
+        exit_code = android_sdk.emulator_start(skin=args.screen_resolution, lang=ANDROID_DEVICE_LANG, country=ANDROID_DEVICE_COUNTRY, show_window=args.show_window, keep_user_data=args.keep_user_data, additional_cli_opts=additional_emulator_cli_options)
+    elif args.mode_wait:
+        exit_code = android_sdk.emulator_wait_for_start()
+    elif args.mode_disableanim:
+        exit_code = android_sdk.emulator_disable_animations()
+    elif args.mode_kill:
+        exit_code = android_sdk.emulator_kill()
+    else:
+        parser.print_help()
+        exit_code = 1
+except:
+    exit_code = 100
+    traceback.print_exc
+
+sys.exit(exit_code)

--- a/buildScripts/jenkins-android-helper/jenkins_android_helper_commons.py
+++ b/buildScripts/jenkins-android-helper/jenkins_android_helper_commons.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+# This file is part of Jenkins-Android-Emulator Helper.
+#    Copyright (C) 2018  Michael Musenbrock
+#
+# Jenkins-Android-Helper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Jenkins-Android-Helper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Jenkins-Android-Helper.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import shutil
+import urllib.request
+import time
+import subprocess
+from hashlib import sha256
+from zipfile import ZipFile
+from pathlib import Path
+
+def remove_file_or_dir(fn):
+    p = Path(fn)
+    if p.is_dir():
+        shutil.rmtree(fn)
+    if p.is_file():
+        p.unlink()
+
+def download_file(url, dest):
+    dwnldfile = urllib.request.urlopen(url)
+    with open(dest,'wb') as output:
+        output.write(dwnldfile.read())
+
+def is_directory(fn):
+    p = Path(fn)
+    return p.is_dir()
+
+def is_file(fn):
+    p = Path(fn)
+    return p.is_file()
+
+def sha256sum(fn):
+    f = open(fn, 'rb')
+    return sha256(f.read()).hexdigest()
+
+def unzip(zipfn, dest):
+    with ZipFile(zipfn, 'r') as zf:
+        for info in zf.infolist():
+            zf.extract(info.filename, path=dest)
+            out_path = os.path.join(dest, info.filename)
+            perm = info.external_attr >> 16
+            os.chmod(out_path, perm)
+
+def find_file_in_subtree(root, fn, depth):
+    found_file = ""
+    for dirpath, dirname, filename in os.walk(root):
+        # distance between the root and the current dir, + 1 for the file itself
+        distance = len(Path(dirpath).parts) - len(Path(root).parts) + 1
+        if fn in filename and distance == depth:
+            found_file = os.path.join(dirpath, fn)
+            break
+
+    return found_file
+
+def split_string_and_get_part(string, delimiter, index, default=""):
+    part = default
+    try:
+        part = string.split(delimiter)[index]
+    except:
+        pass
+
+    return part
+
+def kill_process_by_pid_with_force_try(pid, wait_before_kill=0, time_to_force=10):
+    wait_time = 0
+    while True:
+        if not is_process_running(pid):
+            return
+
+        if wait_time == wait_before_kill:
+            kill_process_by_pid(pid)
+
+        # send kill after 15 seconds, and exit
+        if wait_time == time_to_force:
+            kill_process_by_pid(pid, force=True)
+            break
+
+        time.sleep(1)
+
+        wait_time = wait_time + 1
+
+def is_process_running(pid):
+    if os.name == "posix":
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        else:
+            return True
+    elif os.name == "nt":
+        return len(subprocess.run([ "tasklist", "/FI", "PID eq " + str(pid) ], stdout=subprocess.PIPE).stdout.decode(sys.stdout.encoding).strip().splitlines()) > 1
+    else:
+        raise Exception("Unsupported platform: " + os.name)
+
+def kill_process_by_pid(pid, force=False):
+    if not is_process_running(pid):
+        return
+
+    if os.name == "posix":
+        if force:
+            subprocess.run([ 'kill', '-9', str(pid) ])
+        else:
+            subprocess.run([ 'kill', str(pid) ])
+    elif os.name == "nt":
+        if force:
+            subprocess.run([ 'Taskkill', '/PID', str(pid), '/F' ])
+        else:
+            subprocess.run([ 'Taskkill', '/PID', str(pid) ])
+    else:
+        raise Exception("Unsupported platform: " + os.name)

--- a/buildScripts/jenkins-android-helper/jenkins_android_sdk.py
+++ b/buildScripts/jenkins-android-helper/jenkins_android_sdk.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+
+# This file is part of Jenkins-Android-Emulator Helper.
+#    Copyright (C) 2018  Michael Musenbrock
+#
+# Jenkins-Android-Helper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Jenkins-Android-Helper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Jenkins-Android-Helper.  If not, see <http://www.gnu.org/licenses/>.
+
+## ANDROID_SDK_ROOT needs to be set to the Android SDK
+
+import os
+import sys
+import tempfile
+import subprocess
+import re
+import uuid
+import time
+import shutil
+from collections import namedtuple
+
+import jenkins_android_helper_commons
+import ini_helper_functions
+import android_emulator_helper_functions
+
+ERROR_CODE_WAIT_NO_AVD_CREATED = 1
+ERROR_CODE_WAIT_AVD_CREATED_BUT_NOT_RUNNING = 2
+ERROR_CODE_WAIT_EMULATOR_RUNNING_UNKNOWN_SERIAL = 3
+ERROR_CODE_WAIT_EMULATOR_RUNNING_STARTUP_TIMEOUT = 4
+
+ERROR_CODE_SDK_TOOLS_LICENSE_DIR_DOES_NOT_EXIST_AND_CANT_CREATE = 5
+ERROR_CODE_SDK_TOOLS_ARCHIVE_CHKSUM_MISMATCH = 6
+ERROR_CODE_SDK_TOOLS_ARCHIVE_EXTRACT_ERROR = 7
+
+AndroidSDKContent = namedtuple("AndroidSDKContent", "path, executable, winending")
+
+class AndroidSDK:
+    # SDK paths
+    ## root SDK directory, avd home and workspace will be read from environment
+    __sdk_directory = ""
+    __avd_home_directory = ""
+    __workspace_directory = ""
+
+    ## all other are relative to the root and can be retrievied via __get_full_sdk_path
+    ANDROID_SDK_TOOLS_DIR = "tools"
+    ANDROID_NDK_DIR = "ndk-bundle"
+
+    ANDROID_SDK_TOOLS_BIN_SDKMANAGER = AndroidSDKContent(path=os.path.join(ANDROID_SDK_TOOLS_DIR, "bin", "sdkmanager"), executable=True, winending=".bat")
+    ANDROID_SDK_TOOLS_BIN_AVDMANAGER = AndroidSDKContent(path=os.path.join(ANDROID_SDK_TOOLS_DIR, "bin", "avdmanager"), executable=True, winending=".bat")
+    ANDROID_SDK_TOOLS_BIN_EMULATOR = AndroidSDKContent(path=os.path.join("emulator", "emulator"), executable=True, winending=".exe")
+    ANDROID_SDK_TOOLS_BIN_ADB = AndroidSDKContent(path=os.path.join("platform-tools", "adb"), executable=True, winending=".exe")
+
+    ### Info: This package shall support the platforms: linux, windows, cygwin and mac, therefore
+    ### a general check is done in the constructor, and all further system dependent calls rely
+    ### on a support for those platforms and no further checks are done
+    ### the variables PLATFORM_ID_... shall correspond to sys.platform
+
+    PLATFORM_ID_LINUX = "linux"
+    PLATFORM_ID_MAC = "darwin"
+    PLATFORM_ID_WIN = "win32"
+    PLATFORM_ID_CYGWIN = "cygwin"
+    SUPPORTED_PLATFORMS = [ PLATFORM_ID_LINUX, PLATFORM_ID_MAC, PLATFORM_ID_WIN, PLATFORM_ID_CYGWIN ]
+
+    # SDK URLs and version
+    ANDROID_SDK_TOOLS_ARCHIVE = { PLATFORM_ID_LINUX: "sdk-tools-linux-4333796.zip", PLATFORM_ID_MAC: "sdk-tools-darwin-4333796.zip", PLATFORM_ID_WIN: "sdk-tools-windows-4333796.zip", PLATFORM_ID_CYGWIN: "sdk-tools-windows-4333796.zip" }
+    ANDROID_SDK_TOOLS_ARCHIVE_SHA256_CHECKSUM = { PLATFORM_ID_LINUX: "92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9", PLATFORM_ID_MAC: "ecb29358bc0f13d7c2fa0f9290135a5b608e38434aad9bf7067d0252c160853e", PLATFORM_ID_WIN: "7e81d69c303e47a4f0e748a6352d85cd0c8fd90a5a95ae4e076b5e5f960d3c7a", PLATFORM_ID_CYGWIN: "7e81d69c303e47a4f0e748a6352d85cd0c8fd90a5a95ae4e076b5e5f960d3c7a" }
+    ANDROID_SDK_TOOLS_VERSION = "26.1.1"
+    ANDROID_SDK_BASE_URL = "https://dl.google.com/android/repository"
+
+    ANDROID_NDK_ARCHIVE = { PLATFORM_ID_LINUX: "android-ndk-r16b-linux-x86_64.zip", PLATFORM_ID_MAC: "android-ndk-r16b-darwin-x86_64.zip", PLATFORM_ID_WIN: "android-ndk-r16b-windows-x86_64.zip", PLATFORM_ID_CYGWIN: "android-ndk-r16b-windows-x86_64.zip" }
+    ANDROID_NDK_ARCHIVE_SHA256_CHECKSUM = { PLATFORM_ID_LINUX: "bcdea4f5353773b2ffa85b5a9a2ae35544ce88ec5b507301d8cf6a76b765d901", PLATFORM_ID_MAC: "9654a692ed97713e35154bfcacb0028fdc368128d636326f9644ed83eec5d88b", PLATFORM_ID_WIN: "4c6b39939b29dfd05e27c97caf588f26b611f89fe95aad1c987278bd1267b562", PLATFORM_ID_CYGWIN: "4c6b39939b29dfd05e27c97caf588f26b611f89fe95aad1c987278bd1267b562" }
+
+    ANDROID_SDK_BUILD_TOOLS_VERSION_DEFAULT = "27.0.1"
+    ANDROID_SDK_PLATFORM_VERSION_DEFAULT = "27"
+
+    ### module properties file
+    ANDROID_SDK_SRC_PROPS_FILENAME = "source.properties"
+    ANDROID_SDK_TOOLS_PROP_NAME_PKG_REV = "Pkg.Revision"
+    ANDROID_SDK_TOOLS_PROP_NAME_PKG_PATH = "Pkg.Path"
+    ANDROID_SDK_TOOLS_PROP_NAME_PKG_DESC = "Pkg.Desc"
+
+    ### tools versions and properties contents
+    ANDROID_SDK_TOOLS_PROP_VAL_PKG_REV = ANDROID_SDK_TOOLS_VERSION
+    ANDROID_SDK_TOOLS_PROP_VAL_PKG_PATH = "tools"
+    ANDROID_SDK_TOOLS_PROP_VAL_PKG_DESC = "Android SDK Tools"
+
+    ### ndk versions and properties contents
+    #### Currently catroid can only be build with Android NDK r16, manual install that version
+    ANDROID_NDK_WORKAROUND_KEEP_R16 = False
+    ANDROID_NDK_PROP_VAL_PKG_REV = "16.1.4479499"
+    ANDROID_NDK_PROP_VAL_PKG_PATH = None
+    ANDROID_NDK_PROP_VAL_PKG_DESC = "Android NDK"
+
+    ## sdk licenses
+    ANDROID_SDK_ROOT_LICENSE_DIR = "licenses"
+    ANDROID_SDK_ROOT_LICENSE_STANDARD_FILE = os.path.join(ANDROID_SDK_ROOT_LICENSE_DIR, "android-sdk-license")
+    ANDROID_SDK_ROOT_LICENSE_PREVIEW_FILE = os.path.join(ANDROID_SDK_ROOT_LICENSE_DIR, "android-sdk-preview-license")
+    ANDROID_SDK_ROOT_LICENSE_STANDARD_HASH = "d56f5187479451eabf01fb78af6dfcb131a6481e"
+    ANDROID_SDK_ROOT_LICENSE_PREVIEW_HASH = "84831b9409646a918e30573bab4c9c91346d8abd"
+
+    ## sdk modules, platform-tools are always installed
+    ANDROID_SDK_MODULE_PLATFORM_TOOLS = "platform-tools"
+    ANDROID_SDK_MODULE_NDK = "ndk-bundle"
+    ANDROID_SDK_MODULE_EMULATOR = "emulator"
+
+    ANDROID_SDK_SYSTEM_IMAGE_IDENTIFIER = "system-images"
+
+
+    __download_if_neccessary = False
+
+    # Emulator functionality
+    emulator_avd_name = ""
+
+    ANDROID_EMULATOR_DEFAULT_SDCARD_SIZE = "200M"
+
+    ANDROID_EMULATOR_SWITCH_NO_WINDOW = "-no-window"
+    ANDROID_EMULATOR_SWITCH_WIPE_DATA = "-wipe-data"
+
+    AVD_NAME_UNIQUE_STORE_FILENAME = "last_unique_avd_name.tmp"
+
+    def __init__(self):
+        self.__sdk_directory = os.getenv('ANDROID_SDK_ROOT', "")
+        if self.__sdk_directory is None or self.__sdk_directory == "":
+            raise Exception("Environment variable ANDROID_SDK_ROOT needs to be set")
+
+        android_home = os.getenv('ANDROID_HOME', "")
+        if android_home != "":
+            print("INFO: Current ANDROID_HOME [{}] will be set to given ANDROID_SDK_ROOT[{}]!".format(android_home, self.__sdk_directory))
+        os.environ['ANDROID_HOME'] = self.__sdk_directory
+
+        self.__avd_home_directory = os.getenv('ANDROID_AVD_HOME', "")
+        if self.__avd_home_directory is None or self.__avd_home_directory == "":
+            raise Exception("Environment variable ANDROID_AVD_HOME needs to be set")
+
+        self.__workspace_directory = os.getenv('WORKSPACE', "")
+        if self.__workspace_directory is None or self.__workspace_directory == "":
+            raise Exception("Environment variable WORKSPACE needs to be set")
+
+        self.emulator_read_avd_name()
+
+        if not sys.platform in self.SUPPORTED_PLATFORMS:
+            raise Exception("Unsupported platform: " + sys.platform)
+
+    def get_sdk_directory(self):
+        return self.__sdk_directory
+
+    def __is_tool_valid(self, tool):
+        full_path = self.__get_full_sdk_path(tool)
+
+        is_posix = (sys.platform == self.PLATFORM_ID_LINUX or sys.platform == self.PLATFORM_ID_MAC)
+
+        if is_posix and tool.executable:
+            return os.access(full_path, os.X_OK)
+        else:
+            return os.access(full_path, os.R_OK)
+
+
+    def __get_full_sdk_path(self, tool):
+        if isinstance(tool, str):
+            return os.path.join(self.__sdk_directory, tool)
+
+        full_path = os.path.join(self.__sdk_directory, tool.path)
+
+        if (sys.platform == self.PLATFORM_ID_WIN or sys.platform == self.PLATFORM_ID_CYGWIN) and tool.winending != "":
+            full_path = full_path + tool.winending
+
+        return full_path
+
+    def download_if_neccessary(self):
+        self.__download_if_neccessary = True
+
+    def is_module_installed(self, module_name, expected_revision, expected_pkg_path, expected_desc, verbose=False):
+        module_source_props = os.path.join(self.__get_full_sdk_path(module_name), self.ANDROID_SDK_SRC_PROPS_FILENAME)
+
+        if not jenkins_android_helper_commons.is_file(module_source_props):
+            if verbose:
+                print("[%s] is not readable" % (module_source_props))
+            return False
+
+        if expected_revision is not None and not ini_helper_functions.ini_file_helper_check_key_for_value(module_source_props, self.ANDROID_SDK_TOOLS_PROP_NAME_PKG_REV, expected_revision):
+            if verbose:
+                print("[%s] Value for key [%s] does not match expected: [%s]" % (module_source_props, self.ANDROID_SDK_TOOLS_PROP_NAME_PKG_REV, expected_revision))
+            return False
+
+        if expected_pkg_path is not None and not ini_helper_functions.ini_file_helper_check_key_for_value(module_source_props, self.ANDROID_SDK_TOOLS_PROP_NAME_PKG_PATH, expected_pkg_path):
+            if verbose:
+                print("[%s] Value for key [%s] does not match expected: [%s]" % (module_source_props, self.ANDROID_SDK_TOOLS_PROP_NAME_PKG_PATH, expected_pkg_path))
+            return False
+
+        if expected_desc is not None and not ini_helper_functions.ini_file_helper_check_key_for_value(module_source_props, self.ANDROID_SDK_TOOLS_PROP_NAME_PKG_DESC, expected_desc):
+            if verbose:
+                print("[%s] Value for key [%s] does not match expected: [%s]" % (module_source_props, self.ANDROID_SDK_TOOLS_PROP_NAME_PKG_DESC, expected_desc))
+            return False
+
+        return True
+
+    def are_sdk_tools_installed(self, verbose=False):
+        if not os.path.isdir(self.__sdk_directory):
+            if verbose:
+                print("[%s] is not a directory" % self.__sdk_directory)
+            return False
+
+        # validate current tools
+        if not self.__is_tool_valid(self.ANDROID_SDK_TOOLS_BIN_SDKMANAGER):
+            if verbose:
+                print("[%s] is not executable" % self.__get_full_sdk_path(self.ANDROID_SDK_TOOLS_BIN_SDKMANAGER))
+            return False
+
+        if not self.is_module_installed(self.ANDROID_SDK_TOOLS_DIR, self.ANDROID_SDK_TOOLS_PROP_VAL_PKG_REV, self.ANDROID_SDK_TOOLS_PROP_VAL_PKG_PATH, self.ANDROID_SDK_TOOLS_PROP_VAL_PKG_DESC, verbose=verbose):
+            if verbose:
+                print("SDK tools are not correclty (or in the correct version) installed")
+            return False
+
+        return True
+
+    def validate_or_download_sdk_tools(self):
+        if not self.are_sdk_tools_installed():
+            self.download_and_install_sdk_tools()
+
+        if not self.are_sdk_tools_installed(verbose=True):
+            raise Exception("Newly setup SDK directory [%s] does not look like a valid installation!" % self.__sdk_directory)
+
+    def download_and_install_package(self, archive_to_download, checksum_sha256, directory_inside_tools):
+        if not os.path.isdir(self.__sdk_directory):
+            try:
+                os.makedirs(self.__sdk_directory, exist_ok=True)
+            except:
+                raise Exception("Directory [%s] was not existent and could not be created!!" % self.__sdk_directory)
+
+        if not os.access(self.__sdk_directory, os.W_OK):
+            raise Exception("Directory [%s] is not writable!!" % self.__sdk_directory)
+
+        # remove dest dir, if already exists
+        jenkins_android_helper_commons.remove_file_or_dir(self.__get_full_sdk_path(directory_inside_tools))
+
+        with tempfile.TemporaryDirectory() as tmp_download_dir:
+            dest_file_name = os.path.join(tmp_download_dir, archive_to_download)
+            download_url = self.ANDROID_SDK_BASE_URL + "/" + archive_to_download
+
+            jenkins_android_helper_commons.download_file(download_url, dest_file_name)
+
+            # check archive
+            computed_checksum = jenkins_android_helper_commons.sha256sum(dest_file_name)
+            if computed_checksum != checksum_sha256:
+                sys.exit(ERROR_CODE_SDK_TOOLS_ARCHIVE_CHKSUM_MISMATCH)
+
+            try:
+                jenkins_android_helper_commons.unzip(dest_file_name, self.get_sdk_directory())
+            except ValueError:
+                sys.exit(ERROR_CODE_SDK_TOOLS_ARCHIVE_EXTRACT_ERROR)
+
+    def download_and_install_sdk_tools(self):
+        self.download_and_install_package(self.ANDROID_SDK_TOOLS_ARCHIVE[sys.platform], self.ANDROID_SDK_TOOLS_ARCHIVE_SHA256_CHECKSUM[sys.platform], self.ANDROID_SDK_TOOLS_DIR)
+
+    ### Workaround for removed archs in r17
+    def download_and_install_ndk(self):
+        self.download_and_install_package(self.ANDROID_NDK_ARCHIVE[sys.platform], self.ANDROID_NDK_ARCHIVE_SHA256_CHECKSUM[sys.platform], self.ANDROID_NDK_DIR)
+        shutil.move(self.__get_full_sdk_path('android-ndk-r16b'), self.__get_full_sdk_path(self.ANDROID_NDK_DIR))
+
+    def download_sdk_modules(self, build_tools_version="", platform_version="", ndk=False, system_image="", additional_modules=[]):
+        sdkmanager_command = [ self.__get_full_sdk_path(self.ANDROID_SDK_TOOLS_BIN_SDKMANAGER) ]
+
+        sdkmanager_command = sdkmanager_command + [ self.ANDROID_SDK_MODULE_PLATFORM_TOOLS ]
+
+        # install ndk if requested
+        if ndk:
+            if self.ANDROID_NDK_WORKAROUND_KEEP_R16:
+                if not self.is_module_installed(self.ANDROID_NDK_DIR, self.ANDROID_NDK_PROP_VAL_PKG_REV, self.ANDROID_NDK_PROP_VAL_PKG_PATH, self.ANDROID_NDK_PROP_VAL_PKG_DESC, verbose=True):
+                    print("Manually downloading NDK version %s, otherwise build failes due to missing MIPS tools" % (self.ANDROID_NDK_PROP_VAL_PKG_REV))
+                    self.download_and_install_ndk()
+            else:
+                sdkmanager_command = sdkmanager_command + [ self.ANDROID_SDK_MODULE_NDK ]
+
+        # always install the build tools, if the given version does look bogus, fallback to default
+        build_tools_version_str = self.ANDROID_SDK_BUILD_TOOLS_VERSION_DEFAULT
+        if build_tools_version is not None and build_tools_version != "":
+            if re.match("^[0-9]+\.[0-9]+\.[0-9]+$", build_tools_version):
+                build_tools_version_str = build_tools_version
+            else:
+                print("Given build-tools version [" + build_tools_version + "] does not look like a valid version number")
+                print("Fallback to default version [" + build_tools_version_str + "]")
+        sdkmanager_command = sdkmanager_command + [ "build-tools;" + build_tools_version_str ]
+
+        # always install a platform, if the given version does look bogus, fallback to default
+        platform_version_str = self.ANDROID_SDK_PLATFORM_VERSION_DEFAULT
+        if platform_version is not None and platform_version != "":
+            if re.match("^[0-9]+$", platform_version):
+                platform_version_str = platform_version
+            else:
+                print("Given platform version [" + platform_version + "] does not look like a valid version number")
+                print("Fallback to default version [" + platform_version_str + "]")
+        sdkmanager_command = sdkmanager_command + [ "platforms;android-" + platform_version_str ]
+
+        # System image in form of system-images;android-24;default;x86
+        # if a system image is set, also install the emulator package
+        if system_image is not None and system_image != "":
+            system_image_type = jenkins_android_helper_commons.split_string_and_get_part(system_image, ";", 0)
+            system_image_platform = jenkins_android_helper_commons.split_string_and_get_part(system_image, ";", 1)
+            system_image_vendor = jenkins_android_helper_commons.split_string_and_get_part(system_image, ";", 2)
+
+            if system_image_type == self.ANDROID_SDK_SYSTEM_IMAGE_IDENTIFIER:
+                sdkmanager_command = sdkmanager_command + [ self.ANDROID_SDK_MODULE_EMULATOR ]
+                sdkmanager_command = sdkmanager_command + [ system_image ]
+
+                ## between api level 15 and 24 there is an explicit add-ons package for google apis listed
+                try:
+                    system_image_api_level = int(system_image_platform.split("-")[1])
+                    if system_image_vendor == "google_apis" and system_image_api_level >= 15 and system_image_api_level <= 24:
+                        sdkmanager_command = sdkmanager_command + [ "add-ons;addon-google_apis-google-" + str(system_image_api_level) ]
+                except:
+                    pass
+
+        sdkmanager_command = sdkmanager_command + additional_modules
+
+        ## remove empty entries
+        sdkmanager_command = list(filter(None, sdkmanager_command))
+
+        print('echo y | ' + ' '.join(sdkmanager_command))
+        subprocess.run(sdkmanager_command, input=b"y\n", stdout=None, stderr=None)
+
+    def create_avd(self, android_system_image, sdcard_size="default", additional_properties=[]):
+        if android_system_image is None or android_system_image == "":
+            raise ValueError("An android emulator image needs to be set!")
+
+        self.generate_unique_avd_name()
+
+        avdmanager_command = [ self.__get_full_sdk_path(self.ANDROID_SDK_TOOLS_BIN_AVDMANAGER) ]
+
+        avdmanager_command = avdmanager_command + [ "create", "avd", "-f" ]
+
+        if sdcard_size is not None and sdcard_size != "":
+            if sdcard_size == "default":
+                avdmanager_command = avdmanager_command + [ "-c", self.ANDROID_EMULATOR_DEFAULT_SDCARD_SIZE ]
+            else:
+                avdmanager_command = avdmanager_command + [ "-c", sdcard_size ]
+
+        avdmanager_command = avdmanager_command + [ "-n", self.emulator_avd_name, "-k", android_system_image ]
+
+        ## remove empty entries
+        avdmanager_command = list(filter(None, avdmanager_command))
+
+        print('echo no | ' + ' '.join(avdmanager_command))
+        subprocess.run(avdmanager_command, input=b"no\n", stdout=None, stderr=None).check_returncode()
+
+        # write the additional properties to the avd config file
+        avd_home_directory = os.path.join(self.__avd_home_directory, self.emulator_avd_name + ".avd")
+        avd_config_file = os.path.join(avd_home_directory, "config.ini")
+
+        for keyval in additional_properties:
+            ini_helper_functions.ini_file_helper_add_or_update_key_value(avd_config_file, keyval)
+
+        return 0
+
+    def emulator_start(self, skin="", lang="", country="", show_window=False, keep_user_data=False, additional_cli_opts=[]):
+        print("Start the emulator!")
+
+        emulator_command = [ self.__get_full_sdk_path(self.ANDROID_SDK_TOOLS_BIN_EMULATOR) ]
+
+        emulator_command = emulator_command + [ "-avd", self.emulator_avd_name ]
+
+        if skin is not None and skin != "":
+            emulator_command = emulator_command + [ "-skin", skin ]
+
+        if lang is not None and lang != "":
+            emulator_command = emulator_command + [ "-prop", "persist.sys.language=" + lang ]
+
+        if country is not None and country != "":
+            emulator_command = emulator_command + [ "-prop", "persist.sys.country=" + country ]
+
+        if not show_window:
+            emulator_command = emulator_command + [ self.ANDROID_EMULATOR_SWITCH_NO_WINDOW ]
+
+        if not keep_user_data:
+            emulator_command = emulator_command + [ self.ANDROID_EMULATOR_SWITCH_WIPE_DATA ]
+
+        emulator_command = emulator_command + additional_cli_opts
+
+        ## remove empty entries
+        emulator_command = list(filter(None, emulator_command))
+
+        print(' '.join(emulator_command))
+        proc = subprocess.Popen(emulator_command)
+
+        ## check process after a few seconds
+        time.sleep(5)
+        rc = proc.poll()
+
+        # still running?
+        if rc is None:
+            rc = 0
+
+        return rc
+
+    def emulator_wait_for_start(self):
+        print("Waiting for the emulator!")
+
+        if self.emulator_avd_name is None or self.emulator_avd_name == '':
+            print("It seems that an AVD was never created! Nothing to wait for!")
+            return ERROR_CODE_WAIT_NO_AVD_CREATED
+
+        emulator_pid = android_emulator_helper_functions.android_emulator_get_pid_from_avd_name(self.emulator_avd_name)
+        if emulator_pid <= 0:
+            print("AVD with the name [" + self.emulator_avd_name + "] does not seem to run! Startup failure? Nothing to wait for!")
+            return ERROR_CODE_WAIT_AVD_CREATED_BUT_NOT_RUNNING
+
+        emulator_max_startup_time = 300
+        emulator_startup_time = 0
+
+        android_emulator_serial = android_emulator_helper_functions.android_emulator_serial_via_port_from_used_avd_name(self.emulator_avd_name)
+        if android_emulator_serial is None or android_emulator_serial == '':
+            print("Could not detect android_emulator_serial for emulator [PID: '" + str(emulator_pid) + "', AVD: '" + self.emulator_avd_name + "']! Can't properly wait!")
+            return ERROR_CODE_WAIT_EMULATOR_RUNNING_UNKNOWN_SERIAL
+
+        while True:
+            emulator_wait_command = [ self.__get_full_sdk_path(self.ANDROID_SDK_TOOLS_BIN_ADB), "-s", android_emulator_serial, "shell", "getprop", "init.svc.bootanim" ]
+
+            bootanim_output = subprocess.run(emulator_wait_command, stdout=subprocess.PIPE).stdout.decode(sys.stdout.encoding).strip()
+            if bootanim_output == "stopped":
+                return 0
+
+            time.sleep(5)
+
+            if emulator_startup_time > emulator_max_startup_time:
+                print("AVD with the name [" + self.emulator_avd_name + "] seems to run, but startup does not finish within " + emulator_max_startup_time + " seconds!")
+                break
+
+            time.sleep(1)
+            emulator_startup_time = emulator_startup_time + 1
+
+        return ERROR_CODE_WAIT_EMULATOR_RUNNING_STARTUP_TIMEOUT
+
+    def emulator_disable_animations(self):
+        print("Disable animations!")
+
+        animations_to_disable = [ 'window_animation_scale', 'transition_animation_scale', 'animator_duration_scale' ]
+
+        if self.emulator_avd_name is None or self.emulator_avd_name == '':
+            print("It seems that an AVD was never created! Nothing to do here!")
+            return 1
+
+        emulator_pid = android_emulator_helper_functions.android_emulator_get_pid_from_avd_name(self.emulator_avd_name)
+        if emulator_pid <= 0:
+            print("AVD with the name [" + self.emulator_avd_name + "] does not seem to run. Nothing to do here!")
+            return 1
+
+        android_emulator_serial = android_emulator_helper_functions.android_emulator_serial_via_port_from_used_avd_name_single_run(self.emulator_avd_name)
+        if android_emulator_serial is None or android_emulator_serial == '':
+            print("Could not detect android_emulator_serial for emulator [PID: '" + str(emulator_pid) + "', AVD: '" + self.emulator_avd_name + "']")
+            return 1
+
+        # WORKAROUND: Settings provider needs sometimes more time to start, so even after waiting for emulator, the commands could fail
+        time.sleep(5)
+
+        rc = 0
+        for animation_to_disable in animations_to_disable:
+            disable_animation_command = [ self.__get_full_sdk_path(self.ANDROID_SDK_TOOLS_BIN_ADB), '-s', android_emulator_serial, 'shell', 'settings', 'put', 'global', animation_to_disable, '0' ]
+            rc_last = subprocess.run(disable_animation_command).returncode
+
+            # save first error as rc
+            if rc == 0 and rc_last != 0:
+                rc = rc_last
+
+        return rc
+
+    def emulator_kill(self):
+        print("Stop emulator!")
+
+        if self.emulator_avd_name is None or self.emulator_avd_name == '':
+            print("It seems that an AVD was never created! Nothing to do here!")
+            return 0
+
+        emulator_pid = android_emulator_helper_functions.android_emulator_get_pid_from_avd_name(self.emulator_avd_name)
+        if emulator_pid <= 0:
+            print("AVD with the name [" + self.emulator_avd_name + "] does not seem to run. Nothing to do here!")
+            return 0
+
+        android_emulator_serial = android_emulator_helper_functions.android_emulator_serial_via_port_from_used_avd_name_single_run(self.emulator_avd_name)
+        if android_emulator_serial is None or android_emulator_serial == '':
+            print("Could not detect android_emulator_serial for emulator [PID: '" + str(emulator_pid) + "', AVD: '" + self.emulator_avd_name + "']")
+            print("  > skip sending 'emu kill' command and proceed with sending kill signals")
+        else:
+            emulator_kill_command = [ self.__get_full_sdk_path(self.ANDROID_SDK_TOOLS_BIN_ADB), '-s', android_emulator_serial, 'emu', 'kill' ]
+            subprocess.run(emulator_kill_command)
+
+        jenkins_android_helper_commons.kill_process_by_pid_with_force_try(emulator_pid, wait_before_kill=10, time_to_force=20)
+
+        return 0
+
+    def run_command_with_android_serial_set(self, command=[], cwd=None):
+        android_emulator_serial = android_emulator_helper_functions.android_emulator_serial_via_port_from_used_avd_name(self.emulator_avd_name)
+        return subprocess.run(command, cwd=cwd, env=dict(os.environ, ANDROID_SERIAL=android_emulator_serial)).returncode
+
+    def write_license_files(self):
+        license_dir = self.__get_full_sdk_path(self.ANDROID_SDK_ROOT_LICENSE_DIR)
+        try:
+            if not jenkins_android_helper_commons.is_directory(license_dir):
+                os.mkdir(license_dir)
+        except OSError:
+            print("Directory [" + license_dir + "] was not existent and could not be created!!")
+            sys.exit(ERROR_CODE_SDK_TOOLS_LICENSE_DIR_DOES_NOT_EXIST_AND_CANT_CREATE)
+
+        with open(self.__get_full_sdk_path(self.ANDROID_SDK_ROOT_LICENSE_STANDARD_FILE), 'w') as licensefile:
+            licensefile.write("\n")
+            licensefile.write(self.ANDROID_SDK_ROOT_LICENSE_STANDARD_HASH)
+
+        with open(self.__get_full_sdk_path(self.ANDROID_SDK_ROOT_LICENSE_PREVIEW_FILE), 'w') as licensefile:
+            licensefile.write("\n")
+            licensefile.write(self.ANDROID_SDK_ROOT_LICENSE_PREVIEW_HASH)
+
+    def __get_unique_avd_file_name(self):
+        return os.path.join(self.__workspace_directory, self.AVD_NAME_UNIQUE_STORE_FILENAME)
+
+    ## this shall only be called on avd creation, all other calls will reference this name
+    def generate_unique_avd_name(self):
+        with open(self.__get_unique_avd_file_name(), 'w') as avdnamestore:
+            print(uuid.uuid4().hex, file=avdnamestore)
+
+        self.emulator_read_avd_name()
+
+    def emulator_read_avd_name(self):
+        try:
+            with open(self.__get_unique_avd_file_name()) as f:
+                self.emulator_avd_name = f.readline().strip()
+        except:
+            self.emulator_avd_name = ""
+
+    def info(self):
+        print("Current SDK directory: " + self.__sdk_directory)

--- a/buildScripts/jenkins-android-helper/jenkins_android_sdk_installer
+++ b/buildScripts/jenkins-android-helper/jenkins_android_sdk_installer
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# This file is part of Jenkins-Android-Emulator Helper.
+#    Copyright (C) 2018  Michael Musenbrock
+#
+# Jenkins-Android-Helper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Jenkins-Android-Helper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Jenkins-Android-Helper.  If not, see <http://www.gnu.org/licenses/>.
+
+## ANDROID_SDK_ROOT needs to be set to the Android SDK
+
+import os
+import sys
+import shutil
+import re
+import argparse
+
+from jenkins_android_sdk import AndroidSDK
+import ini_helper_functions
+import jenkins_android_helper_commons
+
+_OPWD = os.getcwd()
+
+### assume that the script runs locally
+if not 'WORKSPACE' in os.environ:
+    print("It seems that the script runs outside Jenkins. WORKSPACE will be set to PWD [" + _OPWD + "]!")
+    os.environ["WORKSPACE"] = _OPWD
+
+## Make sure the avd is installed in the current workspace
+os.environ["ANDROID_AVD_HOME"] = os.environ["WORKSPACE"]
+
+android_sdk = AndroidSDK()
+
+GRADLE_PROPS_FILENAME_DEFAULT = "build.gradle"
+
+def get_value_from_props_line(line, key, valregex):
+    value = ""
+    try:
+        splitted_line = line.strip().split(" ", maxsplit=1)
+        splitted_key = splitted_line[0]
+        splitted_val = splitted_line[1].lstrip("'").rstrip("'")
+        if splitted_key == key:
+            if re.match(valregex, splitted_val):
+                value = splitted_val
+    except:
+        value = ""
+
+    return value
+
+#[ ( -a <platform version> -b <build tools version> ) | -g <gradle.props file> | -d ] [ -s <system-image> ]
+parser = argparse.ArgumentParser(description='The environment variable ANDROID_SDK_ROOT needs to be set.')
+parser.add_argument('-a', type=str, metavar='platform version', dest='platformvers', help='The platform version to download (only number: eg 24 for android-24)')
+parser.add_argument('-b', type=str, metavar='build tools version', dest='buildtoolsvers', help='The version of the build to to download')
+parser.add_argument('-g', type=str, metavar='gradle.props file', dest='gradleprops', help='Read the build tools and the plaform version from the gradle properties')
+parser.add_argument('-d', action='store_true', dest='gradlepropsautodetect', help='Same as -g, but tries to auto-detect ' + GRADLE_PROPS_FILENAME_DEFAULT + ' file by using finds first match for ' + GRADLE_PROPS_FILENAME_DEFAULT + ' inside a sub-module')
+parser.add_argument('-s', type=str, metavar='system-image', dest='systemimage', help='The system image to download')
+args = parser.parse_args()
+
+platform_version = args.platformvers
+build_tools_version = args.buildtoolsvers
+
+if args.gradlepropsautodetect or args.gradleprops is not None:
+    GRADLE_PROPS_FILENAME = ""
+    if args.gradleprops is not None:
+        GRADLE_PROPS_FILENAME = args.gradleprops
+    elif args.gradlepropsautodetect:
+        GRADLE_PROPS_FILENAME = jenkins_android_helper_commons.find_file_in_subtree(os.environ["WORKSPACE"], GRADLE_PROPS_FILENAME_DEFAULT, 2)
+        print("Auto-detected build.gradle file [" + GRADLE_PROPS_FILENAME + "]")
+
+    if GRADLE_PROPS_FILENAME != "" and not os.path.isabs(GRADLE_PROPS_FILENAME):
+        GRADLE_PROPS_FILENAME = os.path.join(_OPWD, GRADLE_PROPS_FILENAME)
+
+    if jenkins_android_helper_commons.is_file(GRADLE_PROPS_FILENAME):
+
+        # Parse build.props file for buildToolsVersion and compileSdkVersion
+        with open(GRADLE_PROPS_FILENAME,'r') as gradlefile:
+            for line in gradlefile:
+                if build_tools_version is None or build_tools_version == "":
+                    build_tools_version = get_value_from_props_line(line, "buildToolsVersion", "^[0-9]+\.[0-9]+\.[0-9]+$")
+
+                if platform_version is None or platform_version == "":
+                    platform_version = get_value_from_props_line(line, "compileSdkVersion", "^[0-9]+$")
+
+                if build_tools_version != "" and platform_version != "":
+                    break
+    else:
+        print("gradle.properties file [" + GRADLE_PROPS_FILENAME + "] does not exist!")
+
+    if platform_version == "":
+        print("Could not read build tools from gradle file")
+
+    if platform_version == "":
+        print("Could not read platform from gradle file")
+
+android_sdk.download_if_neccessary()
+android_sdk.info()
+android_sdk.validate_or_download_sdk_tools()
+android_sdk.write_license_files()
+android_sdk.download_sdk_modules(build_tools_version=build_tools_version, platform_version=platform_version, ndk=True, system_image=args.systemimage)

--- a/buildScripts/log_parser_rules
+++ b/buildScripts/log_parser_rules
@@ -1,0 +1,5 @@
+# This file instruments the LogParser-Plugin
+# The initial use-case is to mark builds erroneous on instrumentation failures
+
+error /(?i)Instrumentation run failed due/
+error /(?i)ddmlib.*Exception/


### PR DESCRIPTION
The developer needs to be easily able to run the same build steps on the dev machine like they are run on Jenkins. This requirement includes using the same emulator setting and the same build options like Jenkins.

Therefore the logic of the build steps from the Jenkinsfile is moved to separate script per step ( `buildScripts/build_*`-scripts). Those scripts are capable of running inside a Jenkins build and on a local developer machine. The script are intended to work on Linux/Mac/Windows.

The scripts take care of creating and starting the emulator. The AVD to use can be configured via the `buildScripts/emulator_config.ini`-file.

To avoid external dependencies the Jenkins-Android-Helper: https://github.com/redeamer/jenkins-android-helper (used to handle the SDK installation and the emulator handling) is imported to `buildScripts/jenkins-android-helper`.