### PR TITLE
JENKINS-221: Run unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,12 @@ pipeline {
 
 		stage('Unit and Device tests') {
 			steps {
-				// Run Unit and device tests
+				// Run local unit tests
+				sh "./buildScripts/build_step_run_unit_tests__all_tests"
+				// ensure that the following test run does not overwrite the results
+				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build ${env.GRADLE_PROJECT_MODULE_NAME}/build-unittest"
+
+				// Run device tests
 				sh "./buildScripts/build_step_run_tests_on_emulator__all_tests"
 
 				// Convert the JaCoCo coverate to the Cobertura XML file format.

--- a/buildScripts/build_helper_run_tests_on_emulator
+++ b/buildScripts/build_helper_run_tests_on_emulator
@@ -16,10 +16,7 @@ This scripts runs all the tests on an emulator. The emulator is configured
 in 'emulator_config.ini'. A single class or package to test can be passed
 as single command line argument.
 
-The environment variable ANDROID_SDK_ROOT needs to be set.
-
-Be aware that Jenkins cleans the workspace before every build, this can
-be partly replicated by './gradlew clean'.""")
+The environment variable ANDROID_SDK_ROOT needs to be set.""")
 
 def detect_class_or_package(class_or_package):
     if class_or_package is None or class_or_package == "":
@@ -46,7 +43,7 @@ if len(sys.argv) > 1:
 build_helper_functions.bring_emulator_in_running_state()
 
 ## RUN tests
-test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), 'clean', 'adbDisableAnimationsGlobally', 'test', 'createDebugCoverageReport', 'adbResetAnimationsGlobally', '-Pjenkins' ]
+test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), 'clean', 'adbDisableAnimationsGlobally', 'createDebugCoverageReport', 'adbResetAnimationsGlobally', '-Pjenkins' ]
 if test_runner_arg is not None and test_runner_arg != "":
     test_runner_cmd = test_runner_cmd + [ test_runner_arg ]
 

--- a/buildScripts/build_helper_run_unit_tests
+++ b/buildScripts/build_helper_run_unit_tests
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """ <test_filter>
+
+This scripts runs all the local unit tests for the debug flavor.
+A filter can be passed as single argument which is then passed as
+'--tests <filter>' parameter.
+See: https://docs.gradle.org/current/userguide/java_testing.html#test_filtering
+
+The environment variable ANDROID_SDK_ROOT needs to be set.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count_min=0, valid_param_count_max=1, usage_func=usage)
+
+## RUN tests
+test_runner_cmd = [ build_helper_functions.get_relative_gradle_name(), '-Pjenkins', 'clean', 'testDebug' ]
+## pass filter if argument is given
+if len(sys.argv) > 1:
+    test_runner_cmd = test_runner_cmd + [ '--tests', sys.argv[1] ]
+
+print("Calling: " + " ".join(test_runner_cmd))
+return_code = subprocess.run( test_runner_cmd, cwd=os.environ['REPO_DIR'] ).returncode
+sys.exit(return_code)

--- a/buildScripts/build_step_run_unit_tests__all_tests
+++ b/buildScripts/build_step_run_unit_tests__all_tests
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+This script is a simple wrapper for the build_helper_run_unit_tests which
+allows to add a test-filter, but currently all tests are run.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+# Run Unit and device tests for all tests
+test_runner_cmd = build_helper_functions.get_build_scripts_executable('build_helper_run_unit_tests')
+
+print("Calling: " + " ".join(test_runner_cmd))
+return_code = subprocess.run( test_runner_cmd ).returncode
+sys.exit(return_code)


### PR DESCRIPTION
Run local unit tests in separate build step.
Run local unit tests only for debug variant, otherwise the tests run twice (for debug and release) and so they are also reported twice.
Merging of coverage reports are not supported out of the box or via the plugin. So do not report coverage for the unit tests at the moment.