### PR TITLE
PAINT 275: rewrite or drop idnored tests

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ActivityOpenedFromPocketCodeTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ActivityOpenedFromPocketCodeTest.java
@@ -33,7 +33,6 @@ import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -114,24 +113,6 @@ public class ActivityOpenedFromPocketCodeTest {
 
 		assertThat("Image modification not saved", imageFile.lastModified(), greaterThan(lastModifiedBefore));
 		assertThat("Saved image length not changed", imageFile.length(), greaterThan(fileSizeBefore));
-	}
-
-	@Test
-	@Ignore //TODO: does export still exist?
-	public void testExportNotTouchingOriginal() {
-		onDrawingSurfaceView()
-				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
-
-		onNavigationDrawer()
-				.performOpen();
-
-		long lastModifiedBefore = imageFile.lastModified();
-		long fileSizeBefore = imageFile.length();
-
-		onView(withText(R.string.menu_export)).perform(click());
-
-		assertThat("Image modified", imageFile.lastModified(), equalTo(lastModifiedBefore));
-		assertThat("Saved image length changed", imageFile.length(), equalTo(fileSizeBefore));
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
@@ -41,7 +41,6 @@ import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,14 +68,12 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getWorkingBitmap;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.resetColorPicker;
-import static org.catrobat.paintroid.test.espresso.util.UiInteractions.swipe;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.NavigationDrawerInteraction.onNavigationDrawer;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -484,69 +481,6 @@ public class MenuFileActivityIntegrationTest {
 
 		onDrawingSurfaceView()
 				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE);
-	}
-
-	@Test
-	@Ignore // TODO: fails, File is still the same
-	public void testSaveLoadedImage() {
-
-		// Save new image, stub ACTION_GET_CONTENT intent
-		Intent intent = new Intent();
-		intent.setData(MainActivity.savedPictureUri);
-		Instrumentation.ActivityResult result = new Instrumentation.ActivityResult(Activity.RESULT_OK, intent);
-		intending(hasAction(Intent.ACTION_GET_CONTENT)).respondWith(result);
-
-		onDrawingSurfaceView()
-				.perform(swipe(DrawingSurfaceLocationProvider.MIDDLE, DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
-
-		onNavigationDrawer()
-				.performOpen();
-
-		onView(withText(R.string.menu_save_image)).perform(click());
-
-		assertNotNull("Saved picture uri is null", MainActivity.savedPictureUri);
-
-		addUriToDeletionFileList(MainActivity.savedPictureUri);
-
-		// Load the saved image
-		onNavigationDrawer()
-				.performOpen();
-
-		onView(withText(R.string.menu_load_image)).perform(click());
-
-		assertTrue("Save copy flag not true", launchActivityRule.getActivity().copySaved);
-
-		onNavigationDrawer()
-				.performOpen();
-
-		// Save copy of image
-		onView(withText(R.string.menu_save_copy)).perform(click());
-
-		assertNotNull("Saved picture uri is null", MainActivity.savedPictureUri);
-
-		addUriToDeletionFileList(MainActivity.savedPictureUri);
-
-		File saveFile = new File(MainActivity.savedPictureUri.getPath());
-
-		final long oldLength = saveFile.length();
-		final long firstModified = saveFile.lastModified();
-
-		// Draw and save image
-		onDrawingSurfaceView()
-				.perform(swipe(DrawingSurfaceLocationProvider.MIDDLE, DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_MIDDLE));
-
-		onNavigationDrawer()
-				.performOpen();
-
-		onView(withText(R.string.menu_save_image)).perform(click());
-
-		File actualSaveFile = new File(MainActivity.savedPictureUri.getPath());
-
-		long newLength = actualSaveFile.length();
-		long lastModified = actualSaveFile.lastModified();
-
-		assertNotEquals("File is still the same", oldLength, newLength);
-		assertNotEquals("File not currently modified", firstModified, lastModified);
 	}
 
 	private void addUriToDeletionFileList(Uri uri) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ScrollingViewIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ScrollingViewIntegrationTest.java
@@ -9,7 +9,6 @@ import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.test.espresso.util.UiInteractions;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,7 +16,6 @@ import org.junit.runner.RunWith;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 
-import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.clickSelectedToolButton;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getActionbarHeight;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getCanvasPointFromSurfacePoint;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getStatusbarHeight;
@@ -101,66 +99,6 @@ public class ScrollingViewIntegrationTest {
 //		dragAndCheckIfCanvasHasMovedInXAndY(bottomLeft, middle);
 //		dragAndCheckIfCanvasHasMovedInXAndY(middle, topLeft);
 //		dragAndCheckIfCanvasHasMovedInXAndY(topLeft, middle);
-	}
-
-	@Ignore
-	@Test
-	public void testScrollingViewRectTool() throws NoSuchFieldException, IllegalAccessException {
-
-		final int perspectiveScale = 5;
-		PaintroidApplication.perspective.setScale(perspectiveScale);
-
-		float surfaceWidth = getSurfaceWidth();
-		float surfaceHeight = getSurfaceHeight();
-
-		float distanceToLayerView = 60;
-		float distanceToNavigationDrawer = 60;
-		float xRight = surfaceWidth - distanceToLayerView;
-		float xLeft = distanceToNavigationDrawer;
-		float xMiddle = surfaceWidth / 2;
-
-		final float actionBarHeight = getActionbarHeight();
-		final float statusBarHeight = getStatusbarHeight();
-
-		float yMiddle = (surfaceHeight / 2 + actionBarHeight + statusBarHeight);
-		float yTop = (actionBarHeight + statusBarHeight);
-		float yBottom = surfaceHeight + yTop - 1;
-
-		PointF middle = new PointF(xMiddle, yMiddle);
-		PointF rightMiddle = new PointF(xRight, yMiddle);
-		PointF leftMiddle = new PointF(xLeft, yMiddle);
-		PointF topMiddle = new PointF(xMiddle, yTop);
-		PointF bottomMiddle = new PointF(xMiddle, yBottom);
-		PointF topLeft = new PointF(xLeft, yTop);
-		PointF bottomRight = new PointF(xRight, yBottom);
-		PointF bottomLeft = new PointF(xLeft, yBottom);
-		PointF topRight = new PointF(xRight, yTop);
-
-		selectTool(ToolType.SHAPE);
-		clickSelectedToolButton();
-
-		dragAndCheckIfCanvasHasMovedInXOrY(middle, rightMiddle);
-		dragAndCheckIfCanvasHasMovedInXOrY(rightMiddle, middle);
-		dragAndCheckIfCanvasHasMovedInXOrY(middle, leftMiddle);
-		dragAndCheckIfCanvasHasMovedInXOrY(leftMiddle, middle);
-		dragAndCheckIfCanvasHasMovedInXOrY(middle, topMiddle);
-		dragAndCheckIfCanvasHasMovedInXOrY(topMiddle, middle);
-		dragAndCheckIfCanvasHasMovedInXOrY(middle, bottomMiddle);
-		dragAndCheckIfCanvasHasMovedInXOrY(bottomMiddle, middle);
-
-		dragAndCheckIfCanvasHasMovedInXAndY(middle, topRight);
-		dragAndCheckIfCanvasHasMovedInXAndY(topRight, middle);
-		dragAndCheckIfCanvasHasMovedInXAndY(middle, bottomRight);
-		dragAndCheckIfCanvasHasMovedInXAndY(bottomRight, middle);
-		dragAndCheckIfCanvasHasMovedInXAndY(middle, bottomLeft);
-		dragAndCheckIfCanvasHasMovedInXAndY(bottomLeft, middle);
-		dragAndCheckIfCanvasHasMovedInXAndY(middle, topLeft);
-		dragAndCheckIfCanvasHasMovedInXAndY(topLeft, middle);
-
-		/*dragAndCheckIfCanvasHasNotMoved(topLeft, topRight);
-		dragAndCheckIfCanvasHasNotMoved(bottomRight, topRight);
-		dragAndCheckIfCanvasHasNotMoved(bottomRight, bottomLeft);
-		dragAndCheckIfCanvasHasNotMoved(topLeft, bottomLeft);*/
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
@@ -40,7 +40,6 @@ import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,7 +61,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class ToolSelectionIntegrationTest {
@@ -198,21 +196,6 @@ public class ToolSelectionIntegrationTest {
 		onToolBarView().performSelectTool(ToolType.TRANSFORM);
 
 		assertFalse("Tool button should be most right", scrollView.canScrollHorizontally(scrollRight));
-	}
-
-	// TODO: how to implement?
-	@Test
-	@Ignore
-	public void testToolSelectionStartAnimation() {
-		int scrollX = scrollView.getScrollX();
-		assertTrue("Scroll position should be > 0 at start", scrollX > 0);
-
-		for (int i = 0; i < 5; i++) {
-			assertTrue(scrollView.getScrollX() <= scrollX);
-			scrollX = scrollView.getScrollX();
-		}
-
-		assertEquals("Animation should be finished after a second", 0, scrollX);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
@@ -37,7 +37,6 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -113,7 +112,7 @@ public class RectangleFillToolIntegrationTest {
 	 * Fails if whole espresso tests run, there lives an artifact in drawing surface:
 	 * AssertionError: expected:<0> but was:<-16777216>
 	 */
-	@Ignore
+	//@Ignore
 	@Test
 	public void testEllipseIsDrawnOnBitmap() {
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
@@ -42,7 +42,6 @@ import org.catrobat.paintroid.tools.implementation.BaseToolWithShape;
 import org.catrobat.paintroid.tools.implementation.TransformTool;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -458,12 +457,11 @@ public class TransformToolIntegrationTest {
 				.checkBitmapDimension(initialWidth, initialHeight);
 	}
 
-	@Ignore("This is probably not intended behaviour")
 	@Test
 	public void testCenterBitmapAfterCropAndUndo() {
-		final PointF originalTopLeft = getSurfacePointFromCanvasPoint(new PointF(0, 0));
+	/*	final PointF originalTopLeft = getSurfacePointFromCanvasPoint(new PointF(0, 0));
 		final PointF originalBottomRight = getSurfacePointFromCanvasPoint(
-				new PointF(initialWidth - 1, initialHeight - 1));
+				new PointF(initialWidth - 1, initialHeight - 1));*/
 
 		drawPlus(getWorkingBitmap(), initialWidth / 2);
 
@@ -478,27 +476,31 @@ public class TransformToolIntegrationTest {
 
 		final Bitmap croppedBitmap = getWorkingBitmap();
 
-		final PointF topLeft = getSurfacePointFromCanvasPoint(new PointF(0, 0));
+	/*	final PointF topLeft = getSurfacePointFromCanvasPoint(new PointF(0, 0));
 		final PointF bottomRight = getSurfacePointFromCanvasPoint(
-				new PointF(croppedBitmap.getWidth(), croppedBitmap.getHeight()));
+				new PointF(croppedBitmap.getWidth(), croppedBitmap.getHeight()));*/
 
 		assertThat(initialHeight, greaterThan(croppedBitmap.getHeight()));
 		assertThat(initialWidth, greaterThan(croppedBitmap.getWidth()));
 
-		assertThat(topLeft.x, greaterThan(originalTopLeft.x));
+		/*assertThat(topLeft.x, greaterThan(originalTopLeft.x));
 		assertThat(topLeft.y, greaterThan(originalTopLeft.y));
 		assertThat(bottomRight.x, lessThan(originalBottomRight.x));
-		assertThat(bottomRight.y, lessThan(originalBottomRight.y));
+		assertThat(bottomRight.y, lessThan(originalBottomRight.y));*/
 
 		onTopBarView()
 				.performUndo();
 
-		final PointF undoTopLeft = getSurfacePointFromCanvasPoint(new PointF(0, 0));
+		//PaintroidApplication.perspective.setScale(50);
+
+		/*final PointF undoTopLeft = getSurfacePointFromCanvasPoint(new PointF(0, 0));
 		final PointF undoBottomRight = getSurfacePointFromCanvasPoint(
 				new PointF(initialWidth - 1, initialHeight - 1));
-
 		assertEquals(undoTopLeft, originalTopLeft);
-		assertEquals(undoBottomRight, originalBottomRight);
+		assertEquals(undoBottomRight, originalBottomRight);*/
+		Bitmap undoBitmap = getWorkingBitmap();
+		assertEquals("undoBitmap.getHeight should be initialHeight", undoBitmap.getHeight(), initialHeight);
+		assertEquals("undoBitmap.getWidth should be initialWidth", undoBitmap.getWidth(), initialWidth);
 	}
 
 	@Test


### PR DESCRIPTION
deleted tests: 
testExportNotTouchingOriginal() in ActivityOpenedFromPocketCodeTest.java
testSaveLoadedImage() in MenuFileActivityIntegrationTest.java
testScrollingViewRectTool() in ScrollingViewIntegrationTest.java
testToolSelectionStartAnimation() in ToolSelectionIntegrationTest.java

rewritten tests:
testCenterBitmapAfterCropAndUndo() in TransformToolIntegrationTest.java

testEllipseIsDrawnOnBitmap() in RectangleFillToolIntegrationTest.java works without chnging anything