### PR TITLE
PAINT-308: Refactor colorpicker

### DIFF
--- a/Paintroid/config/lint.xml
+++ b/Paintroid/config/lint.xml
@@ -19,10 +19,11 @@
 -->
 
 <lint>
+    <issue id="UnusedResources">
+        <ignore regexp="res/values-(?!de).*/string.xml$" />
+    </issue>
 
-    <issue id="StringFormatInvalid" >
-        <ignore path="src/androidTest/java/org/catrobat/paintroid/test/espresso/MainActivityIntegrationTest.java" />
-    </issue >
-
-    <issue id="ResourceType" severity="warning" />
+    <issue id="ShowToast">
+        <ignore path="src/main/java/org/catrobat/paintroid/ui/ToastFactory.java" />
+    </issue>
 </lint>

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
@@ -1,20 +1,20 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.test.espresso;
@@ -32,7 +32,6 @@ import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
 import org.catrobat.paintroid.test.espresso.util.ActivityHelper;
 import org.catrobat.paintroid.test.espresso.util.UiInteractions;
 import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
@@ -84,8 +83,8 @@ public class ToolSelectionIntegrationTest {
 
 		PaintroidApplication.drawingSurface.destroyDrawingCache();
 
-		toolsLayout = (LinearLayout) launchActivityRule.getActivity().findViewById(R.id.tools_layout);
-		scrollView = (HorizontalScrollView) launchActivityRule.getActivity().findViewById(R.id.bottom_bar_scroll_view);
+		toolsLayout = launchActivityRule.getActivity().findViewById(R.id.tools_layout);
+		scrollView = launchActivityRule.getActivity().findViewById(R.id.bottom_bar_scroll_view);
 
 		onToolBarView()
 				.performSelectTool(ToolType.BRUSH);
@@ -94,7 +93,6 @@ public class ToolSelectionIntegrationTest {
 	@After
 	public void tearDown() {
 		IndeterminateProgressDialog.getInstance().dismiss();
-		ColorPickerDialog.getInstance().dismiss();
 
 		activityHelper = null;
 	}
@@ -108,7 +106,7 @@ public class ToolSelectionIntegrationTest {
 	}
 
 	protected int getNumberOfNotVisibleTools() {
-		LinearLayout toolsLayout = (LinearLayout) launchActivityRule.getActivity().findViewById(R.id.tools_layout);
+		LinearLayout toolsLayout = launchActivityRule.getActivity().findViewById(R.id.tools_layout);
 		int toolCount = toolsLayout.getChildCount();
 		int numberOfNotVisibleTools = 0;
 		for (int i = 0; i < toolCount; i++) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -1,24 +1,25 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.test.espresso.dialog;
 
+import android.content.pm.ActivityInfo;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
@@ -29,14 +30,9 @@ import android.widget.Button;
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
 import org.catrobat.paintroid.dialog.colorpicker.HSVColorPickerView;
 import org.catrobat.paintroid.dialog.colorpicker.PresetSelectorView;
 import org.catrobat.paintroid.dialog.colorpicker.RgbSelectorView;
-import org.catrobat.paintroid.tools.ToolType;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,13 +49,12 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.clickColorPickerPresetSelectorButton;
-import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.openColorPickerDialog;
-import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.selectTool;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchCenterLeft;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchCenterRight;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.withBackground;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.withBackgroundColor;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.withTextColor;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.ColorPickerViewInteraction.onColorPickerView;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -86,34 +81,22 @@ public class ColorDialogIntegrationTest {
 	@Rule
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
 
-	@Before
-	public void setUp() throws NoSuchFieldException, IllegalAccessException {
-		PaintroidApplication.drawingSurface.destroyDrawingCache();
-
-		selectTool(ToolType.BRUSH);
-	}
-
-	@After
-	public void tearDown() {
-
-		IndeterminateProgressDialog.getInstance().dismiss();
-		ColorPickerDialog.getInstance().dismiss();
-	}
-
-	protected int getColorById(int colorId) {
+	private int getColorById(int colorId) {
 		return launchActivityRule.getActivity().getResources().getColor(colorId);
 	}
 
 	@Test
-	public void testStandardTabSelected() throws Throwable {
-		openColorPickerDialog();
+	public void testStandardTabSelected() {
+		onColorPickerView()
+				.performOpenColorPicker();
 
 		onView(withClassName(containsString(TAB_VIEW_PRESET_SELECTOR_CLASS))).check(matches(isDisplayed()));
 	}
 
 	@Test
-	public void testTabsAreSelectable() throws Throwable {
-		openColorPickerDialog();
+	public void testTabsAreSelectable() {
+		onColorPickerView()
+				.performOpenColorPicker();
 
 		onView(withClassName(containsString(TAB_VIEW_PRESET_SELECTOR_CLASS))).check(matches(isDisplayed()));
 
@@ -130,7 +113,8 @@ public class ColorDialogIntegrationTest {
 	@Test
 	public void testColorNewColorButtonChangesStandard() {
 
-		openColorPickerDialog();
+		onColorPickerView()
+				.performOpenColorPicker();
 
 		final Resources resources = launchActivityRule.getActivity().getResources();
 		final TypedArray presetColors = resources.obtainTypedArray(R.array.preset_colors);
@@ -150,8 +134,9 @@ public class ColorDialogIntegrationTest {
 	}
 
 	@Test
-	public void buttonTextColorPickerButtonShouldBeDifferentFromBackground() {
-		openColorPickerDialog();
+	public void testButtonTextColorPickerButtonShouldBeDifferentFromBackground() {
+		onColorPickerView()
+				.performOpenColorPicker();
 
 		final Resources resources = launchActivityRule.getActivity().getResources();
 		final TypedArray presetColors = resources.obtainTypedArray(R.array.preset_colors);
@@ -170,10 +155,11 @@ public class ColorDialogIntegrationTest {
 	}
 
 	@Test
-	public void colorPickerDialogOnBackPressedSelectedColorShouldNotChange() {
+	public void testColorPickerDialogOnBackPressedSelectedColorShouldNotChange() {
 		int expectedSelectedColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
 
-		openColorPickerDialog();
+		onColorPickerView()
+				.performOpenColorPicker();
 
 		onView(allOf(withId(R.id.tab_icon), withBackground(R.drawable.icon_color_chooser_tab_palette))).perform(click());
 		onView(withClassName(containsString(TAB_VIEW_PRESET_SELECTOR_CLASS))).check(matches(isDisplayed()));
@@ -195,8 +181,9 @@ public class ColorDialogIntegrationTest {
 	}
 
 	@Test
-	public void testIfRGBSeekBarsDoChangeColor() throws SecurityException, IllegalArgumentException, NoSuchFieldException, IllegalAccessException {
-		openColorPickerDialog();
+	public void testIfRGBSeekBarsDoChangeColor() {
+		onColorPickerView()
+				.performOpenColorPicker();
 
 		onView(allOf(withId(R.id.tab_icon), withBackground(R.drawable.icon_color_chooser_tab_palette))).perform(click());
 		onView(withClassName(containsString(TAB_VIEW_PRESET_SELECTOR_CLASS))).check(matches(isDisplayed()));
@@ -266,8 +253,35 @@ public class ColorDialogIntegrationTest {
 
 	@Test
 	public void testOpenColorPickerOnClickOnColorButton() {
-		openColorPickerDialog();
-		onView(withId(R.id.colorchooser_base_layout)).check(matches(isDisplayed()));
-		onView(withId(R.id.view_colorpicker)).check(matches(isDisplayed()));
+		onColorPickerView()
+				.performOpenColorPicker();
+
+		onView(withId(R.id.colorchooser_base_layout))
+				.check(matches(isDisplayed()));
+		onColorPickerView()
+				.check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testColorPickerRemainsOpenOnOrientationChange() {
+		onColorPickerView()
+				.performOpenColorPicker();
+
+		launchActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+		onColorPickerView().check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testColorPickerTabRestoredOnOrientationChange() {
+		onColorPickerView()
+				.performOpenColorPicker();
+		onView(allOf(withId(R.id.tab_icon), withBackground(R.drawable.icon_color_chooser_tab_rgba)))
+				.perform(click());
+
+		launchActivityRule.getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+		onView(withClassName(containsString(TAB_VIEW_RGBA_SELECTOR_CLASS)))
+				.check(matches(isDisplayed()));
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/DrawToolTests.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/DrawToolTests.java
@@ -34,11 +34,8 @@ import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.command.implementation.PathCommand;
 import org.catrobat.paintroid.command.implementation.PointCommand;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog.OnColorPickedListener;
 import org.catrobat.paintroid.listener.BrushPickerView;
 import org.catrobat.paintroid.test.junit.stubs.PathStub;
-import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.Tool.StateChange;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.BaseTool;
@@ -343,22 +340,6 @@ public class DrawToolTests {
 	public void testShouldReturnBlackForForTopParameterButton() {
 		int color = getAttributeButtonColor();
 		assertEquals(Color.BLACK, color);
-	}
-
-	@UiThreadTest
-	@Test
-	public void testShouldChangePaintFromColorPicker() {
-		toolToTest.setDrawPaint(paint);
-		ColorPickerDialog colorPicker = ColorPickerDialog.getInstance();
-		List<OnColorPickedListener> colorPickerListener = colorPicker.onColorPickedListener;
-
-		for (OnColorPickedListener onColorPickedListener : colorPickerListener) {
-			onColorPickedListener.colorChanged(Color.RED);
-			// check if colorpicker listener is a tool, can also be color Button
-			if (onColorPickedListener instanceof Tool) {
-				assertEquals(Color.RED, toolToTest.getDrawPaint().getColor());
-			}
-		}
 	}
 
 	@UiThreadTest

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
@@ -28,6 +28,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.PaintroidApplication;
+import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog.OnColorPickedListener;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.BaseTool;
 import org.catrobat.paintroid.tools.implementation.PipetteTool;
@@ -36,7 +37,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @RunWith(AndroidJUnit4.class)
 public class PipetteToolTest {
@@ -50,11 +55,14 @@ public class PipetteToolTest {
 	public ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class);
 
 	private PipetteTool toolToTest;
+	private OnColorPickedListener listener;
 
 	@UiThreadTest
 	@Before
 	public void setUp() {
-		toolToTest = new PipetteTool(activityTestRule.getActivity(), ToolType.PIPETTE);
+		listener = mock(OnColorPickedListener.class);
+
+		toolToTest = new PipetteTool(activityTestRule.getActivity(), listener, ToolType.PIPETTE);
 
 		Bitmap bitmap = PaintroidApplication.layerModel.getCurrentLayer().getBitmap();
 		bitmap.setPixel(X_COORDINATE_RED, 0, Color.RED);
@@ -72,6 +80,9 @@ public class PipetteToolTest {
 		assertEquals(Color.RED, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleMove(new PointF(X_COORDINATE_PART_TRANSPARENT, 0));
 		assertEquals(0xAAAAAAAA, toolToTest.getDrawPaint().getColor());
+
+		verify(listener).colorChanged(Color.RED);
+		verify(listener).colorChanged(0xAAAAAAAA);
 	}
 
 	@UiThreadTest
@@ -85,6 +96,11 @@ public class PipetteToolTest {
 		assertEquals(Color.GREEN, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleMove(new PointF(X_COORDINATE_PART_TRANSPARENT, 0));
 		assertEquals(0xAAAAAAAA, toolToTest.getDrawPaint().getColor());
+
+		verify(listener).colorChanged(Color.RED);
+		verify(listener).colorChanged(Color.TRANSPARENT);
+		verify(listener).colorChanged(Color.GREEN);
+		verify(listener).colorChanged(0xAAAAAAAA);
 	}
 
 	@UiThreadTest
@@ -94,13 +110,15 @@ public class PipetteToolTest {
 		assertEquals(Color.BLUE, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleUp(new PointF(X_COORDINATE_PART_TRANSPARENT, 0));
 		assertEquals(0xAAAAAAAA, toolToTest.getDrawPaint().getColor());
+
+		verify(listener).colorChanged(Color.BLUE);
+		verify(listener).colorChanged(0xAAAAAAAA);
 	}
 
 	@UiThreadTest
 	@Test
 	public void testShouldReturnCorrectToolType() {
-		ToolType toolType = toolToTest.getToolType();
-		assertEquals(ToolType.PIPETTE, toolType);
+		assertThat(toolToTest.getToolType(), is(ToolType.PIPETTE));
 	}
 
 	@UiThreadTest

--- a/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplication.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplication.java
@@ -20,6 +20,8 @@
 package org.catrobat.paintroid;
 
 import android.app.Application;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.contract.LayerContracts;
@@ -38,11 +40,13 @@ public class PaintroidApplication extends Application {
 	public static String defaultSystemLanguage;
 	public static LayerContracts.Model layerModel;
 	public static File cacheDir;
+	public static Bitmap backgroundBitmap;
 
 	@Override
 	public void onCreate() {
 		super.onCreate();
 		cacheDir = getCacheDir();
 		defaultSystemLanguage = Locale.getDefault().getLanguage();
+		backgroundBitmap = BitmapFactory.decodeResource(getResources(), R.drawable.checkeredbg);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
@@ -37,6 +37,7 @@ public final class Constants {
 	public static final String SAVE_DIALOG_FRAGMENT_TAG = "savedialogerror";
 	public static final String HELP_DIALOG_FRAGMENT_TAG = "helpdialogfragmenttag";
 	public static final String LOAD_DIALOG_FRAGMENT_TAG = "loadbitmapdialogerror";
+	public static final String COLOR_PICKER_DIALOG_TAG = "ColorPickerDialogTag";
 
 	private Constants() {
 		throw new AssertionError();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -17,10 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.tools;
+package org.catrobat.paintroid.contract;
 
-import android.app.Activity;
-
-public interface ToolFactory {
-	Tool createTool(Activity activity, ToolType toolType);
+public interface MainActivityContracts {
+	interface Navigator {
+		void showColorPickerDialog();
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/ColorPickerView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/ColorPickerView.java
@@ -1,20 +1,20 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  *    This file incorporates work covered by the following copyright and
@@ -39,6 +39,9 @@
 package org.catrobat.paintroid.dialog.colorpicker;
 
 import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutCompat;
 import android.util.AttributeSet;
 import android.view.View;
@@ -50,18 +53,14 @@ import android.widget.TabHost.TabSpec;
 import org.catrobat.paintroid.R;
 
 public class ColorPickerView extends LinearLayoutCompat {
-
-	private final String rgbTag = getContext().getString(R.string.color_rgb);
-	private final String preTag = getContext().getString(R.string.color_pre);
-	private final String circleTag = getContext().getString(R.string.color_hsv);
+	private static final String RGB_TAG = "RGB";
+	private static final String PRE_TAG = "PRE";
+	private static final String HSV_TAG = "HSV";
 
 	private RgbSelectorView rgbSelectorView;
 	private PresetSelectorView preSelectorView;
 	private HSVSelectorView hsvSelectorView;
 	private TabHost tabHost;
-
-	private int maxViewWidth = 0;
-	private int maxViewHeight = 0;
 
 	private int selectedColor;
 
@@ -77,11 +76,29 @@ public class ColorPickerView extends LinearLayoutCompat {
 		init();
 	}
 
-	private static View createTabView(final Context context, final int iconResourceId) {
+	private static View createTabView(Context context, int iconResourceId) {
 		View tabView = inflate(context, R.layout.tab_image_only, null);
-		ImageView tabIcon = (ImageView) tabView.findViewById(R.id.tab_icon);
+		ImageView tabIcon = tabView.findViewById(R.id.tab_icon);
 		tabIcon.setBackgroundResource(iconResourceId);
 		return tabView;
+	}
+
+	@Nullable
+	@Override
+	protected Parcelable onSaveInstanceState() {
+		Parcelable superState = super.onSaveInstanceState();
+		return new SavedState(superState, tabHost.getCurrentTabTag());
+	}
+
+	@Override
+	protected void onRestoreInstanceState(Parcelable state) {
+		if (state instanceof SavedState) {
+			SavedState savedState = (SavedState) state;
+			super.onRestoreInstanceState(savedState.getSuperState());
+			tabHost.setCurrentTabByTag(savedState.currentTabTag);
+		} else {
+			super.onRestoreInstanceState(state);
+		}
 	}
 
 	private void setSelectedColor(int color, View sender) {
@@ -116,26 +133,25 @@ public class ColorPickerView extends LinearLayoutCompat {
 		preSelectorView = new PresetSelectorView(getContext());
 		hsvSelectorView = new HSVSelectorView(getContext());
 
-		tabHost = (TabHost) tabView.findViewById(R.id.colorview_tabColors);
+		tabHost = tabView.findViewById(R.id.colorview_tabColors);
 		tabHost.setup();
 		ColorTabContentFactory factory = new ColorTabContentFactory();
 
-		View preTabView = createTabView(getContext(),
-				R.drawable.icon_color_chooser_tab_palette);
-		TabSpec preTab = tabHost.newTabSpec(preTag)
+		View preTabView = createTabView(getContext(), R.drawable.icon_color_chooser_tab_palette);
+		TabSpec preTab = tabHost.newTabSpec(PRE_TAG)
 				.setIndicator(preTabView)
 				.setContent(factory);
 
-		View hsvTabView = createTabView(getContext(),
-				R.drawable.icon_color_chooser_tab_circle);
-		TabSpec hsvTab = tabHost.newTabSpec(circleTag)
+		View hsvTabView = createTabView(getContext(), R.drawable.icon_color_chooser_tab_circle);
+		TabSpec hsvTab = tabHost.newTabSpec(HSV_TAG)
 				.setIndicator(hsvTabView)
 				.setContent(factory);
 
-		View rgbTabView = createTabView(getContext(),
-				R.drawable.icon_color_chooser_tab_rgba);
-		TabSpec rgbTab = tabHost.newTabSpec(rgbTag).setIndicator(rgbTabView)
+		View rgbTabView = createTabView(getContext(), R.drawable.icon_color_chooser_tab_rgba);
+		TabSpec rgbTab = tabHost.newTabSpec(RGB_TAG)
+				.setIndicator(rgbTabView)
 				.setContent(factory);
+
 		tabHost.addTab(preTab);
 		tabHost.addTab(hsvTab);
 		tabHost.addTab(rgbTab);
@@ -144,8 +160,8 @@ public class ColorPickerView extends LinearLayoutCompat {
 	@Override
 	protected void onAttachedToWindow() {
 		super.onAttachedToWindow();
-		preSelectorView
-				.setOnColorChangedListener(new PresetSelectorView.OnColorChangedListener() {
+		preSelectorView.setOnColorChangedListener(
+				new PresetSelectorView.OnColorChangedListener() {
 					@Override
 					public void colorChanged(int color) {
 						setSelectedColor(color, preSelectorView);
@@ -159,8 +175,8 @@ public class ColorPickerView extends LinearLayoutCompat {
 						setSelectedColor(color, hsvSelectorView);
 					}
 				});
-		rgbSelectorView
-				.setOnColorChangedListener(new RgbSelectorView.OnColorChangedListener() {
+		rgbSelectorView.setOnColorChangedListener(
+				new RgbSelectorView.OnColorChangedListener() {
 					@Override
 					public void colorChanged(int color) {
 						setSelectedColor(color, rgbSelectorView);
@@ -189,17 +205,7 @@ public class ColorPickerView extends LinearLayoutCompat {
 	@Override
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
 		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-		if (preTag.equals(tabHost.getCurrentTabTag())) {
-			maxViewHeight = getMeasuredHeight();
-			maxViewWidth = getMeasuredWidth();
-		} else if (rgbTag.equals(tabHost.getCurrentTabTag())) {
-			maxViewHeight = getMeasuredHeight();
-			maxViewWidth = getMeasuredWidth();
-		} else if (circleTag.equals(tabHost.getCurrentTabTag())) {
-			maxViewHeight = getMeasuredHeight();
-			maxViewWidth = getMeasuredWidth();
-		}
-		setMeasuredDimension(maxViewWidth, maxViewHeight);
+		setMeasuredDimension(getMeasuredWidth(), getMeasuredHeight());
 	}
 
 	public interface OnColorChangedListener {
@@ -209,17 +215,48 @@ public class ColorPickerView extends LinearLayoutCompat {
 	class ColorTabContentFactory implements TabContentFactory {
 		@Override
 		public View createTabContent(String tag) {
-
-			if (rgbTag.equals(tag)) {
-				return rgbSelectorView;
+			switch (tag) {
+				case RGB_TAG:
+					return rgbSelectorView;
+				case PRE_TAG:
+					return preSelectorView;
+				case HSV_TAG:
+					return hsvSelectorView;
+				default:
+					throw new IllegalArgumentException();
 			}
-			if (preTag.equals(tag)) {
-				return preSelectorView;
-			}
-			if (circleTag.equals(tag)) {
-				return hsvSelectorView;
-			}
-			return null;
 		}
+	}
+
+	static class SavedState extends BaseSavedState {
+		String currentTabTag;
+
+		SavedState(Parcel source) {
+			super(source);
+			currentTabTag = source.readString();
+		}
+
+		SavedState(Parcelable superState, String currentTabTag) {
+			super(superState);
+			this.currentTabTag = currentTabTag;
+		}
+
+		@Override
+		public void writeToParcel(Parcel dest, int flags) {
+			super.writeToParcel(dest, flags);
+			dest.writeString(currentTabTag);
+		}
+
+		public static final Creator<SavedState> CREATOR = new Creator<SavedState>() {
+			@Override
+			public SavedState createFromParcel(Parcel source) {
+				return new SavedState(source);
+			}
+
+			@Override
+			public SavedState[] newArray(int size) {
+				return new SavedState[size];
+			}
+		};
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/BrushPickerView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/BrushPickerView.java
@@ -1,20 +1,20 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.listener;
@@ -34,7 +34,6 @@ import android.widget.ImageButton;
 import android.widget.SeekBar;
 
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
 import org.catrobat.paintroid.ui.tools.DrawerPreview;
 import org.catrobat.paintroid.ui.tools.NumberRangeFilter;
 
@@ -52,7 +51,6 @@ public final class BrushPickerView implements View.OnClickListener {
 	private final ImageButton buttonCircle;
 	private final ImageButton buttonRect;
 	private final DrawerPreview drawerPreview;
-	private final ColorPickerDialog.OnColorPickedListener onColorPickedListener;
 
 	public BrushPickerView(ViewGroup rootView) {
 		brushChangedListener = new ArrayList<>();
@@ -70,14 +68,6 @@ public final class BrushPickerView implements View.OnClickListener {
 
 		buttonCircle.setOnClickListener(this);
 		buttonRect.setOnClickListener(this);
-
-		onColorPickedListener = new ColorPickerDialog.OnColorPickedListener() {
-			@Override
-			public void colorChanged(int color) {
-				drawerPreview.invalidate();
-			}
-		};
-		ColorPickerDialog.getInstance().addOnColorPickedListener(onColorPickedListener);
 
 		brushSizeText.addTextChangedListener(new TextWatcher() {
 			@Override
@@ -143,10 +133,6 @@ public final class BrushPickerView implements View.OnClickListener {
 		brushChangedListener.remove(listener);
 	}
 
-	public void removeListeners() {
-		ColorPickerDialog.getInstance().removeOnColorPickedListener(onColorPickedListener);
-	}
-
 	private void updateStrokeChange(int strokeWidth) {
 		for (OnBrushChangedListener listener : brushChangedListener) {
 			listener.setStroke(strokeWidth);
@@ -157,6 +143,10 @@ public final class BrushPickerView implements View.OnClickListener {
 		for (OnBrushChangedListener listener : brushChangedListener) {
 			listener.setCap(cap);
 		}
+	}
+
+	public void invalidate() {
+		drawerPreview.invalidate();
 	}
 
 	public interface OnBrushChangedListener {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.java
@@ -1,23 +1,26 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.tools;
+
+import android.support.annotation.IdRes;
+import android.support.annotation.StringRes;
 
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.Tool.StateChange;
@@ -56,11 +59,11 @@ public enum ToolType {
 		this.toolButtonID = toolButtonID;
 	}
 
-	public int getNameResource() {
+	public @StringRes int getNameResource() {
 		return nameResource;
 	}
 
-	public int getHelpTextResource() {
+	public @StringRes int getHelpTextResource() {
 		return helpTextResource;
 	}
 
@@ -73,7 +76,7 @@ public enum ToolType {
 				|| stateChangeBehaviour.contains(stateChange);
 	}
 
-	public int getToolButtonID() {
+	public @IdRes int getToolButtonID() {
 		return toolButtonID;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
@@ -52,8 +52,6 @@ import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.CommandFactory;
 import org.catrobat.paintroid.command.implementation.DefaultCommandFactory;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
-import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog.OnColorPickedListener;
 import org.catrobat.paintroid.listener.BrushPickerView.OnBrushChangedListener;
 import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolType;
@@ -79,7 +77,6 @@ public abstract class BaseTool implements Tool {
 	final Context context;
 	final PointF movedDistance;
 	final OnBrushChangedListener onBrushChangedListener;
-	private final OnColorPickedListener onColorPickedListener;
 	private final PorterDuffXfermode eraseXfermode;
 	private final ToolType toolType;
 	boolean toolOptionsShown = false;
@@ -102,13 +99,6 @@ public abstract class BaseTool implements Tool {
 
 		scrollTolerance = resources.getDisplayMetrics().widthPixels
 				* SCROLL_TOLERANCE_PERCENTAGE / 100;
-
-		onColorPickedListener = new OnColorPickedListener() {
-			@Override
-			public void colorChanged(int color) {
-				changePaintColor(color);
-			}
-		};
 
 		onBrushChangedListener = new OnBrushChangedListener() {
 			@Override
@@ -347,12 +337,10 @@ public abstract class BaseTool implements Tool {
 
 	@Override
 	public void startTool() {
-		ColorPickerDialog.getInstance().addOnColorPickedListener(onColorPickedListener);
 		PaintroidApplication.drawingSurface.refreshDrawingSurface();
 	}
 
 	@Override
 	public void leaveTool() {
-		ColorPickerDialog.getInstance().removeOnColorPickedListener(onColorPickedListener);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
@@ -71,6 +71,9 @@ public class CursorTool extends BaseToolWithShape {
 		if (toolInDrawMode) {
 			cursorToolSecondaryShapeColor = BITMAP_PAINT.getColor();
 		}
+		if (brushPickerView != null) {
+			brushPickerView.invalidate();
+		}
 	}
 
 	@Override
@@ -343,6 +346,5 @@ public class CursorTool extends BaseToolWithShape {
 	public void leaveTool() {
 		super.leaveTool();
 		brushPickerView.removeBrushChangedListener(onBrushChangedListener);
-		brushPickerView.removeListeners();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.tools.implementation;
+
+import android.app.Activity;
+
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.tools.ToolFactory;
+import org.catrobat.paintroid.tools.ToolType;
+
+public class DefaultToolFactory implements ToolFactory {
+	@Override
+	public Tool createTool(Activity activity, ToolType toolType) {
+		Tool tool;
+		switch (toolType) {
+			case BRUSH:
+				tool = new DrawTool(activity, toolType);
+				break;
+			case CURSOR:
+				tool = new CursorTool(activity, toolType);
+				break;
+			case STAMP:
+				tool = new StampTool(activity, toolType);
+				break;
+			case IMPORTPNG:
+				tool = new ImportTool(activity, toolType);
+				break;
+			case PIPETTE:
+				tool = new PipetteTool(activity, ((MainActivity) activity).topBar, toolType);
+				break;
+			case FILL:
+				tool = new FillTool(activity, toolType);
+				break;
+			case TRANSFORM:
+				tool = new TransformTool(activity, toolType);
+				break;
+			case SHAPE:
+				tool = new GeometricFillTool(activity, toolType);
+				break;
+			case ERASER:
+				tool = new EraserTool(activity, toolType);
+				break;
+			case LINE:
+				tool = new LineTool(activity, toolType);
+				break;
+			case TEXT:
+				tool = new TextTool(activity, toolType);
+				break;
+			default:
+				tool = new DrawTool(activity, ToolType.BRUSH);
+				break;
+		}
+		tool.setupToolOptions();
+		return tool;
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DrawTool.java
@@ -157,6 +157,12 @@ public class DrawTool extends BaseTool {
 	}
 
 	@Override
+	public void changePaintColor(int color) {
+		super.changePaintColor(color);
+		brushPickerView.invalidate();
+	}
+
+	@Override
 	public void setupToolOptions() {
 		brushPickerView = new BrushPickerView(toolSpecificOptionsLayout);
 		brushPickerView.setCurrentPaint(BITMAP_PAINT);
@@ -171,6 +177,5 @@ public class DrawTool extends BaseTool {
 	public void leaveTool() {
 		super.leaveTool();
 		brushPickerView.removeBrushChangedListener(onBrushChangedListener);
-		brushPickerView.removeListeners();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
@@ -118,6 +118,12 @@ public class LineTool extends BaseTool {
 	}
 
 	@Override
+	public void changePaintColor(int color) {
+		super.changePaintColor(color);
+		brushPickerView.invalidate();
+	}
+
+	@Override
 	public void setupToolOptions() {
 		brushPickerView = new BrushPickerView(toolSpecificOptionsLayout);
 		brushPickerView.setCurrentPaint(BITMAP_PAINT);
@@ -133,6 +139,5 @@ public class LineTool extends BaseTool {
 	public void leaveTool() {
 		super.leaveTool();
 		brushPickerView.removeBrushChangedListener(onBrushChangedListener);
-		brushPickerView.removeListeners();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
@@ -1,20 +1,20 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.tools.implementation;
@@ -32,9 +32,11 @@ import org.catrobat.paintroid.tools.ToolType;
 public class PipetteTool extends BaseTool {
 
 	private Bitmap surfaceBitmap;
+	private ColorPickerDialog.OnColorPickedListener listener;
 
-	public PipetteTool(Context context, ToolType toolType) {
+	public PipetteTool(Context context, ColorPickerDialog.OnColorPickedListener listener, ToolType toolType) {
 		super(context, toolType);
+		this.listener = listener;
 
 		updateSurfaceBitmap();
 	}
@@ -70,7 +72,7 @@ public class PipetteTool extends BaseTool {
 
 		int color = surfaceBitmap.getPixel((int) coordinate.x, (int) coordinate.y);
 
-		ColorPickerDialog.getInstance().setInitialColor(color);
+		listener.colorChanged(color);
 		changePaintColor(color);
 		return true;
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -1,0 +1,48 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.ui;
+
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.PaintroidApplication;
+import org.catrobat.paintroid.contract.MainActivityContracts;
+import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
+
+import static org.catrobat.paintroid.common.Constants.COLOR_PICKER_DIALOG_TAG;
+
+public class MainActivityNavigator implements MainActivityContracts.Navigator {
+	private MainActivity mainActivity;
+
+	public MainActivityNavigator(MainActivity mainActivity) {
+		this.mainActivity = mainActivity;
+	}
+
+	@Override
+	public void showColorPickerDialog() {
+		ColorPickerDialog dialog = ColorPickerDialog.newInstance(PaintroidApplication.currentTool.getDrawPaint().getColor());
+		dialog.addOnColorPickedListener(new ColorPickerDialog.OnColorPickedListener() {
+			@Override
+			public void colorChanged(int color) {
+				PaintroidApplication.currentTool.changePaintColor(color);
+			}
+		});
+		dialog.addOnColorPickedListener(mainActivity.topBar);
+		dialog.show(mainActivity.getSupportFragmentManager(), COLOR_PICKER_DIALOG_TAG);
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/ToastFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/ToastFactory.java
@@ -1,25 +1,24 @@
-/**
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.ui;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.annotation.StringRes;
 import android.widget.Toast;
@@ -30,7 +29,6 @@ public final class ToastFactory {
 	private ToastFactory() {
 	}
 
-	@SuppressLint("ShowToast")
 	public static Toast makeText(Context context, @StringRes int resId, int duration) {
 		if (currentToast != null) {
 			currentToast.cancel();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/TopBar.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/TopBar.java
@@ -27,29 +27,50 @@ import android.widget.ImageButton;
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.contract.MainActivityContracts;
 import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
-import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.implementation.BaseTool;
 import org.catrobat.paintroid.ui.button.ColorButton;
 
-public class TopBar implements View.OnClickListener, ColorPickerDialog.OnColorPickedListener {
+public class TopBar implements ColorPickerDialog.OnColorPickedListener {
 	private ImageButton undoButton;
 	private ImageButton redoButton;
 	private ColorButton colorButton;
+	private MainActivityContracts.Navigator navigator;
 	private DrawerLayout layerDrawer;
 
-	public TopBar(MainActivity mainActivity) {
+	public TopBar(MainActivity mainActivity, MainActivityContracts.Navigator navigator) {
 		undoButton = mainActivity.findViewById(R.id.btn_top_undo);
 		redoButton = mainActivity.findViewById(R.id.btn_top_redo);
 		colorButton = mainActivity.findViewById(R.id.btn_top_color);
-		ImageButton layerButton = mainActivity.findViewById(R.id.btn_top_layers);
 		layerDrawer = mainActivity.findViewById(R.id.drawer_layout);
+		ImageButton layerButton = mainActivity.findViewById(R.id.btn_top_layers);
+		this.navigator = navigator;
 
-		undoButton.setOnClickListener(this);
-		redoButton.setOnClickListener(this);
-		colorButton.setOnClickListener(this);
-		ColorPickerDialog.getInstance().addOnColorPickedListener(this);
-		layerButton.setOnClickListener(this);
+		undoButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				onUndoClick();
+			}
+		});
+		redoButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				onRedoClick();
+			}
+		});
+		colorButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				onColorClick();
+			}
+		});
+		layerButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				onLayerClick();
+			}
+		});
 
 		refreshButtons();
 
@@ -73,36 +94,18 @@ public class TopBar implements View.OnClickListener, ColorPickerDialog.OnColorPi
 	}
 
 	private void onColorClick() {
-		Tool currentTool = PaintroidApplication.currentTool;
-		if (!currentTool.getToolType().isColorChangeAllowed()) {
-			return;
+		if (PaintroidApplication.currentTool.getToolType().isColorChangeAllowed()) {
+			navigator.showColorPickerDialog();
 		}
-		ColorPickerDialog.getInstance().show();
+	}
+
+	private void onLayerClick() {
+		layerDrawer.openDrawer(Gravity.END);
 	}
 
 	public void refreshButtons() {
 		undoButton.setEnabled(PaintroidApplication.commandManager.isUndoAvailable());
 		redoButton.setEnabled(PaintroidApplication.commandManager.isRedoAvailable());
-	}
-
-	@Override
-	public void onClick(View view) {
-		switch (view.getId()) {
-			case R.id.btn_top_undo:
-				onUndoClick();
-				break;
-			case R.id.btn_top_redo:
-				onRedoClick();
-				break;
-			case R.id.btn_top_color:
-				onColorClick();
-				break;
-			case R.id.btn_top_layers:
-				layerDrawer.openDrawer(Gravity.END);
-				break;
-			default:
-				break;
-		}
 	}
 
 	@Override

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -47,13 +47,10 @@
     <string name="about_link_template" translatable="false">&lt;a href=\"%1$s\">%2$s&lt;/a></string>
     <string name="about_version">Version:</string>
     <string name="color_chooser_title">Color Chooser</string>
-    <string name="color_rgb">Red Green Blue (RGB)</string>
     <string name="color_red">Red</string>
     <string name="color_green">Green</string>
     <string name="color_blue">Blue</string>
     <string name="color_alpha">Alpha</string>
-    <string name="color_pre">preselected</string>
-    <string name="color_hsv">hsv color picker</string>
     <string name="dialog_tools_title">Tools</string>
     <string name="dialog_error_save_title">Error load/save File</string>
     <string name="dialog_error_sdcard_text">Check Image or SD-Card!</string>


### PR DESCRIPTION
* Refactor `ColorPickerDialog` to a `DialogFragment`
* Remove Singleton behavior from `ColorPickerDialog`
* Refactor the `ColorPickerDialog` listener behaviour for tools
* Change tab tags to regular constant strings
* Remove unused strings from default language strings
* Clean up lint ignores, ignore any unused non-default-language strings
* Add tests to confirm that dialog stays open and keeps selected tab
  on configuration changes