### PR TITLE
Avoids gradle warnings.

### DIFF
--- a/Paintroid/gradle/code_quality_tasks.gradle
+++ b/Paintroid/gradle/code_quality_tasks.gradle
@@ -31,7 +31,7 @@ task checkstyle(type: Checkstyle) {
 
     reports {
         xml.enabled = true
-        xml.destination "build/reports/checkstyle.xml"
+        xml.destination file("build/reports/checkstyle.xml")
     }
 }
 
@@ -47,6 +47,6 @@ task pmd(type: Pmd) {
     reports {
         xml.enabled = true
         html.enabled = true
-        xml.destination "build/reports/pmd.xml"
+        xml.destination file("build/reports/pmd.xml")
     }
 }


### PR DESCRIPTION
With gradle 5.0 the setDestination function will only accept File.
The overload/version taking Object is deprecated.