### PR TITLE
PAINT-305: Remove observers

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/PathCommandTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/PathCommandTest.java
@@ -22,17 +22,11 @@ package org.catrobat.paintroid.test.junit.command;
 import android.graphics.Path;
 import android.graphics.RectF;
 
-import org.catrobat.paintroid.command.Command;
-import org.catrobat.paintroid.command.implementation.BaseCommand;
 import org.catrobat.paintroid.command.implementation.PathCommand;
+import org.catrobat.paintroid.common.CommonFactory;
 import org.catrobat.paintroid.test.utils.PaintroidAsserts;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Observable;
-import java.util.Observer;
-
-import static org.junit.Assert.assertTrue;
 
 public class PathCommandTest extends CommandTestSetup {
 
@@ -43,7 +37,7 @@ public class PathCommandTest extends CommandTestSetup {
 		Path pathUnderTest = new Path();
 		pathUnderTest.moveTo(1, 0);
 		pathUnderTest.lineTo(1, canvasBitmapUnderTest.getHeight());
-		commandUnderTest = new PathCommand(paintUnderTest, pathUnderTest);
+		commandUnderTest = new PathCommand(paintUnderTest, pathUnderTest, new CommonFactory());
 	}
 
 	@Test
@@ -56,13 +50,9 @@ public class PathCommandTest extends CommandTestSetup {
 		float bottom = canvasBitmapUnderTest.getHeight() + 100;
 		path.addRect(new RectF(left, top, right, bottom), Path.Direction.CW);
 
-		commandUnderTest = new PathCommand(paintUnderTest, path);
+		commandUnderTest = new PathCommand(paintUnderTest, path, new CommonFactory());
 
-		CommandManagerMockup commandManagerMockup = new CommandManagerMockup();
-		commandManagerMockup.testCommand(commandUnderTest);
 		commandUnderTest.run(canvasUnderTest, null);
-
-		assertTrue("PathCommand should have failed but didn't get deleted", commandManagerMockup.gotDeleted);
 	}
 
 	@Test
@@ -75,22 +65,5 @@ public class PathCommandTest extends CommandTestSetup {
 		}
 		commandUnderTest.run(canvasUnderTest, null);
 		PaintroidAsserts.assertBitmapEquals(bitmapUnderTest, canvasBitmapUnderTest);
-	}
-
-	private class CommandManagerMockup implements Observer {
-		boolean gotDeleted = false;
-
-		void testCommand(Command command) {
-			((BaseCommand) command).addObserver(this);
-		}
-
-		@Override
-		public void update(Observable observable, Object data) {
-			if (data instanceof BaseCommand.NotifyStates
-					&& BaseCommand.NotifyStates.COMMAND_FAILED == data
-					&& observable instanceof Command) {
-				gotDeleted = true;
-			}
-		}
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTests.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTests.java
@@ -33,7 +33,8 @@ import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.command.implementation.FillCommand;
 import org.catrobat.paintroid.model.Layer;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.helper.FillAlgorithm;
+import org.catrobat.paintroid.tools.helper.JavaFillAlgorithm;
+import org.catrobat.paintroid.tools.helper.NativeFillAlgorithm;
 import org.catrobat.paintroid.tools.implementation.BaseTool;
 import org.catrobat.paintroid.tools.implementation.FillTool;
 import org.junit.After;
@@ -95,7 +96,8 @@ public class FillToolTests {
 		int targetColor = 16777215;
 		int replacementColor = 0;
 
-		FillAlgorithm fillAlgorithm = new FillAlgorithm(bitmap, clickedPixel, targetColor, replacementColor, HALF_TOLERANCE);
+		JavaFillAlgorithm fillAlgorithm = new JavaFillAlgorithm();
+		fillAlgorithm.setParameters(bitmap, clickedPixel, targetColor, replacementColor, HALF_TOLERANCE);
 
 		int[][] algorithmPixels = fillAlgorithm.pixels;
 		assertEquals("Wrong array size", height, algorithmPixels.length);
@@ -128,7 +130,7 @@ public class FillToolTests {
 		Paint paint = new Paint();
 		paint.setColor(targetColor);
 
-		FillCommand fillCommand = new FillCommand(clickedPixel, paint, NO_TOLERANCE);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, NO_TOLERANCE);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		int[][] pixels = getPixelsFromBitmap(bitmap);
@@ -160,7 +162,7 @@ public class FillToolTests {
 		pixels[1][0] = boundaryColor;
 		putPixelsToBitmap(bitmap, pixels);
 
-		FillCommand fillCommand = new FillCommand(clickedPixel, paint, NO_TOLERANCE);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, NO_TOLERANCE);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		pixels = getPixelsFromBitmap(bitmap);
@@ -201,7 +203,7 @@ public class FillToolTests {
 		pixels[1][0] = boundaryColor;
 		putPixelsToBitmap(bitmap, pixels);
 
-		FillCommand fillCommand = new FillCommand(clickedPixel, paint, MAX_TOLERANCE);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, MAX_TOLERANCE);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		pixels = getPixelsFromBitmap(bitmap);
@@ -234,7 +236,7 @@ public class FillToolTests {
 		pixels[1][0] = boundaryColor;
 		putPixelsToBitmap(bitmap, pixels);
 
-		FillCommand fillCommand = new FillCommand(clickedPixel, paint, MAX_TOLERANCE - 1);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, MAX_TOLERANCE - 1);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		pixels = getPixelsFromBitmap(bitmap);
@@ -269,7 +271,7 @@ public class FillToolTests {
 		pixels[boundaryPixel.x][boundaryPixel.y] = boundaryColor;
 		putPixelsToBitmap(bitmap, pixels);
 
-		FillCommand fillCommand = new FillCommand(clickedPixel, paint, HALF_TOLERANCE);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, HALF_TOLERANCE);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		pixels = getPixelsFromBitmap(bitmap);
@@ -308,7 +310,7 @@ public class FillToolTests {
 		Point boundaryPixel = new Point(width / 2, height / 4);
 		pixels[boundaryPixel.y][boundaryPixel.x] = boundaryColor;
 		putPixelsToBitmap(bitmap, pixels);
-		FillCommand fillCommand = new FillCommand(topLeftQuarterPixel, paint, HALF_TOLERANCE);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), topLeftQuarterPixel, paint, HALF_TOLERANCE);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		int[][] actualPixels = getPixelsFromBitmap(bitmap);
@@ -341,7 +343,7 @@ public class FillToolTests {
 		paint.setColor(targetColor);
 
 		putPixelsToBitmap(bitmap, pixels);
-		FillCommand fillCommand = new FillCommand(clickedPixel, paint, HALF_TOLERANCE);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, HALF_TOLERANCE);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		int[][] actualPixels = getPixelsFromBitmap(bitmap);
@@ -384,7 +386,7 @@ public class FillToolTests {
 			PaintroidApplication.layerModel.getCurrentLayer().setBitmap(bitmap);
 			bitmap.eraseColor(replacementColor);
 			putPixelsToBitmap(bitmap, pixels);
-			FillCommand fillCommand = new FillCommand(clickedPixel, paint, HALF_TOLERANCE);
+			FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, HALF_TOLERANCE);
 			fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 			int[][] actualPixels = getPixelsFromBitmap(bitmap);
@@ -418,7 +420,7 @@ public class FillToolTests {
 		PaintroidApplication.layerModel.getCurrentLayer().setBitmap(bitmap);
 		bitmap.eraseColor(replacementColor);
 		putPixelsToBitmap(bitmap, pixels);
-		FillCommand fillCommand = new FillCommand(clickedPixel, paint, HALF_TOLERANCE);
+		FillCommand fillCommand = new FillCommand(new NativeFillAlgorithm(), clickedPixel, paint, HALF_TOLERANCE);
 		fillCommand.run(new Canvas(), PaintroidApplication.layerModel);
 
 		int[][] actualPixels = getPixelsFromBitmap(bitmap);

--- a/Paintroid/src/main/cpp/native-lib.cpp
+++ b/Paintroid/src/main/cpp/native-lib.cpp
@@ -232,7 +232,7 @@ private:
 
 extern "C"
 JNIEXPORT void JNICALL
-Java_org_catrobat_paintroid_command_implementation_FillCommand_performFilling(JNIEnv *env,
+Java_org_catrobat_paintroid_tools_helper_NativeFillAlgorithm_performFilling(JNIEnv *env,
 																	  jobject obj,
 																	  jintArray arr,
 																	  jint x_start,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -61,6 +61,8 @@ import org.catrobat.paintroid.command.CommandFactory;
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.command.implementation.AsyncCommandManager;
 import org.catrobat.paintroid.command.implementation.DefaultCommandFactory;
+import org.catrobat.paintroid.command.implementation.DefaultCommandManager;
+import org.catrobat.paintroid.common.CommonFactory;
 import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.dialog.CustomAlertDialogBuilder;
 import org.catrobat.paintroid.dialog.DialogAbout;
@@ -221,7 +223,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
 			DisplayMetrics metrics = getResources().getDisplayMetrics();
 
-			CommandManager commandManager = new AsyncCommandManager();
+			CommandManager synchronousCommandManager = new DefaultCommandManager(new CommonFactory(), PaintroidApplication.layerModel);
+			CommandManager commandManager = new AsyncCommandManager(synchronousCommandManager, PaintroidApplication.layerModel);
 			Command initCommand = commandFactory.createInitCommand(metrics.widthPixels, metrics.heightPixels);
 			commandManager.setInitialStateCommand(initCommand);
 			commandManager.reset();
@@ -485,7 +488,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 		if (changeToToolType == ToolType.IMPORTPNG) {
 			Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 			intent.setType("image/*");
-			intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+			setNewDocumentFlags(intent);
 			startActivityForResult(intent, REQUEST_CODE_IMPORTPNG);
 			return;
 		}
@@ -643,8 +646,16 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 	private void startLoadImageIntent() {
 		Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 		intent.setType("image/*");
-		intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+		setNewDocumentFlags(intent);
 		startActivityForResult(intent, REQUEST_CODE_LOAD_PICTURE);
+	}
+
+	private static void setNewDocumentFlags(Intent intent) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+			intent.setFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
+		} else {
+			intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+		}
 	}
 
 	protected void newImage() {
@@ -742,7 +753,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 				cameraImageUri = uri;
 				Intent intent = new Intent("android.media.action.IMAGE_CAPTURE");
 				intent.putExtra(MediaStore.EXTRA_OUTPUT, cameraImageUri);
-				intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+				setNewDocumentFlags(intent);
 				startActivityForResult(intent, REQUEST_CODE_TAKE_PICTURE);
 				break;
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.java
@@ -21,6 +21,8 @@ package org.catrobat.paintroid.command;
 
 import android.graphics.Bitmap;
 import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Point;
 import android.graphics.PointF;
 
 import org.catrobat.paintroid.command.implementation.FlipCommand.FlipDirection;
@@ -50,5 +52,13 @@ public interface CommandFactory {
 			int resizeCoordinateXRight, int resizeCoordinateYBottom,
 			int maximumBitmapResolution);
 
-	Command createPointCommand(Paint bitmapPaint, PointF coordinate);
+	Command createPointCommand(Paint paint, PointF coordinate);
+
+	Command createFillCommand(int x, int y, Paint paint, float colorTolerance);
+
+	Command createGeometricFillCommand(Bitmap bitmap, Point position, float boxWidth, float boxHeight, float boxRotation, Paint paint);
+
+	Command createPathCommand(Paint paint, Path path);
+
+	Command createTextToolCommand(String[] multilineText, Paint textPaint, int boxOffset, float boxWidth, float boxHeight, PointF toolPosition, float boxRotation);
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.java
@@ -21,10 +21,8 @@ package org.catrobat.paintroid.command.implementation;
 
 import android.os.AsyncTask;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.common.CommonFactory;
 import org.catrobat.paintroid.contract.LayerContracts;
 
 import java.util.ArrayList;
@@ -32,8 +30,14 @@ import java.util.List;
 
 public class AsyncCommandManager implements CommandManager {
 	private List<CommandListener> commandListeners = new ArrayList<>();
-	private CommandManager commandManager = new DefaultCommandManager(new CommonFactory());
+	private CommandManager commandManager;
+	private final LayerContracts.Model layerModel;
 	private boolean running = true;
+
+	public AsyncCommandManager(CommandManager commandManager, LayerContracts.Model layerModel) {
+		this.commandManager = commandManager;
+		this.layerModel = layerModel;
+	}
 
 	@Override
 	public void addCommandListener(CommandListener commandListener) {
@@ -66,8 +70,7 @@ public class AsyncCommandManager implements CommandManager {
 			@Override
 			protected Void doInBackground(Void... voids) {
 				if (running) {
-					final LayerContracts.Model model = PaintroidApplication.layerModel;
-					synchronized (model) {
+					synchronized (layerModel) {
 						commandManager.addCommand(command);
 					}
 				}
@@ -92,8 +95,7 @@ public class AsyncCommandManager implements CommandManager {
 			@Override
 			protected Void doInBackground(Void... voids) {
 				if (running) {
-					final LayerContracts.Model model = PaintroidApplication.layerModel;
-					synchronized (model) {
+					synchronized (layerModel) {
 						commandManager.undo();
 					}
 				}
@@ -119,8 +121,7 @@ public class AsyncCommandManager implements CommandManager {
 			@Override
 			protected Void doInBackground(Void... voids) {
 				if (running) {
-					final LayerContracts.Model model = PaintroidApplication.layerModel;
-					synchronized (model) {
+					synchronized (layerModel) {
 						commandManager.redo();
 					}
 				}
@@ -136,8 +137,7 @@ public class AsyncCommandManager implements CommandManager {
 
 	@Override
 	public void reset() {
-		final LayerContracts.Model model = PaintroidApplication.layerModel;
-		synchronized (model) {
+		synchronized (layerModel) {
 			commandManager.reset();
 		}
 		notifyCommandPostExecute();
@@ -150,8 +150,7 @@ public class AsyncCommandManager implements CommandManager {
 
 	@Override
 	public void setInitialStateCommand(Command command) {
-		final LayerContracts.Model model = PaintroidApplication.layerModel;
-		synchronized (model) {
+		synchronized (layerModel) {
 			commandManager.setInitialStateCommand(command);
 		}
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/BaseCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/BaseCommand.java
@@ -31,10 +31,9 @@ import org.catrobat.paintroid.command.Command;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Observable;
 import java.util.Random;
 
-public abstract class BaseCommand extends Observable implements Command {
+public abstract class BaseCommand implements Command {
 	private static final String TAG = BaseCommand.class.getSimpleName();
 	@VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
 	public Paint paint;
@@ -84,11 +83,6 @@ public abstract class BaseCommand extends Observable implements Command {
 		}
 		bitmap.recycle();
 		bitmap = null;
-	}
-
-	protected void notifyStatus(NotifyStates state) {
-		setChanged();
-		notifyObservers(state);
 	}
 
 	public enum NotifyStates {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.java
@@ -21,7 +21,6 @@ package org.catrobat.paintroid.command.implementation;
 
 import android.graphics.Canvas;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.common.CommonFactory;
@@ -38,10 +37,13 @@ public class DefaultCommandManager implements CommandManager {
 	private Deque<Command> redoCommandList = new ArrayDeque<>();
 	private Deque<Command> undoCommandList = new ArrayDeque<>();
 	private Command initialStateCommand;
-	private CommonFactory commonFactory;
 
-	public DefaultCommandManager(CommonFactory commonFactory) {
+	private final CommonFactory commonFactory;
+	private final LayerContracts.Model layerModel;
+
+	public DefaultCommandManager(CommonFactory commonFactory, LayerContracts.Model layerModel) {
 		this.commonFactory = commonFactory;
+		this.layerModel = layerModel;
 	}
 
 	@Override
@@ -69,7 +71,6 @@ public class DefaultCommandManager implements CommandManager {
 		redoCommandList.clear();
 		undoCommandList.addFirst(command);
 
-		LayerContracts.Model layerModel = PaintroidApplication.layerModel;
 		LayerContracts.Layer currentLayer = layerModel.getCurrentLayer();
 		Canvas canvas = commonFactory.createCanvas();
 		canvas.setBitmap(currentLayer.getBitmap());
@@ -83,7 +84,6 @@ public class DefaultCommandManager implements CommandManager {
 		Command command = undoCommandList.pop();
 		redoCommandList.addFirst(command);
 
-		LayerContracts.Model layerModel = PaintroidApplication.layerModel;
 		layerModel.reset();
 
 		Canvas canvas = commonFactory.createCanvas();
@@ -107,7 +107,6 @@ public class DefaultCommandManager implements CommandManager {
 		Command command = redoCommandList.pop();
 		undoCommandList.addFirst(command);
 
-		LayerContracts.Model layerModel = PaintroidApplication.layerModel;
 		LayerContracts.Layer currentLayer = layerModel.getCurrentLayer();
 		Canvas canvas = commonFactory.createCanvas();
 		canvas.setBitmap(currentLayer.getBitmap());
@@ -120,8 +119,6 @@ public class DefaultCommandManager implements CommandManager {
 	public void reset() {
 		undoCommandList.clear();
 		redoCommandList.clear();
-
-		LayerContracts.Model layerModel = PaintroidApplication.layerModel;
 		layerModel.reset();
 
 		if (initialStateCommand != null) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/GeometricFillCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/GeometricFillCommand.java
@@ -22,55 +22,33 @@ package org.catrobat.paintroid.command.implementation;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.graphics.Point;
 import android.graphics.RectF;
 
 import org.catrobat.paintroid.contract.LayerContracts;
 
 public class GeometricFillCommand extends BaseCommand {
-	protected final Point coordinates;
-	protected final float boxWidth;
-	protected final float boxHeight;
-	protected final float boxRotation;
-	protected final RectF boxRect;
+	private final float boxRotation;
+	private final RectF boxRect;
+	private final int pointX;
+	private final int pointY;
+	private final Paint geometricFillPaint;
 
-	protected Paint geometricFillPaint;
-
-	public GeometricFillCommand(Bitmap bitmap, Point position, float width, float height,
-			float rotation, Paint paint) {
-		super(new Paint(Paint.DITHER_FLAG));
-
-		coordinates = position != null ? new Point(position.x, position.y) : null;
-		if (bitmap != null) {
-			this.bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true);
-		}
-		boxWidth = width;
-		boxHeight = height;
-		boxRotation = rotation;
-		boxRect = new RectF(-boxWidth / 2f, -boxHeight / 2f, boxWidth / 2f,
-				boxHeight / 2f);
-		geometricFillPaint = new Paint(paint);
+	public GeometricFillCommand(Bitmap bitmap, int pointX, int pointY, RectF boxRect,
+			float boxRotation, Paint paint) {
+		this.pointX = pointX;
+		this.pointY = pointY;
+		this.boxRect = boxRect;
+		this.bitmap = bitmap;
+		this.boxRotation = boxRotation;
+		geometricFillPaint = paint;
 	}
 
 	@Override
 	public void run(Canvas canvas, LayerContracts.Model layerModel) {
-
-		notifyStatus(NotifyStates.COMMAND_STARTED);
-
-		if (bitmap == null) {
-			setChanged();
-			notifyStatus(NotifyStates.COMMAND_FAILED);
-			return;
-		}
-
 		canvas.save();
-		canvas.translate(coordinates.x, coordinates.y);
+		canvas.translate(pointX, pointY);
 		canvas.rotate(boxRotation);
-
 		canvas.drawBitmap(bitmap, null, boxRect, geometricFillPaint);
-
 		canvas.restore();
-
-		notifyStatus(NotifyStates.COMMAND_DONE);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadCommand.java
@@ -22,27 +22,27 @@ package org.catrobat.paintroid.command.implementation;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 
+import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.contract.LayerContracts;
 import org.catrobat.paintroid.model.Layer;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
 
-public class LoadCommand extends BaseCommand {
-
+public class LoadCommand implements Command {
 	private Bitmap loadedImage;
 
 	public LoadCommand(Bitmap newBitmap) {
-		loadedImage = newBitmap.copy(ARGB_8888, false);
+		loadedImage = newBitmap;
 	}
 
 	@Override
 	public void run(Canvas canvas, LayerContracts.Model layerModel) {
-		notifyStatus(NotifyStates.COMMAND_STARTED);
-
 		Layer currentLayer = new Layer(loadedImage.copy(ARGB_8888, true));
-		layerModel.getLayers().add(currentLayer);
+		layerModel.addLayerAt(0, currentLayer);
 		layerModel.setCurrentLayer(currentLayer);
+	}
 
-		notifyStatus(NotifyStates.COMMAND_DONE);
+	@Override
+	public void freeResources() {
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/StampCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/StampCommand.java
@@ -54,14 +54,11 @@ public class StampCommand extends BaseCommand {
 	@Override
 	public void run(Canvas canvas, LayerContracts.Model layerModel) {
 
-		notifyStatus(NotifyStates.COMMAND_STARTED);
 		if (fileToStoredBitmap != null) {
 			bitmap = FileIO.getBitmapFromFile(fileToStoredBitmap);
 		}
 
 		if (bitmap == null) {
-			setChanged();
-			notifyStatus(NotifyStates.COMMAND_FAILED);
 			return;
 		}
 
@@ -78,7 +75,5 @@ public class StampCommand extends BaseCommand {
 			bitmap.recycle();
 			bitmap = null;
 		}
-
-		notifyStatus(NotifyStates.COMMAND_DONE);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/TextToolCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/TextToolCommand.java
@@ -25,35 +25,31 @@ import android.graphics.Paint;
 import android.graphics.PointF;
 import android.graphics.Rect;
 
+import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.contract.LayerContracts;
 
-public class TextToolCommand extends BaseCommand {
-	protected final String[] multilineText;
-	protected final Paint textPaint;
-	protected final float boxOffset;
-	protected final float boxWidth;
-	protected final float boxHeight;
-	protected final PointF toolPosition;
-	protected final float rotationAngle;
+public class TextToolCommand implements Command {
+	private final String[] multilineText;
+	private final Paint textPaint;
+	private final float boxOffset;
+	private final float boxWidth;
+	private final float boxHeight;
+	private final PointF toolPosition;
+	private final float rotationAngle;
 
 	public TextToolCommand(String[] multilineText, Paint textPaint, float boxOffset,
 			float boxWidth, float boxHeight, PointF toolPosition, float rotationAngle) {
-		super(new Paint());
-
-		this.multilineText = new String[multilineText.length];
-		System.arraycopy(multilineText, 0, this.multilineText, 0, this.multilineText.length);
-		this.textPaint = new Paint(textPaint);
+		this.multilineText = multilineText.clone();
+		this.textPaint = textPaint;
 		this.boxOffset = boxOffset;
 		this.boxWidth = boxWidth;
 		this.boxHeight = boxHeight;
-		this.toolPosition = new PointF(toolPosition.x, toolPosition.y);
+		this.toolPosition = toolPosition;
 		this.rotationAngle = rotationAngle;
 	}
 
 	@Override
 	public void run(Canvas canvas, LayerContracts.Model layerModel) {
-		notifyStatus(NotifyStates.COMMAND_STARTED);
-
 		canvas.save();
 
 		canvas.translate(toolPosition.x, toolPosition.y);
@@ -88,7 +84,9 @@ public class TextToolCommand extends BaseCommand {
 		canvas.drawBitmap(textBitmap, srcRect, dstRect, textPaint);
 
 		canvas.restore();
+	}
 
-		notifyStatus(NotifyStates.COMMAND_DONE);
+	@Override
+	public void freeResources() {
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/CommonFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/CommonFactory.java
@@ -23,7 +23,10 @@ import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Point;
 import android.graphics.PointF;
+import android.graphics.RectF;
 
 public class CommonFactory {
 	public Canvas createCanvas() {
@@ -40,5 +43,21 @@ public class CommonFactory {
 
 	public PointF createPointF(PointF point) {
 		return new PointF(point.x, point.y);
+	}
+
+	public RectF createRectF(float left, float top, float right, float bottom) {
+		return new RectF(left, top, right, bottom);
+	}
+
+	public Point createPoint(int x, int y) {
+		return new Point(x, y);
+	}
+
+	public RectF createRectF() {
+		return new RectF();
+	}
+
+	public Path createPath(Path path) {
+		return new Path(path);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/FillAlgorithm.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/FillAlgorithm.java
@@ -1,184 +1,29 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.tools.helper;
 
 import android.graphics.Bitmap;
 import android.graphics.Point;
-import android.support.annotation.VisibleForTesting;
 
-import java.util.LinkedList;
-import java.util.Queue;
+public interface FillAlgorithm {
+	void setParameters(Bitmap bitmap, Point clickedPixel, int targetColor, int replacementColor, float colorToleranceThreshold);
 
-public class FillAlgorithm {
-	private static final boolean UP = true;
-	private static final boolean DOWN = false;
-
-	private Bitmap bitmap;
-	@VisibleForTesting
-	public int[][] pixels;
-	@VisibleForTesting
-	public Point clickedPixel;
-	@VisibleForTesting
-	public int targetColor;
-	@VisibleForTesting
-	public int replacementColor;
-	@VisibleForTesting
-	public int colorToleranceThresholdSquared;
-	private boolean considerTolerance;
-	private int width;
-	private int height;
-	@VisibleForTesting
-	public Queue<Range> ranges;
-	private boolean[][] filledPixels;
-
-	public FillAlgorithm(Bitmap bitmap, Point clickedPixel, int targetColor, int replacementColor, float colorToleranceThreshold) {
-		this.bitmap = bitmap;
-		width = bitmap.getWidth();
-		height = bitmap.getHeight();
-		pixels = new int[bitmap.getHeight()][bitmap.getWidth()];
-		for (int i = 0; i < height; i++) {
-			this.bitmap.getPixels(pixels[i], 0, width, 0, i, width, 1);
-		}
-		filledPixels = new boolean[bitmap.getHeight()][bitmap.getWidth()];
-		this.clickedPixel = clickedPixel;
-		this.targetColor = targetColor;
-		this.replacementColor = replacementColor;
-		ranges = new LinkedList<>();
-		colorToleranceThresholdSquared = (int) (colorToleranceThreshold * colorToleranceThreshold);
-		considerTolerance = colorToleranceThreshold > 0;
-	}
-
-	public void performFilling() {
-		Range range = generateRangeAndReplaceColor(clickedPixel.y, clickedPixel.x, UP);
-		ranges.add(range);
-		ranges.add(new Range(range.line, range.start, range.end, DOWN));
-
-		int row;
-		while (!ranges.isEmpty()) {
-			range = ranges.poll();
-
-			if (range.direction == UP) {
-				row = range.line - 1;
-				if (row >= 0) {
-					checkRangeAndGenerateNewRanges(range, row, UP);
-				}
-			} else {
-				row = range.line + 1;
-				if (row < height) {
-					checkRangeAndGenerateNewRanges(range, row, DOWN);
-				}
-			}
-		}
-	}
-
-	private Range generateRangeAndReplaceColor(int row, int col, boolean direction) {
-		Range range = new Range();
-		int i;
-		int start;
-
-		pixels[row][col] = targetColor;
-		filledPixels[row][col] = true;
-
-		for (i = col - 1; i >= 0; i--) {
-			if (!filledPixels[row][i] && (pixels[row][i] == replacementColor
-					|| (considerTolerance && isPixelWithinColorTolerance(pixels[row][i], replacementColor)))) {
-				pixels[row][i] = targetColor;
-				filledPixels[row][i] = true;
-			} else {
-				break;
-			}
-		}
-		start = i + 1;
-
-		for (i = col + 1; i < width; i++) {
-			if (!filledPixels[row][i] && (pixels[row][i] == replacementColor
-					|| (considerTolerance && isPixelWithinColorTolerance(pixels[row][i], replacementColor)))) {
-				pixels[row][i] = targetColor;
-				filledPixels[row][i] = true;
-			} else {
-				break;
-			}
-		}
-
-		range.line = row;
-		range.start = start;
-		range.end = i - 1;
-		range.direction = direction;
-
-		bitmap.setPixels(pixels[row], start, width, start, row, i - start, 1);
-
-		return range;
-	}
-
-	private void checkRangeAndGenerateNewRanges(Range range, int row, boolean directionUp) {
-		Range newRange;
-		for (int col = range.start; col <= range.end; col++) {
-			if (!filledPixels[row][col] && (pixels[row][col] == replacementColor
-					|| (considerTolerance && isPixelWithinColorTolerance(pixels[row][col], replacementColor)))) {
-				newRange = generateRangeAndReplaceColor(row, col, directionUp);
-				ranges.add(newRange);
-
-				if (newRange.start <= range.start - 2) {
-					ranges.add(new Range(row, newRange.start, range.start - 2, !directionUp));
-				}
-				if (newRange.end >= range.end + 2) {
-					ranges.add(new Range(row, range.end + 2, newRange.end, !directionUp));
-				}
-
-				if (newRange.end >= range.end - 1) {
-					break;
-				} else {
-					col = newRange.end + 1;
-				}
-			}
-		}
-	}
-
-	private boolean isPixelWithinColorTolerance(int pixel, int referenceColor) {
-		int redDiff = ((pixel >> 16) & 0xFF) - ((referenceColor >> 16) & 0xFF);
-		int greenDiff = ((pixel >> 8) & 0xFF) - ((referenceColor >> 8) & 0xFF);
-		int blueDiff = (pixel & 0xFF) - (referenceColor & 0xFF);
-		int alphaDiff = (pixel >>> 24) - (referenceColor >>> 24);
-
-		return redDiff * redDiff + greenDiff * greenDiff + blueDiff * blueDiff + alphaDiff * alphaDiff
-				<= colorToleranceThresholdSquared;
-	}
-
-	class Range {
-		public int line;
-		public int start;
-		public int end;
-		public boolean direction;
-
-		Range(int line, int start, int end, boolean directionUp) {
-			this.line = line;
-			this.start = start;
-			this.end = end;
-			this.direction = directionUp;
-		}
-
-		Range() {
-			this.line = 0;
-			this.start = 0;
-			this.end = 0;
-			this.direction = false;
-		}
-	}
+	void performFilling();
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/JavaFillAlgorithm.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/JavaFillAlgorithm.java
@@ -1,0 +1,186 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.tools.helper;
+
+import android.graphics.Bitmap;
+import android.graphics.Point;
+import android.support.annotation.VisibleForTesting;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class JavaFillAlgorithm implements FillAlgorithm {
+	private static final boolean UP = true;
+	private static final boolean DOWN = false;
+
+	private Bitmap bitmap;
+	@VisibleForTesting
+	public int[][] pixels;
+	@VisibleForTesting
+	public Point clickedPixel;
+	@VisibleForTesting
+	public int targetColor;
+	@VisibleForTesting
+	public int replacementColor;
+	@VisibleForTesting
+	public int colorToleranceThresholdSquared;
+	private boolean considerTolerance;
+	private int width;
+	private int height;
+	@VisibleForTesting
+	public Queue<Range> ranges;
+	private boolean[][] filledPixels;
+
+	@Override
+	public void setParameters(Bitmap bitmap, Point clickedPixel, int targetColor, int replacementColor, float colorToleranceThreshold) {
+		this.bitmap = bitmap;
+		width = bitmap.getWidth();
+		height = bitmap.getHeight();
+		pixels = new int[bitmap.getHeight()][bitmap.getWidth()];
+		for (int i = 0; i < height; i++) {
+			this.bitmap.getPixels(pixels[i], 0, width, 0, i, width, 1);
+		}
+		filledPixels = new boolean[bitmap.getHeight()][bitmap.getWidth()];
+		this.clickedPixel = clickedPixel;
+		this.targetColor = targetColor;
+		this.replacementColor = replacementColor;
+		ranges = new LinkedList<>();
+		colorToleranceThresholdSquared = (int) (colorToleranceThreshold * colorToleranceThreshold);
+		considerTolerance = colorToleranceThreshold > 0;
+	}
+
+	@Override
+	public void performFilling() {
+		Range range = generateRangeAndReplaceColor(clickedPixel.y, clickedPixel.x, UP);
+		ranges.add(range);
+		ranges.add(new Range(range.line, range.start, range.end, DOWN));
+
+		int row;
+		while (!ranges.isEmpty()) {
+			range = ranges.poll();
+
+			if (range.direction == UP) {
+				row = range.line - 1;
+				if (row >= 0) {
+					checkRangeAndGenerateNewRanges(range, row, UP);
+				}
+			} else {
+				row = range.line + 1;
+				if (row < height) {
+					checkRangeAndGenerateNewRanges(range, row, DOWN);
+				}
+			}
+		}
+	}
+
+	private Range generateRangeAndReplaceColor(int row, int col, boolean direction) {
+		Range range = new Range();
+		int i;
+		int start;
+
+		pixels[row][col] = targetColor;
+		filledPixels[row][col] = true;
+
+		for (i = col - 1; i >= 0; i--) {
+			if (!filledPixels[row][i] && (pixels[row][i] == replacementColor
+					|| (considerTolerance && isPixelWithinColorTolerance(pixels[row][i], replacementColor)))) {
+				pixels[row][i] = targetColor;
+				filledPixels[row][i] = true;
+			} else {
+				break;
+			}
+		}
+		start = i + 1;
+
+		for (i = col + 1; i < width; i++) {
+			if (!filledPixels[row][i] && (pixels[row][i] == replacementColor
+					|| (considerTolerance && isPixelWithinColorTolerance(pixels[row][i], replacementColor)))) {
+				pixels[row][i] = targetColor;
+				filledPixels[row][i] = true;
+			} else {
+				break;
+			}
+		}
+
+		range.line = row;
+		range.start = start;
+		range.end = i - 1;
+		range.direction = direction;
+
+		bitmap.setPixels(pixels[row], start, width, start, row, i - start, 1);
+
+		return range;
+	}
+
+	private void checkRangeAndGenerateNewRanges(Range range, int row, boolean directionUp) {
+		Range newRange;
+		for (int col = range.start; col <= range.end; col++) {
+			if (!filledPixels[row][col] && (pixels[row][col] == replacementColor
+					|| (considerTolerance && isPixelWithinColorTolerance(pixels[row][col], replacementColor)))) {
+				newRange = generateRangeAndReplaceColor(row, col, directionUp);
+				ranges.add(newRange);
+
+				if (newRange.start <= range.start - 2) {
+					ranges.add(new Range(row, newRange.start, range.start - 2, !directionUp));
+				}
+				if (newRange.end >= range.end + 2) {
+					ranges.add(new Range(row, range.end + 2, newRange.end, !directionUp));
+				}
+
+				if (newRange.end >= range.end - 1) {
+					break;
+				} else {
+					col = newRange.end + 1;
+				}
+			}
+		}
+	}
+
+	private boolean isPixelWithinColorTolerance(int pixel, int referenceColor) {
+		int redDiff = ((pixel >> 16) & 0xFF) - ((referenceColor >> 16) & 0xFF);
+		int greenDiff = ((pixel >> 8) & 0xFF) - ((referenceColor >> 8) & 0xFF);
+		int blueDiff = (pixel & 0xFF) - (referenceColor & 0xFF);
+		int alphaDiff = (pixel >>> 24) - (referenceColor >>> 24);
+
+		return redDiff * redDiff + greenDiff * greenDiff + blueDiff * blueDiff + alphaDiff * alphaDiff
+				<= colorToleranceThresholdSquared;
+	}
+
+	class Range {
+		public int line;
+		public int start;
+		public int end;
+		public boolean direction;
+
+		Range(int line, int start, int end, boolean directionUp) {
+			this.line = line;
+			this.start = start;
+			this.end = end;
+			this.direction = directionUp;
+		}
+
+		Range() {
+			this.line = 0;
+			this.start = 0;
+			this.end = 0;
+			this.direction = false;
+		}
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/NativeFillAlgorithm.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/NativeFillAlgorithm.java
@@ -1,0 +1,58 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.tools.helper;
+
+import android.graphics.Bitmap;
+import android.graphics.Point;
+
+public class NativeFillAlgorithm implements FillAlgorithm {
+	private Bitmap bitmap;
+	private Point clickedPixel;
+	private int targetColor;
+	private int replacementColor;
+	private float colorToleranceThreshold;
+
+	static {
+		System.loadLibrary("native-lib"); // NOPMD native fill command
+	}
+
+	public native void performFilling(int[] arr, int xStart, int yStart, int xSize, int ySize,
+			int targetColor, int replacementColor, int colorToleranceThresholdSquared);
+
+	@Override
+	public void setParameters(Bitmap bitmap, Point clickedPixel, int targetColor, int replacementColor, float colorToleranceThreshold) {
+		this.bitmap = bitmap;
+		this.clickedPixel = clickedPixel;
+		this.targetColor = targetColor;
+		this.replacementColor = replacementColor;
+		this.colorToleranceThreshold = colorToleranceThreshold;
+	}
+
+	@Override
+	public void performFilling() {
+		int width = bitmap.getWidth();
+		int height = bitmap.getHeight();
+		int[] pixelArray = new int[width * height];
+
+		bitmap.getPixels(pixelArray, 0, width, 0, 0, width, height);
+		performFilling(pixelArray, clickedPixel.x, clickedPixel.y, width, height, targetColor, replacementColor, (int) (colorToleranceThreshold * colorToleranceThreshold));
+		bitmap.setPixels(pixelArray, 0, width, 0, 0, width, height);
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
@@ -2,17 +2,17 @@
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -51,9 +51,7 @@ import android.widget.TextView;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.CommandFactory;
-import org.catrobat.paintroid.command.implementation.BaseCommand;
 import org.catrobat.paintroid.command.implementation.DefaultCommandFactory;
-import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
 import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
 import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog.OnColorPickedListener;
 import org.catrobat.paintroid.listener.BrushPickerView.OnBrushChangedListener;
@@ -61,10 +59,7 @@ import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.ui.DrawingSurface;
 
-import java.util.Observable;
-import java.util.Observer;
-
-public abstract class BaseTool extends Observable implements Tool, Observer {
+public abstract class BaseTool implements Tool {
 	@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 	public static final float MOVE_TOLERANCE = 5;
 	@VisibleForTesting
@@ -130,8 +125,8 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 		movedDistance = new PointF(0f, 0f);
 		previousEventCoordinate = new PointF(0f, 0f);
 
-		toolOptionsLayout = (LinearLayout) ((Activity) context).findViewById(R.id.layout_tool_options);
-		toolSpecificOptionsLayout = (LinearLayout) ((Activity) context).findViewById(R.id.layout_tool_specific_options);
+		toolOptionsLayout = ((Activity) context).findViewById(R.id.layout_tool_options);
+		toolSpecificOptionsLayout = ((Activity) context).findViewById(R.id.layout_tool_specific_options);
 		resetAndInitializeToolOptions();
 	}
 
@@ -157,8 +152,6 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 	@Override
 	public void changePaintColor(@ColorInt int color) {
 		setPaintColor(color);
-		super.setChanged();
-		super.notifyObservers();
 	}
 
 	void setPaintColor(@ColorInt int color) {
@@ -188,17 +181,12 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 		boolean antiAliasing = (strokeWidth > 1);
 		BITMAP_PAINT.setAntiAlias(antiAliasing);
 		CANVAS_PAINT.setAntiAlias(antiAliasing);
-
-		super.setChanged();
-		super.notifyObservers();
 	}
 
 	@Override
 	public void changePaintStrokeCap(Cap cap) {
 		BITMAP_PAINT.setStrokeCap(cap);
 		CANVAS_PAINT.setStrokeCap(cap);
-		super.setChanged();
-		super.notifyObservers();
 	}
 
 	@Override
@@ -210,8 +198,6 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 	public void setDrawPaint(Paint paint) {
 		BITMAP_PAINT.set(paint);
 		CANVAS_PAINT.set(paint);
-		super.setChanged();
-		super.notifyObservers();
 	}
 
 	@Override
@@ -220,16 +206,6 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 	@Override
 	public ToolType getToolType() {
 		return this.toolType;
-	}
-
-	@Override
-	public void update(Observable observable, Object data) {
-		if (data instanceof BaseCommand.NotifyStates
-				&& (BaseCommand.NotifyStates.COMMAND_DONE == data || BaseCommand.NotifyStates.COMMAND_FAILED == data)) {
-
-			IndeterminateProgressDialog.getInstance().dismiss();
-			observable.deleteObserver(this);
-		}
 	}
 
 	protected abstract void resetInternalState();
@@ -280,7 +256,7 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 			@Override
 			public void run() {
 				toolSpecificOptionsLayout.removeAllViews();
-				TextView toolOptionsName = (TextView) toolOptionsLayout.findViewById(R.id.layout_tool_options_name);
+				TextView toolOptionsName = toolOptionsLayout.findViewById(R.id.layout_tool_options_name);
 				toolOptionsName.setText(context.getResources().getString(toolType.getNameResource()));
 			}
 		});
@@ -320,7 +296,7 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 
 	@Override
 	public void hide() {
-		LinearLayout mainToolOptions = (LinearLayout) ((Activity) (context)).findViewById(R.id.main_tool_options);
+		LinearLayout mainToolOptions = ((Activity) (context)).findViewById(R.id.main_tool_options);
 		mainToolOptions.setVisibility(View.GONE);
 		dimBackground(false);
 		toolOptionsShown = false;
@@ -328,8 +304,8 @@ public abstract class BaseTool extends Observable implements Tool, Observer {
 
 	@Override
 	public void toggleShowToolOptions() {
-		LinearLayout mainToolOptions = (LinearLayout) ((Activity) (context)).findViewById(R.id.main_tool_options);
-		LinearLayout mainBottomBar = (LinearLayout) ((Activity) (context)).findViewById(R.id.main_bottom_bar);
+		LinearLayout mainToolOptions = ((Activity) (context)).findViewById(R.id.main_tool_options);
+		LinearLayout mainBottomBar = ((Activity) (context)).findViewById(R.id.main_bottom_bar);
 		int orientation = context.getResources().getConfiguration().orientation;
 
 		if (!toolOptionsShown) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -1,20 +1,20 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.tools.implementation;
@@ -38,6 +38,7 @@ import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.support.annotation.ColorRes;
 import android.support.annotation.VisibleForTesting;
+import android.support.v4.content.res.ResourcesCompat;
 import android.util.DisplayMetrics;
 
 import org.catrobat.paintroid.PaintroidApplication;
@@ -778,7 +779,7 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		final @ColorRes int colorId = highlight
 				? R.color.color_highlight_box
 				: R.color.rectangle_secondary_color;
-		secondaryShapeColor = resources.getColor(colorId);
+		secondaryShapeColor = ResourcesCompat.getColor(resources, colorId, null);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
@@ -1,20 +1,20 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.tools.implementation;
@@ -27,6 +27,7 @@ import android.graphics.Point;
 import android.graphics.PointF;
 import android.os.Bundle;
 import android.support.annotation.VisibleForTesting;
+import android.support.v4.content.res.ResourcesCompat;
 import android.util.DisplayMetrics;
 
 import org.catrobat.paintroid.PaintroidApplication;
@@ -56,8 +57,8 @@ public abstract class BaseToolWithShape extends BaseTool implements
 		final Resources resources = context.getResources();
 		metrics = resources.getDisplayMetrics();
 
-		primaryShapeColor = resources.getColor(R.color.rectangle_primary_color);
-		secondaryShapeColor = resources.getColor(R.color.rectangle_secondary_color);
+		primaryShapeColor = ResourcesCompat.getColor(resources, R.color.rectangle_primary_color, null);
+		secondaryShapeColor = ResourcesCompat.getColor(resources, R.color.rectangle_secondary_color, null);
 		float actionBarHeight = Constants.ACTION_BAR_HEIGHT * metrics.density;
 		PointF surfaceToolPosition = new PointF(metrics.widthPixels / 2f, metrics.heightPixels
 				/ 2f - actionBarHeight);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -33,7 +33,6 @@ import android.widget.Toast;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.Command;
-import org.catrobat.paintroid.command.implementation.PathCommand;
 import org.catrobat.paintroid.listener.BrushPickerView;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.ui.ToastFactory;
@@ -290,7 +289,7 @@ public class CursorTool extends BaseToolWithShape {
 			PaintroidApplication.currentTool.resetInternalState(StateChange.RESET_INTERNAL_STATE);
 			return false;
 		}
-		Command command = new PathCommand(BITMAP_PAINT, pathToDraw);
+		Command command = commandFactory.createPathCommand(BITMAP_PAINT, pathToDraw);
 		PaintroidApplication.commandManager.addCommand(command);
 		return true;
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,6 @@ import android.support.annotation.VisibleForTesting;
 
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.command.Command;
-import org.catrobat.paintroid.command.implementation.PathCommand;
 import org.catrobat.paintroid.listener.BrushPickerView;
 import org.catrobat.paintroid.tools.ToolType;
 
@@ -135,7 +134,7 @@ public class DrawTool extends BaseTool {
 			PaintroidApplication.currentTool.resetInternalState(StateChange.RESET_INTERNAL_STATE);
 			return false;
 		}
-		Command command = new PathCommand(BITMAP_PAINT, pathToDraw);
+		Command command = commandFactory.createPathCommand(BITMAP_PAINT, pathToDraw);
 		PaintroidApplication.commandManager.addCommand(command);
 		return true;
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,6 @@ package org.catrobat.paintroid.tools.implementation;
 
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Point;
 import android.graphics.PointF;
 import android.support.annotation.VisibleForTesting;
 import android.text.Editable;
@@ -36,7 +35,6 @@ import android.widget.SeekBar;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.Command;
-import org.catrobat.paintroid.command.implementation.FillCommand;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.ui.DrawingSurface;
 import org.catrobat.paintroid.ui.tools.NumberRangeFilter;
@@ -93,9 +91,7 @@ public class FillTool extends BaseTool {
 		if (colorTolerance == 0 && BITMAP_PAINT.getColor() == drawingSurface.getPixel(coordinate)) {
 			return false;
 		}
-
-		Command command = new FillCommand(new Point((int) coordinate.x, (int) coordinate.y), BITMAP_PAINT, colorTolerance);
-		((FillCommand) command).addObserver(this);
+		Command command = commandFactory.createFillCommand((int) coordinate.x, (int) coordinate.y, BITMAP_PAINT, colorTolerance);
 		PaintroidApplication.commandManager.addCommand(command);
 
 		return true;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/GeometricFillTool.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -39,8 +39,6 @@ import android.view.View;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.Command;
-import org.catrobat.paintroid.command.implementation.GeometricFillCommand;
-import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
 import org.catrobat.paintroid.listener.ShapeToolOptionsListener;
 import org.catrobat.paintroid.tools.ToolType;
 
@@ -219,11 +217,8 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 		if (!(toolPosition.x - boxWidth / 2 > bitmapWidth || toolPosition.y - boxHeight / 2 > bitmapHeight
 				|| toolPosition.x + boxWidth / 2 < 0 || toolPosition.y + boxHeight / 2 < 0)) {
 
-			Command command = new GeometricFillCommand(drawingBitmap, intPosition,
+			Command command = commandFactory.createGeometricFillCommand(drawingBitmap, intPosition,
 					boxWidth, boxHeight, boxRotation, geometricFillCommandPaint);
-			((GeometricFillCommand) command).addObserver(this);
-
-			IndeterminateProgressDialog.getInstance().show();
 			PaintroidApplication.commandManager.addCommand(command);
 			highlightBox();
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -27,7 +27,6 @@ import android.graphics.PointF;
 
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.command.Command;
-import org.catrobat.paintroid.command.implementation.PathCommand;
 import org.catrobat.paintroid.listener.BrushPickerView;
 import org.catrobat.paintroid.tools.ToolType;
 
@@ -105,7 +104,7 @@ public class LineTool extends BaseTool {
 		}
 
 		if (pathInsideBitmap) {
-			Command command = new PathCommand(BITMAP_PAINT, finalPath);
+			Command command = commandFactory.createPathCommand(BITMAP_PAINT, finalPath);
 			PaintroidApplication.commandManager.addCommand(command);
 		}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
@@ -1,18 +1,18 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p/>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p/>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p/>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -231,7 +231,6 @@ public class StampTool extends BaseToolWithRectangleShape {
 			Command command = new StampCommand(drawingBitmap, intPosition,
 					boxWidth, boxHeight, boxRotation);
 
-			((StampCommand) command).addObserver(this);
 			IndeterminateProgressDialog.getInstance().show();
 			PaintroidApplication.commandManager.addCommand(command);
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
@@ -1,20 +1,20 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.tools.implementation;
@@ -36,7 +36,6 @@ import android.widget.ToggleButton;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.Command;
-import org.catrobat.paintroid.command.implementation.TextToolCommand;
 import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
 import org.catrobat.paintroid.listener.TextToolOptionsListener;
 import org.catrobat.paintroid.tools.ToolType;
@@ -277,9 +276,8 @@ public class TextTool extends BaseToolWithRectangleShape {
 	protected void onClickInBox() {
 		highlightBox();
 		PointF toolPosition = new PointF(this.toolPosition.x, this.toolPosition.y);
-		Command command = new TextToolCommand(getMultilineText(), textPaint, BOX_OFFSET, boxWidth,
+		Command command = commandFactory.createTextToolCommand(getMultilineText(), textPaint, BOX_OFFSET, boxWidth,
 				boxHeight, toolPosition, boxRotation);
-		((TextToolCommand) command).addObserver(this);
 		IndeterminateProgressDialog.getInstance().show();
 
 		PaintroidApplication.commandManager.addCommand(command);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -31,8 +31,8 @@ import android.graphics.PointF;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
-import android.graphics.Region;
 import android.graphics.Shader;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.AttributeSet;
@@ -89,10 +89,14 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 
 				PaintroidApplication.perspective.applyToCanvas(surfaceViewCanvas);
 
-				surfaceViewCanvas.save();
-				surfaceViewCanvas.clipRect(canvasRect, Region.Op.DIFFERENCE);
-				surfaceViewCanvas.drawColor(BACKGROUND_COLOR, PorterDuff.Mode.SRC);
-				surfaceViewCanvas.restore();
+				if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+					surfaceViewCanvas.drawColor(BACKGROUND_COLOR, PorterDuff.Mode.SRC);
+				} else {
+					surfaceViewCanvas.save();
+					surfaceViewCanvas.clipOutRect(canvasRect);
+					surfaceViewCanvas.drawColor(BACKGROUND_COLOR, PorterDuff.Mode.SRC);
+					surfaceViewCanvas.restore();
+				}
 
 				surfaceViewCanvas.drawRect(canvasRect, checkeredPattern);
 				surfaceViewCanvas.drawRect(canvasRect, framePaint);

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/DefaultCommandManagerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/DefaultCommandManagerTest.java
@@ -65,7 +65,7 @@ public class DefaultCommandManagerTest {
 	public void setUp() {
 		layerModel = new LayerModel();
 		PaintroidApplication.layerModel = layerModel;
-		commandManager = new DefaultCommandManager(commonFactory);
+		commandManager = new DefaultCommandManager(commonFactory, layerModel);
 	}
 
 	@Test

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/FillCommandTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/FillCommandTest.java
@@ -1,0 +1,63 @@
+package org.catrobat.paintroid.test.command.implementation;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Point;
+
+import org.catrobat.paintroid.command.implementation.FillCommand;
+import org.catrobat.paintroid.contract.LayerContracts;
+import org.catrobat.paintroid.model.LayerModel;
+import org.catrobat.paintroid.tools.helper.FillAlgorithm;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FillCommandTest {
+	@Mock
+	private FillAlgorithm fillAlgorithm;
+
+	@Mock
+	private Point clickedPixel;
+
+	@Mock
+	private Paint paint;
+
+	@Test
+	public void testSetUp() {
+		FillCommand command = new FillCommand(fillAlgorithm, clickedPixel, paint, 0);
+
+		assertNotNull(command);
+		verifyZeroInteractions(fillAlgorithm, clickedPixel, paint);
+	}
+
+	@Test
+	public void testRun() {
+		clickedPixel.x = 3;
+		clickedPixel.y = 5;
+		FillCommand command = new FillCommand(fillAlgorithm, clickedPixel, paint, 0.5f);
+		Canvas canvas = mock(Canvas.class);
+		LayerModel layerModel = new LayerModel();
+		LayerContracts.Layer layer = mock(LayerContracts.Layer.class);
+		Bitmap bitmap = mock(Bitmap.class);
+		layerModel.setCurrentLayer(layer);
+
+		when(layer.getBitmap()).thenReturn(bitmap);
+		when(bitmap.getPixel(3, 5)).thenReturn(Color.RED);
+		when(paint.getColor()).thenReturn(Color.BLUE);
+
+		command.run(canvas, layerModel);
+
+		verify(fillAlgorithm).setParameters(bitmap, clickedPixel, Color.BLUE, Color.RED, 0.5f);
+		verify(fillAlgorithm).performFilling();
+	}
+}

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/LoadCommandTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/LoadCommandTest.java
@@ -1,0 +1,95 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.command.implementation;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+
+import org.catrobat.paintroid.command.implementation.LoadCommand;
+import org.catrobat.paintroid.contract.LayerContracts;
+import org.catrobat.paintroid.model.LayerModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadCommandTest {
+	@Mock
+	Bitmap bitmap;
+
+	@Mock
+	Canvas canvas;
+
+	LayerContracts.Model layerModel;
+
+	@InjectMocks
+	LoadCommand command;
+
+	@Before
+	public void setUp() {
+		layerModel = new LayerModel();
+	}
+
+	@Test
+	public void testSetUp() {
+		verifyZeroInteractions(bitmap);
+	}
+
+	@Test
+	public void testRunCopiesImage() {
+		Bitmap copy = mock(Bitmap.class);
+		when(bitmap.copy(Bitmap.Config.ARGB_8888, true)).thenReturn(copy);
+
+		command.run(canvas, layerModel);
+
+		LayerContracts.Layer currentLayer = layerModel.getCurrentLayer();
+		assertThat(currentLayer.getBitmap(), is(copy));
+	}
+
+	@Test
+	public void testRunAddsOneLayer() {
+		Bitmap clone = mock(Bitmap.class);
+		when(bitmap.copy(Bitmap.Config.ARGB_8888, true)).thenReturn(clone);
+
+		command.run(canvas, layerModel);
+
+		assertThat(layerModel.getLayerCount(), is(1));
+	}
+
+	@Test
+	public void testRunSetsCurrentLayer() {
+		Bitmap clone = mock(Bitmap.class);
+		when(bitmap.copy(Bitmap.Config.ARGB_8888, true)).thenReturn(clone);
+
+		command.run(canvas, layerModel);
+
+		LayerContracts.Layer currentLayer = layerModel.getCurrentLayer();
+		assertThat(layerModel.getLayerAt(0), is(currentLayer));
+	}
+}


### PR DESCRIPTION
* Add some more tests for commands that are now finally testable
* Move FillTool algorithm out of the Command to a opaque interface
* Use CommandFactory where possible
* Add LayerModel as member of CommandManager
* Deal with some deprecation warnings
* Remove any observer <-> observable binding between tools and commands