### PR TITLE
PAINT-302: Refactor drawingsurfacelistener

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
@@ -76,7 +76,7 @@ public class LayerIntegrationTest {
 		dialogWait = new DialogHiddenIdlingResource(IndeterminateProgressDialog.getInstance());
 		IdlingRegistry.getInstance().register(dialogWait);
 
-		Bitmap image = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap image = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		bitmapHeight = image.getHeight();
 		bitmapWidth = image.getWidth();
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
@@ -217,7 +217,7 @@ public class MenuFileActivityIntegrationTest {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
-		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		onNavigationDrawer()
@@ -226,7 +226,7 @@ public class MenuFileActivityIntegrationTest {
 		intended(hasComponent(hasClassName(MultilingualActivity.class.getName())));
 		onView(withText(R.string.device_language)).perform(click());
 
-		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 
@@ -235,7 +235,7 @@ public class MenuFileActivityIntegrationTest {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
-		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		onNavigationDrawer()
@@ -244,7 +244,7 @@ public class MenuFileActivityIntegrationTest {
 		intended(hasComponent(hasClassName(MultilingualActivity.class.getName())));
 		pressBack();
 
-		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 
@@ -261,7 +261,7 @@ public class MenuFileActivityIntegrationTest {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
-		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		onNavigationDrawer()
@@ -270,7 +270,7 @@ public class MenuFileActivityIntegrationTest {
 		intended(hasComponent(hasClassName(WelcomeActivity.class.getName())));
 		onView(withText(R.string.skip)).perform(click());
 
-		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 
@@ -279,7 +279,7 @@ public class MenuFileActivityIntegrationTest {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
-		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageBefore = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		imageBefore = imageBefore.copy(imageBefore.getConfig(), imageBefore.isMutable());
 
 		onNavigationDrawer()
@@ -288,7 +288,7 @@ public class MenuFileActivityIntegrationTest {
 		intended(hasComponent(hasClassName(WelcomeActivity.class.getName())));
 		pressBack();
 
-		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getImage();
+		Bitmap imageAfter = LayerListener.getInstance().getCurrentLayer().getBitmap();
 		assertTrue("Image should not have changed", imageBefore.sameAs(imageAfter));
 	}
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/DrawingSurfaceInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/DrawingSurfaceInteraction.java
@@ -83,7 +83,7 @@ public final class DrawingSurfaceInteraction extends CustomViewInteraction {
 	public DrawingSurfaceInteraction checkThatLayerDimensions(Matcher<Integer> matchesWidth, Matcher<Integer> matchesHeight) {
 		ArrayList<Layer> layers = LayerListener.getInstance().getAdapter().getLayers();
 		for (Layer layer : layers) {
-			Bitmap bitmap = layer.getImage();
+			Bitmap bitmap = layer.getBitmap();
 			assertThat(bitmap.getWidth(), matchesWidth);
 			assertThat(bitmap.getHeight(), matchesHeight);
 		}
@@ -98,7 +98,7 @@ public final class DrawingSurfaceInteraction extends CustomViewInteraction {
 	private void assertLayerDimensions(int expectedWidth, int expectedHeight) {
 		ArrayList<Layer> layers = LayerListener.getInstance().getAdapter().getLayers();
 		for (Layer layer : layers) {
-			assertBitmapDimensions(layer.getImage(), expectedWidth, expectedHeight);
+			assertBitmapDimensions(layer.getBitmap(), expectedWidth, expectedHeight);
 		}
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/ResizeCommandTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/ResizeCommandTest.java
@@ -78,7 +78,7 @@ public class ResizeCommandTest extends CommandTestSetup {
 
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
 
-		Bitmap croppedBitmap = layerUnderTest.getImage();
+		Bitmap croppedBitmap = layerUnderTest.getBitmap();
 		assertEquals("Cropping failed, width not correct ", widthOriginal - resizeCoordinateXLeft
 				- (widthOriginal - (resizeCoordinateXRight + 1)), croppedBitmap.getWidth());
 		assertEquals("Cropping failed, height not correct ", heightOriginal - resizeCoordinateYTop
@@ -99,7 +99,7 @@ public class ResizeCommandTest extends CommandTestSetup {
 
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
 
-		Bitmap enlargedBitmap = layerUnderTest.getImage();
+		Bitmap enlargedBitmap = layerUnderTest.getBitmap();
 		assertEquals("Enlarging failed, width not correct ", widthOriginal - resizeCoordinateXLeft
 				- (widthOriginal - (resizeCoordinateXRight + 1)), enlargedBitmap.getWidth());
 		assertEquals("Enlarging failed, height not correct ", heightOriginal - resizeCoordinateYTop
@@ -120,7 +120,7 @@ public class ResizeCommandTest extends CommandTestSetup {
 
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
 
-		Bitmap enlargedBitmap = layerUnderTest.getImage();
+		Bitmap enlargedBitmap = layerUnderTest.getBitmap();
 		assertEquals("Enlarging failed, width not correct ", widthOriginal, enlargedBitmap.getWidth());
 		assertEquals("Enlarging failed, height not correct ", heightOriginal, enlargedBitmap.getHeight());
 		enlargedBitmap.recycle();
@@ -134,43 +134,43 @@ public class ResizeCommandTest extends CommandTestSetup {
 
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
 
-		assertEquals("Width should not have changed", widthOriginal, layerUnderTest.getImage().getWidth());
-		assertEquals("Height should not have changed", heightOriginal, layerUnderTest.getImage().getHeight());
+		assertEquals("Width should not have changed", widthOriginal, layerUnderTest.getBitmap().getWidth());
+		assertEquals("Height should not have changed", heightOriginal, layerUnderTest.getBitmap().getHeight());
 	}
 
 	@Test
 	public void testIfBitmapIsNotResizedWithInvalidBounds() {
-		Bitmap originalBitmap = layerUnderTest.getImage();
+		Bitmap originalBitmap = layerUnderTest.getBitmap();
 		commandUnderTest = new ResizeCommand(bitmapUnderTest.getWidth(), 0, bitmapUnderTest.getWidth(),
 				0, maximumBitmapResolution);
 
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
-		assertTrue("bitmap must not change if X left is larger than bitmap scope", originalBitmap.sameAs(layerUnderTest.getImage()));
+		assertTrue("bitmap must not change if X left is larger than bitmap scope", originalBitmap.sameAs(layerUnderTest.getBitmap()));
 
 		commandUnderTest = new ResizeCommand(-1, 0, -1, 0, maximumBitmapResolution);
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
-		assertTrue("bitmap must not change if X right is smaller than bitmap scope", originalBitmap.sameAs(layerUnderTest.getImage()));
+		assertTrue("bitmap must not change if X right is smaller than bitmap scope", originalBitmap.sameAs(layerUnderTest.getBitmap()));
 
 		commandUnderTest = new ResizeCommand(0, bitmapUnderTest.getHeight(), 0,
 				bitmapUnderTest.getHeight(), maximumBitmapResolution);
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
-		assertTrue("bitmap must not change if Y top is larger than bitmap scope", originalBitmap.sameAs(layerUnderTest.getImage()));
+		assertTrue("bitmap must not change if Y top is larger than bitmap scope", originalBitmap.sameAs(layerUnderTest.getBitmap()));
 
 		commandUnderTest = new ResizeCommand(0, -1, 0, -1, maximumBitmapResolution);
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
-		assertTrue("bitmap must not change if Y bottom is smaller than bitmap scope", originalBitmap.sameAs(layerUnderTest.getImage()));
+		assertTrue("bitmap must not change if Y bottom is smaller than bitmap scope", originalBitmap.sameAs(layerUnderTest.getBitmap()));
 
 		commandUnderTest = new ResizeCommand(1, 0, 0, 0, maximumBitmapResolution);
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
-		assertTrue("bitmap must not change with widthXRight < widthXLeft bound", originalBitmap.sameAs(layerUnderTest.getImage()));
+		assertTrue("bitmap must not change with widthXRight < widthXLeft bound", originalBitmap.sameAs(layerUnderTest.getBitmap()));
 
 		commandUnderTest = new ResizeCommand(0, 1, 0, 0, maximumBitmapResolution);
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
-		assertTrue("bitmap must not change with widthYBottom < widthYTop bound", originalBitmap.sameAs(layerUnderTest.getImage()));
+		assertTrue("bitmap must not change with widthYBottom < widthYTop bound", originalBitmap.sameAs(layerUnderTest.getBitmap()));
 
 		commandUnderTest = new ResizeCommand(0, 0, bitmapUnderTest.getWidth() - 1,
 				bitmapUnderTest.getHeight() - 1, maximumBitmapResolution);
 		commandUnderTest.run(canvasUnderTest, layerUnderTest);
-		assertTrue("bitmap must not change because bounds are the same as original bitmap", originalBitmap.sameAs(layerUnderTest.getImage()));
+		assertTrue("bitmap must not change because bounds are the same as original bitmap", originalBitmap.sameAs(layerUnderTest.getBitmap()));
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
@@ -61,12 +61,12 @@ public class PipetteToolTest {
 		LayerListener layerListener = LayerListener.getInstance();
 		LayersAdapter layersAdapter = layerListener.getAdapter();
 		Layer layer = layersAdapter.getLayer(0);
-		Bitmap bitmap = layer.getImage();
+		Bitmap bitmap = layer.getBitmap();
 		bitmap.setPixel(X_COORDINATE_RED, 0, Color.RED);
 		bitmap.setPixel(X_COORDINATE_GREEN, 0, Color.GREEN);
 		bitmap.setPixel(X_COORDINATE_BLUE, 0, Color.BLUE);
 		bitmap.setPixel(X_COORDINATE_PART_TRANSPARENT, 0, 0xAAAAAAAA);
-		layer.setImage(bitmap);
+		layer.setBitmap(bitmap);
 
 		toolToTest.updateSurfaceBitmap();
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/ui/LayerTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/ui/LayerTest.java
@@ -68,37 +68,37 @@ public class LayerTest {
 	@Test
 	public void testMergeLayers() {
 		int idFirstLayer = LayerListener.getInstance().getCurrentLayer().getLayerID();
-		LayerListener.getInstance().getCurrentLayer().getImage().setPixel(1, 1, Color.BLACK);
-		LayerListener.getInstance().getCurrentLayer().getImage().setPixel(1, 2, Color.BLACK);
+		LayerListener.getInstance().getCurrentLayer().getBitmap().setPixel(1, 1, Color.BLACK);
+		LayerListener.getInstance().getCurrentLayer().getBitmap().setPixel(1, 2, Color.BLACK);
 		LayerListener.getInstance().createLayer();
 		int idSecondLayer = LayerListener.getInstance().getCurrentLayer().getLayerID();
 		assertNotEquals("New Layer should be selected", idFirstLayer, idSecondLayer);
 
-		LayerListener.getInstance().getCurrentLayer().getImage().setPixel(1, 1, Color.BLUE);
-		LayerListener.getInstance().getCurrentLayer().getImage().setPixel(2, 1, Color.BLUE);
+		LayerListener.getInstance().getCurrentLayer().getBitmap().setPixel(1, 1, Color.BLUE);
+		LayerListener.getInstance().getCurrentLayer().getBitmap().setPixel(2, 1, Color.BLUE);
 		LayerListener.getInstance().mergeLayer(0, 1);
 		int numLayersAfterMerge = LayerListener.getInstance().getAdapter().getCount();
 
 		assertEquals("Only one Layer should exist", 1, numLayersAfterMerge);
-		assertEquals("Color should be black", Color.BLACK, LayerListener.getInstance().getCurrentLayer().getImage().getPixel(1, 2));
-		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getImage().getPixel(2, 1));
-		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getImage().getPixel(1, 1));
+		assertEquals("Color should be black", Color.BLACK, LayerListener.getInstance().getCurrentLayer().getBitmap().getPixel(1, 2));
+		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getBitmap().getPixel(2, 1));
+		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getBitmap().getPixel(1, 1));
 
 		UndoRedoManager.getInstance().performUndo();
 		int numLayersAfterUndo = LayerListener.getInstance().getAdapter().getCount();
 
 		assertEquals("Two Layers should exist", 2, numLayersAfterUndo);
-		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getAdapter().getLayer(0).getImage().getPixel(2, 1));
-		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getAdapter().getLayer(0).getImage().getPixel(1, 1));
-		assertEquals("Color should be black", Color.BLACK, LayerListener.getInstance().getAdapter().getLayer(1).getImage().getPixel(1, 2));
-		assertEquals("Color should be blue", Color.BLACK, LayerListener.getInstance().getAdapter().getLayer(1).getImage().getPixel(1, 1));
+		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getAdapter().getLayer(0).getBitmap().getPixel(2, 1));
+		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getAdapter().getLayer(0).getBitmap().getPixel(1, 1));
+		assertEquals("Color should be black", Color.BLACK, LayerListener.getInstance().getAdapter().getLayer(1).getBitmap().getPixel(1, 2));
+		assertEquals("Color should be blue", Color.BLACK, LayerListener.getInstance().getAdapter().getLayer(1).getBitmap().getPixel(1, 1));
 
 		UndoRedoManager.getInstance().performRedo();
 		int numLayersAfterRedo = LayerListener.getInstance().getAdapter().getCount();
 
 		assertEquals("Only one Layer should exist", 1, numLayersAfterRedo);
-		assertEquals("Color should be black", Color.BLACK, LayerListener.getInstance().getCurrentLayer().getImage().getPixel(1, 2));
-		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getImage().getPixel(2, 1));
-		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getImage().getPixel(1, 1));
+		assertEquals("Color should be black", Color.BLACK, LayerListener.getInstance().getCurrentLayer().getBitmap().getPixel(1, 2));
+		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getBitmap().getPixel(2, 1));
+		assertEquals("Color should be blue", Color.BLUE, LayerListener.getInstance().getCurrentLayer().getBitmap().getPixel(1, 1));
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -201,7 +201,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 		} else {
 			setLayoutDirection();
 
-			drawingSurface.resetBitmap(LayerListener.getInstance().getCurrentLayer().getImage());
+			drawingSurface.resetBitmap(LayerListener.getInstance().getCurrentLayer().getBitmap());
 			PaintroidApplication.perspective.resetScaleAndTranslation();
 			PaintroidApplication.currentTool.resetInternalState(Tool.StateChange.NEW_IMAGE_LOADED);
 
@@ -745,7 +745,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 				isSaved = false;
 				savedPictureUri = null;
 				cameraImageUri = null;
-				currentLayer.setImage(PaintroidApplication.drawingSurface.getBitmapCopy());
+				currentLayer.setBitmap(PaintroidApplication.drawingSurface.getBitmapCopy());
 				layerListener.refreshView();
 				break;
 			case LOAD_IMAGE_IMPORTPNG:
@@ -763,7 +763,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 				isSaved = false;
 				savedPictureUri = uri;
 				cameraImageUri = null;
-				currentLayer.setImage(PaintroidApplication.drawingSurface.getBitmapCopy());
+				currentLayer.setBitmap(PaintroidApplication.drawingSurface.getBitmapCopy());
 				layerListener.refreshView();
 				break;
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/UndoRedoManager.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/UndoRedoManager.java
@@ -73,10 +73,10 @@ public final class UndoRedoManager {
 				}
 			}
 
-			int undoWidth = undoLayer.getImage().getWidth();
-			int undoHeight = undoLayer.getImage().getHeight();
-			int currentWidth = layer.getImage().getWidth();
-			int currentHeight = layer.getImage().getHeight();
+			int undoWidth = undoLayer.getBitmap().getWidth();
+			int undoHeight = undoLayer.getBitmap().getHeight();
+			int currentWidth = layer.getBitmap().getWidth();
+			int currentHeight = layer.getBitmap().getHeight();
 
 			Command resizeCommand = new ResizeCommand(
 					-undoCommand.getResizeCoordinateXLeft(),

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.java
@@ -48,7 +48,7 @@ public class FillCommand extends BaseCommand {
 
 	@Override
 	public void run(Canvas canvas, Layer layer) {
-		Bitmap bitmap = layer.getImage();
+		Bitmap bitmap = layer.getBitmap();
 
 		notifyStatus(NotifyStates.COMMAND_STARTED);
 		if (clickedPixel == null) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FlipCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FlipCommand.java
@@ -39,7 +39,7 @@ public class FlipCommand extends BaseCommand {
 
 	@Override
 	public void run(Canvas canvas, Layer layer) {
-		Bitmap bitmap = layer.getImage();
+		Bitmap bitmap = layer.getBitmap();
 
 		notifyStatus(NotifyStates.COMMAND_STARTED);
 		if (flipDirection == null) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LayerBitmapCommandImpl.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LayerBitmapCommandImpl.java
@@ -166,7 +166,7 @@ public class LayerBitmapCommandImpl implements LayerBitmapCommand {
 			bitmap = Bitmap.createBitmap(dm.widthPixels, dm.heightPixels, Bitmap.Config.ARGB_8888);
 		}
 		bitmap.eraseColor(Color.TRANSPARENT);
-		layer.setImage(bitmap);
+		layer.setBitmap(bitmap);
 		PaintroidApplication.drawingSurface.resetBitmap(bitmap);
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ResizeCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ResizeCommand.java
@@ -49,7 +49,7 @@ public class ResizeCommand extends BaseCommand {
 		notifyStatus(NotifyStates.COMMAND_STARTED);
 
 		try {
-			Bitmap bitmap = layer.getImage();
+			Bitmap bitmap = layer.getBitmap();
 
 			if (resizeCoordinateXRight < resizeCoordinateXLeft) {
 				Log.e(TAG, "coordinate X right must be larger than coordinate X left");
@@ -109,7 +109,7 @@ public class ResizeCommand extends BaseCommand {
 			bitmap.getPixels(pixelsToCopy, 0, copyFromWidth, copyFromXLeft, copyFromYTop, copyFromWidth, copyFromHeight);
 			resizedBitmap.setPixels(pixelsToCopy, 0, copyToWidth, copyToXLeft, copyToYTop, copyToWidth, copyToHeight);
 
-			layer.setImage(resizedBitmap);
+			layer.setBitmap(resizedBitmap);
 
 			setChanged();
 		} catch (Exception e) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/RotateCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/RotateCommand.java
@@ -40,7 +40,7 @@ public class RotateCommand extends BaseCommand {
 
 	@Override
 	public void run(Canvas canvas, Layer layer) {
-		Bitmap bitmap = layer.getImage();
+		Bitmap bitmap = layer.getBitmap();
 
 		setChanged();
 		notifyStatus(NotifyStates.COMMAND_STARTED);
@@ -77,7 +77,7 @@ public class RotateCommand extends BaseCommand {
 
 		rotateCanvas.drawBitmap(bitmap, rotateMatrix, new Paint());
 
-		layer.setImage(rotatedBitmap);
+		layer.setBitmap(rotatedBitmap);
 
 		setChanged();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,12 +21,13 @@ package org.catrobat.paintroid.listener;
 
 import android.graphics.Point;
 import android.graphics.PointF;
-import android.util.Log;
+import android.os.Handler;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
 
 import org.catrobat.paintroid.PaintroidApplication;
+import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.Tool.StateChange;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.ui.DrawingSurface;
@@ -34,107 +35,110 @@ import org.catrobat.paintroid.ui.Perspective;
 
 import java.util.EnumSet;
 
+import static org.catrobat.paintroid.tools.ToolType.FILL;
+import static org.catrobat.paintroid.tools.ToolType.PIPETTE;
+import static org.catrobat.paintroid.tools.ToolType.TRANSFORM;
+
 public class DrawingSurfaceListener implements OnTouchListener {
-	private static final int BLOCKING_TIME = 250 * 1000 * 1000;
+	private TouchMode touchMode;
 
 	private float pointerDistance;
-	private PointF pointerMean;
-	private TouchMode touchMode;
-	private long zoomTimeStamp;
-	private MoveThread moveThread;
+	private final AutoScrollTask autoScrollTask;
 
-	public DrawingSurfaceListener() {
-		pointerMean = new PointF(0, 0);
-		touchMode = TouchMode.DRAW;
+	private float xMidPoint;
+	private float yMidPoint;
+
+	private PointF touchPoint;
+
+	public DrawingSurfaceListener(AutoScrollTask autoScrollTask) {
+		this.touchMode = TouchMode.DRAW;
+		this.autoScrollTask = autoScrollTask;
+
+		touchPoint = new PointF();
 	}
 
 	private float calculatePointerDistance(MotionEvent event) {
 		float x = event.getX(0) - event.getX(1);
 		float y = event.getY(0) - event.getY(1);
-		return (float) Math.sqrt(x * x + y * y);
+		return (float) Math.hypot(x, y);
 	}
 
-	private void calculatePointerMean(MotionEvent event, PointF p) {
-		float x = (event.getX(0) + event.getX(1)) / 2f;
-		float y = (event.getY(0) + event.getY(1)) / 2f;
-		p.set(x, y);
+	private void calculateMidPoint(MotionEvent event) {
+		xMidPoint = (event.getX(0) + event.getX(1)) / 2f;
+		yMidPoint = (event.getY(0) + event.getY(1)) / 2f;
 	}
 
 	@Override
 	public boolean onTouch(View view, MotionEvent event) {
+		Tool currentTool = PaintroidApplication.currentTool;
 		DrawingSurface drawingSurface = (DrawingSurface) view;
 		Perspective perspective = PaintroidApplication.perspective;
-		PointF touchPoint = perspective
-				.getCanvasPointFromSurfacePoint(new PointF(event.getX(), event.getY()));
-		if (drawingSurface.getLock()) {
-			touchMode = TouchMode.LOCK;
-		}
+
+		touchPoint.x = event.getX();
+		touchPoint.y = event.getY();
+		perspective.convertToCanvasFromSurface(touchPoint);
+
 		switch (event.getAction()) {
 			case MotionEvent.ACTION_DOWN:
-				PaintroidApplication.currentTool.handleTouch(touchPoint, MotionEvent.ACTION_DOWN);
+				currentTool.handleTouch(touchPoint, MotionEvent.ACTION_DOWN);
 
-				moveThread = new MoveThread();
-				moveThread.setCalculationVariables(event.getX(), event.getY(),
-						view.getWidth(), view.getHeight());
-				moveThread.start();
+				autoScrollTask.setEventPoint(event.getX(), event.getY());
+				autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
+				autoScrollTask.start();
 
 				break;
 			case MotionEvent.ACTION_MOVE:
 				if (event.getPointerCount() == 1) {
-					if (System.nanoTime() < (zoomTimeStamp + BLOCKING_TIME)) {
-						break;
-					}
-					touchMode = TouchMode.DRAW;
-					if (moveThread != null) {
-						moveThread.setCalculationVariables(event.getX(),
-								event.getY(), view.getWidth(), view.getHeight());
-					}
-					PaintroidApplication.currentTool.handleTouch(touchPoint, MotionEvent.ACTION_MOVE);
-				} else {
-					if (moveThread != null && System.nanoTime() > moveThread.threadStartTime + BLOCKING_TIME) {
+					if (touchMode == TouchMode.PINCH) {
 						break;
 					}
 
-					if (moveThread != null) {
-						if (moveThread.scrolling
-								&& (System.nanoTime() > (moveThread.threadStartTime + BLOCKING_TIME))) {
-							break;
-						} else {
-							moveThread.kill();
-							moveThread = null;
-						}
+					touchMode = TouchMode.DRAW;
+					autoScrollTask.setEventPoint(event.getX(), event.getY());
+					autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
+
+					currentTool.handleTouch(touchPoint, MotionEvent.ACTION_MOVE);
+				} else {
+					if (autoScrollTask.isRunning()) {
+						autoScrollTask.stop();
 					}
+					if (touchMode == TouchMode.DRAW) {
+						currentTool.resetInternalState(StateChange.MOVE_CANCELED);
+					}
+
 					touchMode = TouchMode.PINCH;
 
 					float pointerDistanceOld = pointerDistance;
 					pointerDistance = calculatePointerDistance(event);
-					if (pointerDistanceOld > 0) {
+					if (pointerDistanceOld > 0 && pointerDistanceOld != pointerDistance) {
 						float scale = (pointerDistance / pointerDistanceOld);
 						perspective.multiplyScale(scale);
 					}
 
-					float xOld = pointerMean.x;
-					float yOld = pointerMean.y;
-					calculatePointerMean(event, pointerMean);
-					if (xOld > 0 || yOld > 0) {
-						perspective.translate(pointerMean.x - xOld, pointerMean.y - yOld);
+					float xOld = xMidPoint;
+					float yOld = yMidPoint;
+					calculateMidPoint(event);
+					if (xOld > 0 && xMidPoint != xOld || yOld > 0 && yMidPoint != yOld) {
+						perspective.translate(xMidPoint - xOld, yMidPoint - yOld);
 					}
-					zoomTimeStamp = System.nanoTime();
 				}
 				break;
 			case MotionEvent.ACTION_UP:
 			case MotionEvent.ACTION_CANCEL:
-				if (moveThread != null) {
-					moveThread.kill();
+				if (autoScrollTask.isRunning()) {
+					autoScrollTask.stop();
 				}
-				moveThread = null;
+
 				if (touchMode == TouchMode.DRAW) {
-					PaintroidApplication.currentTool.handleTouch(touchPoint, MotionEvent.ACTION_UP);
+					currentTool.handleTouch(touchPoint, MotionEvent.ACTION_UP);
 				} else {
-					PaintroidApplication.currentTool.resetInternalState(StateChange.MOVE_CANCELED);
+					currentTool.resetInternalState(StateChange.MOVE_CANCELED);
 				}
+
 				pointerDistance = 0;
-				pointerMean.set(0, 0);
+				xMidPoint = 0;
+				yMidPoint = 0;
+				touchMode = TouchMode.DRAW;
 				break;
 		}
 		drawingSurface.refreshDrawingSurface();
@@ -142,87 +146,102 @@ public class DrawingSurfaceListener implements OnTouchListener {
 	}
 
 	enum TouchMode {
-		DRAW, PINCH, LOCK
+		DRAW, PINCH
 	}
 
-	private class MoveThread extends Thread {
-
-		private static final int SCROLL_INTERVAL_FACTOR = 8;
-
-		private int step = 1;
+	public static class AutoScrollTask implements Runnable {
+		// IMPORTANT: If the SCROLL_INTERVAL_FACTOR is chosen too low,
+		// espresso will wait forever for the handler queue to be empty on long touch events.
+		private static final int SCROLL_INTERVAL_FACTOR = 40;
+		private static final float STEP = 2f;
 
 		private boolean running;
-		private boolean scrolling;
-
 		private float pointX;
 		private float pointY;
 		private int width;
 		private int height;
-		private long threadStartTime;
-		private EnumSet<ToolType> ignoredTools = EnumSet.of(ToolType.PIPETTE,
-				ToolType.FILL, ToolType.TRANSFORM);
+		private EnumSet<ToolType> ignoredTools = EnumSet.of(PIPETTE, FILL, TRANSFORM);
+		private final PointF newMovePoint;
 
-		MoveThread() {
-			threadStartTime = System.nanoTime();
-			running = !ignoredTools.contains(PaintroidApplication.currentTool
-					.getToolType());
-			scrolling = false;
+		private final Handler handler;
+		private AutoScrollTaskCallback callback;
+
+		public AutoScrollTask(Handler handler, AutoScrollTaskCallback callback) {
+			this.handler = handler;
+			this.callback = callback;
+			running = false;
+			newMovePoint = new PointF();
 		}
 
-		void setCalculationVariables(float pointX, float pointY, int width, int height) {
+		public void setEventPoint(float pointX, float pointY) {
 			this.pointX = pointX;
 			this.pointY = pointY;
+		}
+
+		public void setViewDimensions(int width, int height) {
 			this.width = width;
 			this.height = height;
 		}
 
-		@Override
-		public synchronized void start() {
-			if (width == 0 || height == 0) {
-				throw new IllegalStateException(
-						"MoveThread could not be started. Illegal width and/or height values.");
+		public void start() {
+			if (running || width == 0 || height == 0) {
+				throw new IllegalStateException();
+			} else if (ignoredTools.contains(callback.getCurrentToolType())) {
+				return;
 			}
-			super.start();
+			running = true;
+			run();
 		}
 
-		void kill() {
-			running = false;
+		public void stop() {
+			if (running) {
+				running = false;
+				handler.removeCallbacks(this);
+			}
+		}
+
+		public boolean isRunning() {
+			return running;
 		}
 
 		private int calculateScrollInterval(float scale) {
-			return (int) (SCROLL_INTERVAL_FACTOR / Math.pow(scale, 1 / 3));
+			return (int) (SCROLL_INTERVAL_FACTOR / Math.cbrt(scale));
 		}
 
 		@Override
 		public void run() {
-			PointF newMovePoint = new PointF();
-			while (running) {
-				Point autoScrollDirection = PaintroidApplication.currentTool
-						.getAutoScrollDirection(pointX, pointY, width, height);
+			Point autoScrollDirection = callback.getToolAutoScrollDirection(pointX, pointY, width, height);
 
-				if (autoScrollDirection.x != 0 || autoScrollDirection.y != 0) {
-					scrolling = true;
+			if (autoScrollDirection.x != 0 || autoScrollDirection.y != 0) {
+				newMovePoint.x = pointX;
+				newMovePoint.y = pointY;
+				callback.convertToCanvasFromSurface(newMovePoint);
 
-					newMovePoint.set(pointX, pointY);
-					PaintroidApplication.perspective.convertToCanvasFromSurface(newMovePoint);
-
-					if (PaintroidApplication.drawingSurface.isPointOnCanvas(newMovePoint)) {
-
-						PaintroidApplication.perspective.translate(autoScrollDirection.x * step,
-								autoScrollDirection.y * step);
-
-						PaintroidApplication.currentTool.handleMove(newMovePoint);
-					}
+				if (callback.isPointOnCanvas(newMovePoint)) {
+					callback.translatePerspective(autoScrollDirection.x * STEP, autoScrollDirection.y * STEP);
+					callback.handleToolMove(newMovePoint);
+					callback.refreshDrawingSurface();
 				}
-
-				try {
-					sleep(calculateScrollInterval(PaintroidApplication.perspective.getScale()));
-				} catch (InterruptedException e) {
-					Log.e(DrawingSurfaceListener.class.getSimpleName(), e.getMessage());
-				}
-				scrolling = false;
-				touchMode = TouchMode.DRAW;
 			}
+			handler.postDelayed(this, calculateScrollInterval(callback.getPerspectiveScale()));
 		}
+	}
+
+	public interface AutoScrollTaskCallback {
+		boolean isPointOnCanvas(PointF point);
+
+		void refreshDrawingSurface();
+
+		void handleToolMove(PointF coordinate);
+
+		Point getToolAutoScrollDirection(float pointX, float pointY, int screenWidth, int screenHeight);
+
+		float getPerspectiveScale();
+
+		void translatePerspective(float dx, float dy);
+
+		void convertToCanvasFromSurface(PointF surfacePoint);
+
+		ToolType getCurrentToolType();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/LayerListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/LayerListener.java
@@ -187,14 +187,12 @@ public final class LayerListener implements OnActiveLayerChangedListener, Adapte
 	public void selectLayer(Layer toSelect) {
 		if (currentLayer != null) {
 			currentLayer.setSelected(false);
-			currentLayer.setImage(PaintroidApplication.drawingSurface.getBitmapCopy());
+			currentLayer.setBitmap(PaintroidApplication.drawingSurface.getBitmapCopy());
 		}
 		currentLayer = toSelect;
 		currentLayer.setSelected(true);
 
-		PaintroidApplication.drawingSurface.setLock(currentLayer.getLocked());
-		PaintroidApplication.drawingSurface.setVisible(currentLayer.getVisible());
-		PaintroidApplication.drawingSurface.setBitmap(currentLayer.getImage());
+		PaintroidApplication.drawingSurface.setBitmap(currentLayer.getBitmap());
 		((Activity) context).runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
@@ -213,14 +211,12 @@ public final class LayerListener implements OnActiveLayerChangedListener, Adapte
 	public void setCurrentLayer(Layer toSelect) {
 		if (currentLayer != null) {
 			currentLayer.setSelected(false);
-			currentLayer.setImage(PaintroidApplication.drawingSurface.getBitmapCopy());
+			currentLayer.setBitmap(PaintroidApplication.drawingSurface.getBitmapCopy());
 		}
 		currentLayer = toSelect;
 		currentLayer.setSelected(true);
 
-		PaintroidApplication.drawingSurface.setLock(currentLayer.getLocked());
-		PaintroidApplication.drawingSurface.setVisible(currentLayer.getVisible());
-		PaintroidApplication.drawingSurface.setBitmap(currentLayer.getImage());
+		PaintroidApplication.drawingSurface.setBitmap(currentLayer.getBitmap());
 	}
 
 	public void refreshView() {
@@ -280,11 +276,6 @@ public final class LayerListener implements OnActiveLayerChangedListener, Adapte
 		PaintroidApplication.commandManager.commitRemoveLayerCommand(new LayerCommand(currentLayer));
 		layersAdapter.removeLayer(currentLayer);
 		selectLayer(layersAdapter.getLayer(newPosition));
-
-		if (layersAdapter.checkAllLayerVisible()) {
-			ToastFactory.makeText(context, R.string.layer_invisible,
-					Toast.LENGTH_LONG).show();
-		}
 
 		updateButtonResource();
 		refreshView();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Layer.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Layer.java
@@ -1,3 +1,22 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.catrobat.paintroid.tools;
 
 import android.graphics.Bitmap;
@@ -5,88 +24,37 @@ import android.graphics.Bitmap;
 import org.catrobat.paintroid.PaintroidApplication;
 
 public class Layer {
-	private static final String LAYER_PREFIX = "Layer ";
-	private int layerID;
+	private final int layerID;
 	private Bitmap bitmap;
 	private boolean isSelected;
-	private String layerName;
-	private boolean isLocked;
-	private boolean isVisible;
-	private int opacity;
 
-	public Layer(int layerId, Bitmap image) {
-		layerID = layerId;
-		bitmap = image;
-		setSelected(false);
-		layerName = LAYER_PREFIX + layerId;
-		isLocked = false;
-		isVisible = true;
-		opacity = 100;
+	public Layer(int layerID, Bitmap bitmap) {
+		this.layerID = layerID;
+		this.bitmap = bitmap;
+		isSelected = false;
 	}
 
 	public boolean getSelected() {
 		return isSelected;
 	}
 
-	public void setSelected(boolean toSet) {
-		isSelected = toSet;
-	}
-
-	public int getOpacity() {
-		return opacity;
-	}
-
-	public void setOpacity(int newOpacity) {
-		opacity = newOpacity;
-	}
-
-	public int getScaledOpacity() {
-		return Math.round((opacity * 255) / 100);
-	}
-
-	public boolean getLocked() {
-		return isLocked;
-	}
-
-	public void setLocked(boolean setTo) {
-		isLocked = setTo;
-	}
-
-	public boolean getVisible() {
-		return isVisible;
-	}
-
-	public void setVisible(boolean setTo) {
-		isVisible = setTo;
-	}
-
-	public String getName() {
-		return layerName;
-	}
-
-	public void setName(String nameTo) {
-		if (nameTo.length() > 0) {
-			layerName = nameTo;
-		}
+	public void setSelected(boolean value) {
+		isSelected = value;
 	}
 
 	public int getLayerID() {
 		return layerID;
 	}
 
-	public Bitmap getImage() {
+	public Bitmap getBitmap() {
 		return bitmap;
 	}
 
-	public void setImage(Bitmap image) {
-		bitmap = image;
+	public void setBitmap(Bitmap bitmap) {
+		this.bitmap = bitmap;
 
-		if (getSelected() && PaintroidApplication.drawingSurface != null) {
-			PaintroidApplication.drawingSurface.setBitmap(image);
+		if (isSelected && PaintroidApplication.drawingSurface != null) {
+			PaintroidApplication.drawingSurface.setBitmap(bitmap);
 		}
-	}
-
-	public Layer getLayer() {
-		return this;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.java
@@ -137,7 +137,8 @@ public class Perspective implements Serializable {
 				+ surfaceCenterX - surfaceTranslationX;
 		float canvasY = (surfacePoint.y - surfaceCenterY) / surfaceScale
 				+ surfaceCenterY - surfaceTranslationY;
-		surfacePoint.set(canvasX, canvasY);
+		surfacePoint.x = canvasX;
+		surfacePoint.y = canvasY;
 	}
 
 	/**

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/button/LayersAdapter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/button/LayersAdapter.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,8 +22,6 @@ package org.catrobat.paintroid.ui.button;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Matrix;
-import android.graphics.Paint;
 import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -105,13 +103,10 @@ public class LayersAdapter extends BaseAdapter implements OnLayerEventListener {
 		return false;
 	}
 
-	public boolean addLayer(Layer existingLayer) {
+	public void addLayer(Layer existingLayer) {
 		if (layerList.size() < MAX_LAYER) {
 			layerList.add(0, existingLayer);
-			return true;
 		}
-
-		return false;
 	}
 
 	public void removeLayer(Layer layer) {
@@ -133,7 +128,6 @@ public class LayersAdapter extends BaseAdapter implements OnLayerEventListener {
 		removeLayer(secondLayer);
 
 		Layer layer = new Layer(layerCounter++, mergedBitmap);
-		layer.setOpacity(100);
 		addLayer(layer);
 
 		return layer;
@@ -141,18 +135,14 @@ public class LayersAdapter extends BaseAdapter implements OnLayerEventListener {
 
 	private Bitmap mergeBitmaps(Layer firstLayer, Layer secondLayer) {
 
-		Bitmap firstBitmap = firstLayer.getImage();
-		Bitmap secondBitmap = secondLayer.getImage();
+		Bitmap firstBitmap = firstLayer.getBitmap();
+		Bitmap secondBitmap = secondLayer.getBitmap();
 
 		Bitmap bmpOverlay = Bitmap.createBitmap(firstBitmap.getWidth(), firstBitmap.getHeight(), firstBitmap.getConfig());
 		Canvas canvas = new Canvas(bmpOverlay);
 
-		Paint overlayPaint = new Paint();
-		overlayPaint.setAlpha(firstLayer.getScaledOpacity());
-
-		canvas.drawBitmap(firstBitmap, new Matrix(), overlayPaint);
-		overlayPaint.setAlpha(secondLayer.getScaledOpacity());
-		canvas.drawBitmap(secondBitmap, 0, 0, overlayPaint);
+		canvas.drawBitmap(firstBitmap, 0, 0, null);
+		canvas.drawBitmap(secondBitmap, 0, 0, null);
 
 		return bmpOverlay;
 	}
@@ -173,7 +163,7 @@ public class LayersAdapter extends BaseAdapter implements OnLayerEventListener {
 						ContextCompat.getColor(context, R.color.custom_background_color));
 			}
 			ImageView imageView = (ImageView) convertView.findViewById(R.id.layer_button_image);
-			imageView.setImageBitmap(layerList.get(position).getImage());
+			imageView.setImageBitmap(layerList.get(position).getBitmap());
 		}
 		return convertView;
 	}
@@ -192,7 +182,7 @@ public class LayersAdapter extends BaseAdapter implements OnLayerEventListener {
 	public void copy(int currentLayer) {
 
 		if (layerList.size() < MAX_LAYER) {
-			Bitmap image = layerList.get(getPosition(currentLayer)).getImage().copy(layerList.get(currentLayer).getImage().getConfig(), true);
+			Bitmap image = layerList.get(getPosition(currentLayer)).getBitmap().copy(layerList.get(currentLayer).getBitmap().getConfig(), true);
 			layerList.add(0, new Layer(layerCounter, image));
 			layerCounter++;
 			notifyDataSetChanged();
@@ -230,32 +220,18 @@ public class LayersAdapter extends BaseAdapter implements OnLayerEventListener {
 	}
 
 	public Bitmap getBitmapToSave() {
-		Bitmap firstBitmap = layerList.get(layerList.size() - 1).getImage();
+		Bitmap firstBitmap = layerList.get(layerList.size() - 1).getBitmap();
 		Bitmap bitmap = Bitmap.createBitmap(firstBitmap.getWidth(), firstBitmap.getHeight(), firstBitmap.getConfig());
 		Canvas canvas = new Canvas(bitmap);
-		Paint overlayPaint = new Paint();
-		overlayPaint.setAlpha(layerList.get(layerList.size() - 1).getScaledOpacity());
-		canvas.drawBitmap(firstBitmap, new Matrix(), overlayPaint);
+		canvas.drawBitmap(firstBitmap, 0, 0, null);
 
 		if (layerList.size() > 1) {
 			for (int i = layerList.size() - 2; i >= 0; i--) {
-				overlayPaint.setAlpha(layerList.get(i).getScaledOpacity());
-				canvas.drawBitmap(layerList.get(i).getImage(), 0, 0, overlayPaint);
+				canvas.drawBitmap(layerList.get(i).getBitmap(), 0, 0, null);
 			}
 		}
 
 		return bitmap;
-	}
-
-	public boolean checkAllLayerVisible() {
-
-		for (Layer layer : layerList) {
-			if (layer.getVisible()) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	public int getLayerCounter() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/BrickDragAndDropLayerMenu.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/BrickDragAndDropLayerMenu.java
@@ -110,7 +110,7 @@ public class BrickDragAndDropLayerMenu extends BrickDragAndDrop {
 			heightOneLayer = view.getChildAt(0).getHeight();
 		}
 
-		Bitmap buffer = LayerListener.getInstance().getAdapter().getLayer(0).getImage();
+		Bitmap buffer = LayerListener.getInstance().getAdapter().getLayer(0).getBitmap();
 		blueBitmap = Bitmap.createBitmap(buffer.getWidth(), buffer.getHeight(), buffer.getConfig());
 		blueBitmap.eraseColor(view.getContext().getResources().getColor(R.color.custom_background_color));
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/MyDragShadowBuilder.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/MyDragShadowBuilder.java
@@ -41,7 +41,7 @@ public class MyDragShadowBuilder extends View.DragShadowBuilder {
 	public MyDragShadowBuilder(View imageView) {
 		super(imageView);
 
-		Bitmap buffer = LayerListener.getInstance().getAdapter().getLayer(0).getImage();
+		Bitmap buffer = LayerListener.getInstance().getAdapter().getLayer(0).getBitmap();
 		greyBitmap = Bitmap.createBitmap(buffer.getWidth(), buffer.getHeight(), buffer.getConfig());
 		greyBitmap.eraseColor(Color.LTGRAY);
 	}
@@ -52,7 +52,7 @@ public class MyDragShadowBuilder extends View.DragShadowBuilder {
 
 	@Override
 	public void onProvideShadowMetrics(Point size, Point touch) {
-		shadowBitmap = mergeBitmaps(greyBitmap, LayerListener.getInstance().getAdapter().getLayer(dragPosition).getImage());
+		shadowBitmap = mergeBitmaps(greyBitmap, LayerListener.getInstance().getAdapter().getLayer(dragPosition).getBitmap());
 		shadow = new BitmapDrawable(getView().getResources(), shadowBitmap);
 
 		final View view = getView();

--- a/Paintroid/src/main/res/values-ar/string.xml
+++ b/Paintroid/src/main/res/values-ar/string.xml
@@ -112,7 +112,6 @@
   <string name="layer_new">طبقة جديدة</string>
   <string name="layer_delete">حذف الطبقة</string>
   <string name="layer_too_many_layers">طبقات عديدة</string>
-  <string name="layer_invisible">كل الطبقات غير مرئية</string>
   <string name="layer_merged">تم دمج الطبقات</string>
   <string name="dialog_shape_text">الشكل</string>
   <string name="dialog_loading_image_failed_title">خطأ في استيراد الصورة</string>

--- a/Paintroid/src/main/res/values-az/string.xml
+++ b/Paintroid/src/main/res/values-az/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-bg-rBG/string.xml
+++ b/Paintroid/src/main/res/values-bg-rBG/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-bs/string.xml
+++ b/Paintroid/src/main/res/values-bs/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Oblik</string>
   <string name="dialog_loading_image_failed_title">Greška prilikom učitavanja slike</string>

--- a/Paintroid/src/main/res/values-ca/string.xml
+++ b/Paintroid/src/main/res/values-ca/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-cs/string.xml
+++ b/Paintroid/src/main/res/values-cs/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Nová vrstva</string>
   <string name="layer_delete">Odstranit vrstvu</string>
   <string name="layer_too_many_layers">Příliš mnoho vrstev</string>
-  <string name="layer_invisible">Všechny vrstvy neviditelné</string>
   <string name="layer_merged">Vrstvy spojeny</string>
   <string name="dialog_shape_text">Tvar</string>
   <string name="dialog_loading_image_failed_title">Chyba při načítání obrázku</string>

--- a/Paintroid/src/main/res/values-da/string.xml
+++ b/Paintroid/src/main/res/values-da/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-de/string.xml
+++ b/Paintroid/src/main/res/values-de/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Neue Ebene</string>
   <string name="layer_delete">Ebene löschen</string>
   <string name="layer_too_many_layers">Zu viele Ebenen</string>
-  <string name="layer_invisible">Alle Ebenen sind unsichtbar</string>
   <string name="layer_merged">Ebenen zusammengefügt</string>
   <string name="dialog_shape_text">Form</string>
   <string name="dialog_loading_image_failed_title">Fehler beim Laden vom Bild</string>

--- a/Paintroid/src/main/res/values-el/string.xml
+++ b/Paintroid/src/main/res/values-el/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-en-rAU/string.xml
+++ b/Paintroid/src/main/res/values-en-rAU/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-en-rCA/string.xml
+++ b/Paintroid/src/main/res/values-en-rCA/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-en-rGB/string.xml
+++ b/Paintroid/src/main/res/values-en-rGB/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-es/string.xml
+++ b/Paintroid/src/main/res/values-es/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Nueva capa</string>
   <string name="layer_delete">Eliminar capa</string>
   <string name="layer_too_many_layers">Demasiadas capas</string>
-  <string name="layer_invisible">Todas las capas invisibles</string>
   <string name="layer_merged">Capas fusionadas</string>
   <string name="dialog_shape_text">Forma</string>
   <string name="dialog_loading_image_failed_title">Error en la carga de la imagen</string>

--- a/Paintroid/src/main/res/values-fa-rAF/string.xml
+++ b/Paintroid/src/main/res/values-fa-rAF/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-fa/string.xml
+++ b/Paintroid/src/main/res/values-fa/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">شکل</string>
   <string name="dialog_loading_image_failed_title">خطا در بارگذاری تصویر</string>

--- a/Paintroid/src/main/res/values-fr/string.xml
+++ b/Paintroid/src/main/res/values-fr/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-gl/string.xml
+++ b/Paintroid/src/main/res/values-gl/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-gu/string.xml
+++ b/Paintroid/src/main/res/values-gu/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-hi/string.xml
+++ b/Paintroid/src/main/res/values-hi/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">नई परत</string>
   <string name="layer_delete">परत हटाएं</string>
   <string name="layer_too_many_layers">बहुत अधिक परतें</string>
-  <string name="layer_invisible">सभी परतों अदृश्य</string>
   <string name="layer_merged">लेयर्स मर्ज किए गए</string>
   <string name="dialog_shape_text">आकार</string>
   <string name="dialog_loading_image_failed_title">चित्र तैयार होने में गड़बड़ी हो गयी हैं</string>

--- a/Paintroid/src/main/res/values-hr/string.xml
+++ b/Paintroid/src/main/res/values-hr/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-hu/string.xml
+++ b/Paintroid/src/main/res/values-hu/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Alakzat</string>
   <string name="dialog_loading_image_failed_title">Hiba a kép betöltése során</string>

--- a/Paintroid/src/main/res/values-in/string.xml
+++ b/Paintroid/src/main/res/values-in/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Lapisan baru</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Bentuk</string>
   <string name="dialog_loading_image_failed_title">Galat saat memuat citra</string>

--- a/Paintroid/src/main/res/values-it/string.xml
+++ b/Paintroid/src/main/res/values-it/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Nuovo livello</string>
   <string name="layer_delete">Elimina livello</string>
   <string name="layer_too_many_layers">Troppi livelli</string>
-  <string name="layer_invisible">Tutti i livelli invisibili</string>
   <string name="layer_merged">Livelli uniti</string>
   <string name="dialog_shape_text">Forma</string>
   <string name="dialog_loading_image_failed_title">Errore durante il caricamento dell\'immagine</string>

--- a/Paintroid/src/main/res/values-iw/string.xml
+++ b/Paintroid/src/main/res/values-iw/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">צורה</string>
   <string name="dialog_loading_image_failed_title">שגיאת בטעינת התמונה</string>

--- a/Paintroid/src/main/res/values-ja/string.xml
+++ b/Paintroid/src/main/res/values-ja/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">新規レイヤ</string>
   <string name="layer_delete">レイヤーを削除</string>
   <string name="layer_too_many_layers">レイヤーが多すぎます</string>
-  <string name="layer_invisible">すべてのレイヤーが非表示</string>
   <string name="layer_merged">レイヤーを統合</string>
   <string name="dialog_shape_text">図形</string>
   <string name="dialog_loading_image_failed_title">イメージの読み込みエラー</string>

--- a/Paintroid/src/main/res/values-kk/string.xml
+++ b/Paintroid/src/main/res/values-kk/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-kn/string.xml
+++ b/Paintroid/src/main/res/values-kn/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-ko/string.xml
+++ b/Paintroid/src/main/res/values-ko/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">새 레이어</string>
   <string name="layer_delete">레이어 삭제</string>
   <string name="layer_too_many_layers">너무 많은 레이어</string>
-  <string name="layer_invisible">보이지 않는 모든 레이어</string>
   <string name="layer_merged">레이어 병합</string>
   <string name="dialog_shape_text">모양</string>
   <string name="dialog_loading_image_failed_title">그림 로딩 중 에러</string>

--- a/Paintroid/src/main/res/values-lt-rLT/string.xml
+++ b/Paintroid/src/main/res/values-lt-rLT/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-mk/string.xml
+++ b/Paintroid/src/main/res/values-mk/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-ml/string.xml
+++ b/Paintroid/src/main/res/values-ml/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-ms/string.xml
+++ b/Paintroid/src/main/res/values-ms/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-nl/string.xml
+++ b/Paintroid/src/main/res/values-nl/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Nieuwe laag</string>
   <string name="layer_delete">Verwijder laag</string>
   <string name="layer_too_many_layers">Te veel lagen</string>
-  <string name="layer_invisible">Alle lagen onzichtbaar</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Vorm</string>
   <string name="dialog_loading_image_failed_title">Fout bij het laden van de afbeelding</string>

--- a/Paintroid/src/main/res/values-no/string.xml
+++ b/Paintroid/src/main/res/values-no/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-pl/string.xml
+++ b/Paintroid/src/main/res/values-pl/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Nowa Warstwa</string>
   <string name="layer_delete">Usuń Warstwę</string>
   <string name="layer_too_many_layers">Za dużo warstw</string>
-  <string name="layer_invisible">Wszystkie warstwy niewidoczne</string>
   <string name="layer_merged">Scalone warstwy</string>
   <string name="dialog_shape_text">Kształt</string>
   <string name="dialog_loading_image_failed_title">Błąd ładowania obrazu</string>

--- a/Paintroid/src/main/res/values-ps/string.xml
+++ b/Paintroid/src/main/res/values-ps/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-pt-rBR/string.xml
+++ b/Paintroid/src/main/res/values-pt-rBR/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Nova Camada</string>
   <string name="layer_delete">Excluir Camada</string>
   <string name="layer_too_many_layers">Há camadas demais</string>
-  <string name="layer_invisible">Todas as camadas invisíveis</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Forma</string>
   <string name="dialog_loading_image_failed_title">Erro ao carregar imagem</string>

--- a/Paintroid/src/main/res/values-pt/string.xml
+++ b/Paintroid/src/main/res/values-pt/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Forma</string>
   <string name="dialog_loading_image_failed_title">Erro ao carregar imagem</string>

--- a/Paintroid/src/main/res/values-ro/string.xml
+++ b/Paintroid/src/main/res/values-ro/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-ru/string.xml
+++ b/Paintroid/src/main/res/values-ru/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Новый слой</string>
   <string name="layer_delete">Удалить слой</string>
   <string name="layer_too_many_layers">Слишком много слоев</string>
-  <string name="layer_invisible">Все слои невидимы</string>
   <string name="layer_merged">Слои объединены</string>
   <string name="dialog_shape_text">Фигура</string>
   <string name="dialog_loading_image_failed_title">Ошибка загрузки изображения</string>

--- a/Paintroid/src/main/res/values-sd/string.xml
+++ b/Paintroid/src/main/res/values-sd/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">نئون ليير</string>
   <string name="layer_delete">ليير ڊاهيو</string>
   <string name="layer_too_many_layers">تمام گهڻا ليير ٿي ويا آهن</string>
-  <string name="layer_invisible">سڀ ليير لڪل آهن</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">شڪل</string>
   <string name="dialog_loading_image_failed_title">تصوير لوڊ ڪرڻ ۾ نقص</string>

--- a/Paintroid/src/main/res/values-sk/string.xml
+++ b/Paintroid/src/main/res/values-sk/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-sl/string.xml
+++ b/Paintroid/src/main/res/values-sl/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Oblika</string>
   <string name="dialog_loading_image_failed_title">Napaka pri nalaganju slike</string>

--- a/Paintroid/src/main/res/values-sq/string.xml
+++ b/Paintroid/src/main/res/values-sq/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-sr-rCS/string.xml
+++ b/Paintroid/src/main/res/values-sr-rCS/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-sr-rSP/string.xml
+++ b/Paintroid/src/main/res/values-sr-rSP/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-sv/string.xml
+++ b/Paintroid/src/main/res/values-sv/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Nytt lager</string>
   <string name="layer_delete">Ta bort lager</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">Alla lager osynliga</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Form</string>
   <string name="dialog_loading_image_failed_title">Fel vid inläsning av bilden</string>

--- a/Paintroid/src/main/res/values-sw/string.xml
+++ b/Paintroid/src/main/res/values-sw/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Tabaka jipya</string>
   <string name="layer_delete">Futa tabaka</string>
   <string name="layer_too_many_layers">Safu nyingi sana</string>
-  <string name="layer_invisible">Safu zote hazionekani</string>
   <string name="layer_merged">Safu zilizounganishwa</string>
   <string name="dialog_shape_text">Umbo</string>
   <string name="dialog_loading_image_failed_title">Kosa kwenye upakiaji picha</string>

--- a/Paintroid/src/main/res/values-ta/string.xml
+++ b/Paintroid/src/main/res/values-ta/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-te/string.xml
+++ b/Paintroid/src/main/res/values-te/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-th/string.xml
+++ b/Paintroid/src/main/res/values-th/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">รูปร่าง</string>
   <string name="dialog_loading_image_failed_title">ข้อผิดพลาดในการโหลดภาพ</string>

--- a/Paintroid/src/main/res/values-tr/string.xml
+++ b/Paintroid/src/main/res/values-tr/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">Yeni Katman</string>
   <string name="layer_delete">Katmanı Sil</string>
   <string name="layer_too_many_layers">Çok fazla katman</string>
-  <string name="layer_invisible">Tüm katmanlar görünmez</string>
   <string name="layer_merged">Birleştirilmiş Katmanlar</string>
   <string name="dialog_shape_text">Şekil</string>
   <string name="dialog_loading_image_failed_title">Resim yüklenirken hata oluştu</string>

--- a/Paintroid/src/main/res/values-uk/string.xml
+++ b/Paintroid/src/main/res/values-uk/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Shape</string>
   <string name="dialog_loading_image_failed_title">Error on loading image</string>

--- a/Paintroid/src/main/res/values-ur/string.xml
+++ b/Paintroid/src/main/res/values-ur/string.xml
@@ -113,7 +113,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">شکل</string>
   <string name="dialog_loading_image_failed_title">تصویر لوڈ کرنے میں نقص</string>

--- a/Paintroid/src/main/res/values-vi/string.xml
+++ b/Paintroid/src/main/res/values-vi/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">Hình dạng</string>
   <string name="dialog_loading_image_failed_title">Lỗi khi tải hình ảnh</string>

--- a/Paintroid/src/main/res/values-zh-rCN/string.xml
+++ b/Paintroid/src/main/res/values-zh-rCN/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">新建图层</string>
   <string name="layer_delete">删除图层</string>
   <string name="layer_too_many_layers">图层数量过多</string>
-  <string name="layer_invisible">所有图层不可见</string>
   <string name="layer_merged">合并的图层</string>
   <string name="dialog_shape_text">形状</string>
   <string name="dialog_loading_image_failed_title">加载图像时出错</string>

--- a/Paintroid/src/main/res/values-zh-rTW/string.xml
+++ b/Paintroid/src/main/res/values-zh-rTW/string.xml
@@ -111,7 +111,6 @@
   <string name="layer_new">New Layer</string>
   <string name="layer_delete">Delete Layer</string>
   <string name="layer_too_many_layers">Too many layers</string>
-  <string name="layer_invisible">All layers invisible</string>
   <string name="layer_merged">Layers merged</string>
   <string name="dialog_shape_text">形狀</string>
   <string name="dialog_loading_image_failed_title">載入圖檔錯誤</string>

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -132,7 +132,6 @@
     <string name="layer_new">New Layer</string>
     <string name="layer_delete">Delete Layer</string>
     <string name="layer_too_many_layers">Too many layers</string>
-    <string name="layer_invisible">All layers invisible</string>
     <string name="layer_merged">Layers merged</string>
 
     <string name="license_url" translatable="false">http://developer.catrobat.org/licenses</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/AutoScrollTaskTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/AutoScrollTaskTest.java
@@ -1,0 +1,239 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.listener;
+
+import android.graphics.Point;
+import android.graphics.PointF;
+import android.os.Handler;
+
+import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTask;
+import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTaskCallback;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.catrobat.paintroid.test.utils.PointFAnswer.setPointFTo;
+import static org.catrobat.paintroid.test.utils.PointFMatcher.pointFEquals;
+import static org.catrobat.paintroid.tools.ToolType.FILL;
+import static org.catrobat.paintroid.tools.ToolType.PIPETTE;
+import static org.catrobat.paintroid.tools.ToolType.TRANSFORM;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AutoScrollTaskTest {
+
+	@Mock
+	private Handler handler;
+
+	@Mock
+	private AutoScrollTaskCallback callback;
+
+	@InjectMocks
+	private AutoScrollTask autoScrollTask;
+
+	@Test
+	public void testSetUp() {
+		verifyZeroInteractions(handler, callback);
+		assertFalse(autoScrollTask.isRunning());
+	}
+
+	@Test
+	public void testRun() {
+		Point autoScrollDirection = mock(Point.class);
+		when(callback.getToolAutoScrollDirection(anyFloat(), anyFloat(), anyInt(), anyInt()))
+				.thenReturn(autoScrollDirection);
+
+		autoScrollTask.run();
+
+		verify(callback).getToolAutoScrollDirection(anyFloat(), anyFloat(), anyInt(), anyInt());
+		verify(handler).postDelayed(eq(autoScrollTask), anyLong());
+	}
+
+	@Test
+	public void testRunAutoScrollLeft() {
+		Point autoScrollDirection = mock(Point.class);
+		autoScrollDirection.x = -1;
+		when(callback.getToolAutoScrollDirection(3f, 5f, 39, 42))
+				.thenReturn(autoScrollDirection);
+		when(callback.isPointOnCanvas(pointFEquals(7f, 11f))).thenReturn(true);
+		setPointFTo(7f, 11f).when(callback).convertToCanvasFromSurface(pointFEquals(3f, 5f));
+
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+		autoScrollTask.run();
+
+		verify(callback).translatePerspective(-1 * 2f, 0);
+		verify(callback).handleToolMove(pointFEquals(7f, 11f));
+		verify(callback).refreshDrawingSurface();
+
+		verify(handler).postDelayed(eq(autoScrollTask), anyLong());
+	}
+
+	@Test
+	public void testRunAutoScrollLeftWhenNotOnCanvas() {
+		Point autoScrollDirection = mock(Point.class);
+		autoScrollDirection.x = -1;
+		when(callback.getToolAutoScrollDirection(3f, 5f, 39, 42))
+				.thenReturn(autoScrollDirection);
+		setPointFTo(7f, 11f).when(callback).convertToCanvasFromSurface(pointFEquals(3f, 5f));
+
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+		autoScrollTask.run();
+
+		verify(callback, never()).translatePerspective(anyFloat(), anyFloat());
+		verify(callback, never()).handleToolMove(any(PointF.class));
+		verify(callback, never()).refreshDrawingSurface();
+
+		verify(handler).postDelayed(eq(autoScrollTask), anyLong());
+	}
+
+	@Test
+	public void testRunAutoScrollUp() {
+		Point autoScrollDirection = mock(Point.class);
+		autoScrollDirection.y = -1;
+		when(callback.getToolAutoScrollDirection(3f, 5f, 39, 42))
+				.thenReturn(autoScrollDirection);
+		when(callback.isPointOnCanvas(pointFEquals(7f, 11f))).thenReturn(true);
+		setPointFTo(7f, 11f).when(callback).convertToCanvasFromSurface(pointFEquals(3f, 5f));
+
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+		autoScrollTask.run();
+
+		verify(callback).translatePerspective(0, -1 * 2f);
+		verify(callback).handleToolMove(pointFEquals(7f, 11f));
+		verify(callback).refreshDrawingSurface();
+
+		verify(handler).postDelayed(eq(autoScrollTask), anyLong());
+	}
+
+	@Test
+	public void testRunAutoScrollUpWhenNotOnCanvas() {
+		Point autoScrollDirection = mock(Point.class);
+		autoScrollDirection.y = -1;
+		when(callback.getToolAutoScrollDirection(3f, 5f, 39, 42))
+				.thenReturn(autoScrollDirection);
+		setPointFTo(7f, 11f).when(callback).convertToCanvasFromSurface(pointFEquals(3f, 5f));
+
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+		autoScrollTask.run();
+
+		verify(callback, never()).translatePerspective(anyFloat(), anyFloat());
+		verify(callback, never()).handleToolMove(any(PointF.class));
+		verify(callback, never()).refreshDrawingSurface();
+
+		verify(handler).postDelayed(eq(autoScrollTask), anyLong());
+	}
+
+	@Test
+	public void testStop() {
+		autoScrollTask.stop();
+		verifyZeroInteractions(handler, callback);
+
+		assertFalse(autoScrollTask.isRunning());
+	}
+
+	@Test
+	public void testStart() {
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+
+		Point autoScrollDirection = mock(Point.class);
+		when(callback.getToolAutoScrollDirection(anyFloat(), anyFloat(), anyInt(), anyInt()))
+				.thenReturn(autoScrollDirection);
+
+		autoScrollTask.start();
+
+		verify(handler).postDelayed(eq(autoScrollTask), anyLong());
+		assertTrue(autoScrollTask.isRunning());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testStartAlreadyStarted() {
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+
+		Point autoScrollDirection = mock(Point.class);
+		when(callback.getToolAutoScrollDirection(anyFloat(), anyFloat(), anyInt(), anyInt()))
+				.thenReturn(autoScrollDirection);
+
+		autoScrollTask.start();
+		autoScrollTask.start();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testStartWithZeroWidth() {
+		autoScrollTask.setViewDimensions(0, 42);
+		autoScrollTask.start();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testStartWithZeroHeight() {
+		autoScrollTask.setViewDimensions(42, 0);
+		autoScrollTask.start();
+	}
+
+	@Test
+	public void testStartIgnoredTools() {
+		when(callback.getCurrentToolType()).thenReturn(PIPETTE, FILL, TRANSFORM);
+
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+
+		autoScrollTask.start();
+		autoScrollTask.start();
+		autoScrollTask.start();
+
+		assertFalse(autoScrollTask.isRunning());
+		verifyZeroInteractions(handler);
+	}
+
+	@Test
+	public void testStopAfterStart() {
+		autoScrollTask.setEventPoint(3f, 5f);
+		autoScrollTask.setViewDimensions(39, 42);
+
+		Point autoScrollDirection = mock(Point.class);
+		when(callback.getToolAutoScrollDirection(anyFloat(), anyFloat(), anyInt(), anyInt()))
+				.thenReturn(autoScrollDirection);
+
+		autoScrollTask.start();
+		autoScrollTask.stop();
+
+		verify(handler).postDelayed(eq(autoScrollTask), anyLong());
+		verify(handler).removeCallbacks(autoScrollTask);
+		assertFalse(autoScrollTask.isRunning());
+	}
+}

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
@@ -1,0 +1,317 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.listener;
+
+import android.graphics.PointF;
+import android.view.MotionEvent;
+
+import org.catrobat.paintroid.PaintroidApplication;
+import org.catrobat.paintroid.listener.DrawingSurfaceListener;
+import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTask;
+import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.ui.DrawingSurface;
+import org.catrobat.paintroid.ui.Perspective;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.catrobat.paintroid.test.utils.PointFMatcher.pointFEquals;
+import static org.catrobat.paintroid.tools.Tool.StateChange.MOVE_CANCELED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DrawingSurfaceListenerTest {
+
+	@Mock
+	private AutoScrollTask autoScrollTask;
+
+	@Mock
+	private Tool currentTool;
+
+	@Mock
+	private Perspective perspective;
+
+	@InjectMocks
+	private DrawingSurfaceListener drawingSurfaceListener;
+
+	@Before
+	public void setUp() {
+		PaintroidApplication.currentTool = currentTool;
+		PaintroidApplication.perspective = perspective;
+	}
+
+	@Test
+	public void testSetUp() {
+		verifyZeroInteractions(currentTool, perspective, autoScrollTask);
+	}
+
+	@Test
+	public void testOnTouchDown() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_DOWN);
+		when(motionEvent.getX()).thenReturn(3f);
+		when(motionEvent.getY()).thenReturn(5f);
+
+		when(drawingSurface.getWidth()).thenReturn(7);
+		when(drawingSurface.getHeight()).thenReturn(11);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(perspective).convertToCanvasFromSurface(pointFEquals(3f, 5f));
+		verify(currentTool).handleTouch(pointFEquals(3f, 5f), eq(MotionEvent.ACTION_DOWN));
+
+		verify(autoScrollTask).setViewDimensions(7, 11);
+		verify(autoScrollTask).setEventPoint(3f, 5f);
+		verify(autoScrollTask).start();
+
+		verifyNoMoreInteractions(autoScrollTask, currentTool, perspective);
+	}
+
+	@Test
+	public void testOnTouchMoveInDrawMode() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE);
+		when(motionEvent.getX()).thenReturn(5f);
+		when(motionEvent.getY()).thenReturn(3f);
+		when(motionEvent.getPointerCount()).thenReturn(1);
+
+		when(drawingSurface.getWidth()).thenReturn(7);
+		when(drawingSurface.getHeight()).thenReturn(11);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(perspective).convertToCanvasFromSurface(pointFEquals(5f, 3f));
+		verify(currentTool).handleTouch(pointFEquals(5f, 3f), eq(MotionEvent.ACTION_MOVE));
+		verify(autoScrollTask).setEventPoint(5f, 3f);
+		verify(autoScrollTask).setViewDimensions(7, 11);
+		verifyNoMoreInteractions(autoScrollTask);
+	}
+
+	@Test
+	public void testOnTouchMoveInDrawModeDoesNotStopAutoScroll() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE);
+		when(motionEvent.getX()).thenReturn(5f);
+		when(motionEvent.getY()).thenReturn(3f);
+		when(motionEvent.getPointerCount()).thenReturn(1);
+
+		when(drawingSurface.getWidth()).thenReturn(7);
+		when(drawingSurface.getHeight()).thenReturn(11);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(autoScrollTask, never()).stop();
+		verify(autoScrollTask, never()).isRunning();
+	}
+
+	@Test
+	public void testOnTouchMoveInDrawModeAfterPinch() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE);
+		when(motionEvent.getX()).thenReturn(5f);
+		when(motionEvent.getY()).thenReturn(3f);
+		when(motionEvent.getPointerCount()).thenReturn(2, 1);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(currentTool, never()).handleTouch(any(PointF.class), anyInt());
+		verify(autoScrollTask, never()).setEventPoint(anyFloat(), anyFloat());
+		verify(autoScrollTask, never()).setViewDimensions(anyInt(), anyInt());
+	}
+
+	@Test
+	public void testOnTouchMoveInPinchMode() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE);
+		when(motionEvent.getX()).thenReturn(7f);
+		when(motionEvent.getY()).thenReturn(11f);
+		when(motionEvent.getPointerCount()).thenReturn(2);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(currentTool, never()).handleTouch(any(PointF.class), anyInt());
+		verify(autoScrollTask, never()).setEventPoint(anyFloat(), anyFloat());
+		verify(autoScrollTask, never()).setViewDimensions(anyInt(), anyInt());
+
+		verify(perspective, never()).translate(anyFloat(), anyFloat());
+		verify(perspective, never()).multiplyScale(anyFloat());
+	}
+
+	@Test
+	public void testOnTouchMoveInPinchModeStopsAutoScroll() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE);
+		when(motionEvent.getPointerCount()).thenReturn(2);
+		when(autoScrollTask.isRunning()).thenReturn(true);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(autoScrollTask).stop();
+	}
+
+	@Test
+	public void testOnTouchMoveTranslateInPinchMode() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE);
+
+		when(motionEvent.getX(0)).thenReturn(7f);
+		when(motionEvent.getY(0)).thenReturn(11f);
+		when(motionEvent.getX(1)).thenReturn(23f);
+		when(motionEvent.getY(1)).thenReturn(29f);
+
+		when(motionEvent.getPointerCount()).thenReturn(2);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		when(motionEvent.getX(0)).thenReturn(17f);
+		when(motionEvent.getY(0)).thenReturn(1f);
+		when(motionEvent.getX(1)).thenReturn(33f);
+		when(motionEvent.getY(1)).thenReturn(19f);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(currentTool, never()).handleTouch(any(PointF.class), anyInt());
+		verify(autoScrollTask, never()).setEventPoint(anyFloat(), anyFloat());
+		verify(autoScrollTask, never()).setViewDimensions(anyInt(), anyInt());
+
+		verify(perspective).translate(10, -10);
+		verify(perspective, never()).multiplyScale(anyFloat());
+	}
+
+	@Test
+	public void testOnTouchMoveScaleInPinchMode() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE);
+
+		when(motionEvent.getX(0)).thenReturn(2f);
+		when(motionEvent.getY(0)).thenReturn(2f);
+		when(motionEvent.getX(1)).thenReturn(4f);
+		when(motionEvent.getY(1)).thenReturn(4f);
+
+		when(motionEvent.getPointerCount()).thenReturn(2);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		when(motionEvent.getX(0)).thenReturn(1f);
+		when(motionEvent.getY(0)).thenReturn(1f);
+		when(motionEvent.getX(1)).thenReturn(5f);
+		when(motionEvent.getY(1)).thenReturn(5f);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		when(motionEvent.getX(0)).thenReturn(2f);
+		when(motionEvent.getY(0)).thenReturn(2f);
+		when(motionEvent.getX(1)).thenReturn(4f);
+		when(motionEvent.getY(1)).thenReturn(4f);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(currentTool, never()).handleTouch(any(PointF.class), anyInt());
+		verify(autoScrollTask, never()).setEventPoint(anyFloat(), anyFloat());
+		verify(autoScrollTask, never()).setViewDimensions(anyInt(), anyInt());
+
+		verify(perspective, never()).translate(anyFloat(), anyFloat());
+		verify(perspective).multiplyScale((2f - 4f) / (1f - 5f));
+		verify(perspective).multiplyScale((1f - 5f) / (2f - 4f));
+	}
+
+	@Test
+	public void testOnTouchUp() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_UP);
+		when(motionEvent.getX()).thenReturn(3f);
+		when(motionEvent.getY()).thenReturn(5f);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(currentTool).handleTouch(pointFEquals(3f, 5f), eq(MotionEvent.ACTION_UP));
+		verifyNoMoreInteractions(currentTool);
+	}
+
+	@Test
+	public void testOnTouchUpAfterPinchResetsTool() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_MOVE, MotionEvent.ACTION_UP);
+		when(motionEvent.getX()).thenReturn(3f);
+		when(motionEvent.getY()).thenReturn(5f);
+		when(motionEvent.getPointerCount()).thenReturn(2);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(currentTool, times(2)).resetInternalState(MOVE_CANCELED);
+		verify(currentTool, never()).handleTouch(any(PointF.class), anyInt());
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(currentTool).handleTouch(pointFEquals(3f, 5f), eq(MotionEvent.ACTION_UP));
+	}
+
+	@Test
+	public void testOnTouchUpStopsAutoScroll() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(autoScrollTask.isRunning()).thenReturn(true);
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_UP);
+
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(autoScrollTask).stop();
+	}
+}

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/tools/LayerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/tools/LayerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.tools;
+
+import android.graphics.Bitmap;
+
+import org.catrobat.paintroid.tools.Layer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LayerTest {
+
+	@Mock
+	Bitmap bitmap;
+
+	@Test
+	public void testGetSelected() {
+		Layer layer = new Layer(13, bitmap);
+
+		assertFalse(layer.getSelected());
+		verifyZeroInteractions(bitmap);
+	}
+
+	@Test
+	public void testSetSelected() {
+		Layer layer = new Layer(13, bitmap);
+
+		layer.setSelected(true);
+
+		assertTrue(layer.getSelected());
+
+		layer.setSelected(false);
+
+		assertFalse(layer.getSelected());
+		verifyZeroInteractions(bitmap);
+	}
+
+	@Test
+	public void testGetLayerID() {
+		Layer layer = new Layer(3, bitmap);
+		Layer secondLayer = new Layer(5, bitmap);
+
+		assertEquals(3, layer.getLayerID());
+		assertEquals(5, secondLayer.getLayerID());
+		verifyZeroInteractions(bitmap);
+	}
+
+	@Test
+	public void testGetBitmap() {
+		Bitmap secondBitmap = mock(Bitmap.class);
+		Layer layer = new Layer(5, bitmap);
+		Layer secondLayer = new Layer(7, secondBitmap);
+
+		assertEquals(bitmap, layer.getBitmap());
+		assertEquals(secondBitmap, secondLayer.getBitmap());
+		verifyZeroInteractions(bitmap, secondBitmap);
+	}
+
+	@Test
+	public void testSetBitmap() {
+		Bitmap secondBitmap = mock(Bitmap.class);
+		Layer layer = new Layer(11, bitmap);
+
+		layer.setBitmap(secondBitmap);
+
+		assertEquals(secondBitmap, layer.getBitmap());
+		verifyZeroInteractions(bitmap, secondBitmap);
+	}
+}

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/utils/PointFAnswer.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/utils/PointFAnswer.java
@@ -1,46 +1,50 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.command.implementation;
+package org.catrobat.paintroid.test.utils;
 
-import android.graphics.Bitmap;
-import android.graphics.Canvas;
+import android.graphics.PointF;
 
-import org.catrobat.paintroid.PaintroidApplication;
-import org.catrobat.paintroid.tools.Layer;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.Stubber;
 
-public class LoadCommand extends BaseCommand {
+import static org.mockito.Mockito.doAnswer;
 
-	private Bitmap loadedImage;
+public final class PointFAnswer implements Answer {
+	private final float pointX;
+	private final float pointY;
 
-	public LoadCommand(Bitmap newBitmap) {
-		loadedImage = newBitmap.copy(Bitmap.Config.ARGB_8888, true);
+	public PointFAnswer(float x, float y) {
+		this.pointX = x;
+		this.pointY = y;
 	}
 
 	@Override
-	public void run(Canvas canvas, Layer layer) {
+	public Object answer(InvocationOnMock invocation) {
+		PointF point = invocation.getArgument(0);
+		point.x = pointX;
+		point.y = pointY;
+		return null;
+	}
 
-		notifyStatus(NotifyStates.COMMAND_STARTED);
-		Bitmap buffer = loadedImage.copy(Bitmap.Config.ARGB_8888, loadedImage.isMutable());
-		PaintroidApplication.drawingSurface.resetBitmap(buffer);
-		layer.setBitmap(buffer);
-
-		notifyStatus(NotifyStates.COMMAND_DONE);
+	public static Stubber setPointFTo(float x, float y) {
+		return doAnswer(new PointFAnswer(x, y));
 	}
 }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/utils/PointFMatcher.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/utils/PointFMatcher.java
@@ -1,46 +1,50 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.command.implementation;
+package org.catrobat.paintroid.test.utils;
 
-import android.graphics.Bitmap;
-import android.graphics.Canvas;
+import android.graphics.PointF;
 
-import org.catrobat.paintroid.PaintroidApplication;
-import org.catrobat.paintroid.tools.Layer;
+import org.mockito.ArgumentMatcher;
 
-public class LoadCommand extends BaseCommand {
+import static org.mockito.ArgumentMatchers.argThat;
 
-	private Bitmap loadedImage;
+public final class PointFMatcher implements ArgumentMatcher<PointF> {
+	private final float pointX;
+	private final float pointY;
 
-	public LoadCommand(Bitmap newBitmap) {
-		loadedImage = newBitmap.copy(Bitmap.Config.ARGB_8888, true);
+	public PointFMatcher(float x, float y) {
+		this.pointX = x;
+		this.pointY = y;
 	}
 
 	@Override
-	public void run(Canvas canvas, Layer layer) {
+	public boolean matches(PointF argument) {
+		return argument.x == pointX && argument.y == pointY;
+	}
 
-		notifyStatus(NotifyStates.COMMAND_STARTED);
-		Bitmap buffer = loadedImage.copy(Bitmap.Config.ARGB_8888, loadedImage.isMutable());
-		PaintroidApplication.drawingSurface.resetBitmap(buffer);
-		layer.setBitmap(buffer);
+	@Override
+	public String toString() {
+		return "PointF(" + pointX + ", " + pointY + ")";
+	}
 
-		notifyStatus(NotifyStates.COMMAND_DONE);
+	public static PointF pointFEquals(float x, float y) {
+		return argThat(new PointFMatcher(x, y));
 	}
 }


### PR DESCRIPTION
* Refactor `DrawingSurfaceListener` class, remove unused functionality
* Rename `MoveThread` to `AutoScrollTask` and use it asynchronously via a Handler
* Add tests for the refactored `DrawingSurfaceListener` and `AutoScrollTask`
* Clean up `Layer` class, remove unused functionality
* Add tests for `Layer` class
* Rename getImage and setImage to getBitmap and setBitmap
* Remove unused functionality in `DrawingSurface`
* Avoid alpha blending in `DrawingSurface` painting when not needed
* Remove unused resources (strings)