### PR TITLE
JENKINS-215 Create, start and stop emulator via gradle.

### DIFF
--- a/Paintroid/gradle/adb_tasks.gradle
+++ b/Paintroid/gradle/adb_tasks.gradle
@@ -17,46 +17,52 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-def getAndroidDevices() {
-    def deviceIds = []
-    [ android.getAdbExecutable().absolutePath, 'devices' ].execute().text.eachLine { line ->
-        def matcher = line =~ /^(.*)\tdevice/
-        if (matcher) {
-            deviceIds << matcher[0][1]
+import org.catrobat.gradle.Adb
+import org.catrobat.gradle.AndroidDevice
+import org.catrobat.gradle.AvdCreator
+import org.catrobat.gradle.AvdStore
+import org.catrobat.gradle.BootIncompleteExcpetion
+import org.catrobat.gradle.DeviceNotFoundException
+import org.catrobat.gradle.EmulatorStarter
+import org.catrobat.gradle.NoDeviceExcpetion
+import org.catrobat.gradle.Utils
+
+Adb adb() {
+    new Adb(android.getAdbExecutable())
+}
+
+def androidDevice(String androidSerial = null) {
+    new AndroidDevice(adb(), androidSerial)
+}
+
+/**
+ * Ensure that any function here works both on local machines as well as one Jenkins.
+ *
+ * This is done by setting the needed environment variables.
+ */
+def determineEnvironment() {
+    def env = new HashMap(System.getenv())
+
+    def fallbackEnv = {k, v ->
+        if (!env.containsKey(k)) {
+            println("ENV: Setting unspecified $k to [$v]")
+            env[k.toString()] = v.toString()
         }
     }
-    deviceIds
+
+    fallbackEnv('ANDROID_AVD_HOME', env['WORKSPACE'] ?: project.rootDir.toPath())
+
+    return env
 }
 
-def getAndroidSerial() {
-    def availableDevices = getAndroidDevices()
-    def androidSerial = System.getenv('ANDROID_SERIAL')
-
-    if (androidSerial?.trim() && !availableDevices.contains(androidSerial)) {
-        throw new IllegalStateException("Device ${androidSerial} not found")
-    } else if (availableDevices.size() == 0) {
-        throw new IllegalStateException("No connected devices!")
-    } else {
-        androidSerial = availableDevices.first()
-    }
-
-    return androidSerial.toString().trim()
-}
-
-def executeShellCommand(command) {
-    println("executing: ${command}")
-    def process = new ProcessBuilder(command).redirectErrorStream(true).start()
-    process.inputStream.eachLine {println it}
-    process.waitFor()
-    if(process.exitValue() != 0)
-        throw new GradleScriptException("adb exited with exit status ${process.exitValue()}", null)
+def avdStore() {
+    new AvdStore(project.rootDir)
 }
 
 def createAdbInstallTask(variant) {
     task ("commandlineAdbInstall${variant.name.capitalize()}") {
         doLast {
-            def command = [ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'install', variant.outputs[0].outputFile.path ]
-            executeShellCommand(command)
+            androidDevice().install(variant.outputs[0].outputFile.path)
         }
     }
 }
@@ -71,37 +77,27 @@ android.testVariants.all { variant ->
 
 task commandlineAdbRunTests {
     doLast {
-        def command = []
-        command.addAll([ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'shell', 'am', 'instrument', '-w', '-e', 'junitOutputDirectory', '/mnt/sdcard/testresults' ])
-        if (System.properties['noDeviceTests']){
-            command.addAll(['-e', 'notAnnotation', 'org.catrobat.catroid.uitest.annotation.Device'])
-        }
-        if (System.properties['onlyDeviceTests']){
-            command.addAll(['-e', 'annotation', 'org.catrobat.catroid.uitest.annotation.Device'])
-        }
-        if (System.properties['testClass']){
-            command.addAll(['-e', 'class', System.properties['testClass'].toString()])
-        }
-        if (System.properties['testPackage']){
-            command.addAll(['-e', 'package', System.properties['testPackage'].toString()])
-        }
+        def device = androidDevice()
 
-        command.addAll(["${android.defaultConfig.testApplicationId}/${android.defaultConfig.testInstrumentationRunner}".toString()])
-        executeShellCommand(command)
+        def cmd = device.command(['shell', 'am', 'instrument', '-w', '-e', 'junitOutputDirectory', '/mnt/sdcard/testresults'])
+        cmd.addOptionalArguments(System.properties['noDeviceTests'], ['-e', 'notAnnotation', 'org.catrobat.catroid.uitest.annotation.Device'])
+        cmd.addOptionalArguments(System.properties['onlyDeviceTests'], ['-e', 'annotation', 'org.catrobat.catroid.uitest.annotation.Device'])
+        cmd.addOptionalArguments(System.properties['testClass'], ['-e', 'class', System.properties['testClass'].toString()])
+        cmd.addOptionalArguments(System.properties['testPackage'], ['-e', 'package', System.properties['testPackage'].toString()])
+        cmd.addArguments(["${android.defaultConfig.testApplicationId}/${android.defaultConfig.testInstrumentationRunner}".toString()])
+        cmd.verbose().execute(null)
 
-        def adbPath = project.getBuildDir().getPath()+"/adb"
-        def adbTestPath = adbPath+"/test"
-        def adbScreenshotsPath = adbPath+"/robotium_screenshots"
+        def adbPath = project.getBuildDir().getPath() + "/adb"
         file(adbPath).deleteDir()
+
+        def adbTestPath = adbPath + "/test"
         file(adbTestPath).mkdirs()
-        file(adbScreenshotsPath).mkdirs()
+        device.command(['pull', '/sdcard/testresults', adbTestPath]).verbose().execute()
 
-        def testPullCommand = [ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'pull', '/sdcard/testresults', adbTestPath ]
-        def screenshotsPullCommand = [ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'pull', '/sdcard/Robotium-Screenshots', adbScreenshotsPath ]
-
-        executeShellCommand(testPullCommand)
         try {
-            executeShellCommand(screenshotsPullCommand)
+            def adbScreenshotsPath = adbPath + "/robotium_screenshots"
+            file(adbScreenshotsPath).mkdirs()
+            device.command(['pull', '/sdcard/Robotium-Screenshots', adbScreenshotsPath]).verbose().execute()
         } catch (GradleScriptException) {}
     }
 }
@@ -112,17 +108,7 @@ task adbDisableAnimationsGlobally() {
 
     doLast {
         logger.lifecycle(description)
-
-        def androidSerial = getAndroidSerial()
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'window_animation_scale', '0.0'
-        }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'transition_animation_scale', '0.0'
-        }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'animator_duration_scale', '0.0'
-        }
+        androidDevice().disableAnimationsGlobally()
     }
 }
 
@@ -132,16 +118,94 @@ task adbResetAnimationsGlobally() {
 
     doLast {
         logger.lifecycle(description)
+        androidDevice().resetAnimationsGlobally()
+    }
+}
 
-        def androidSerial = getAndroidSerial()
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'delete', 'global', 'window_animation_scale'
+def reuseOrCreateAvd() {
+
+        def avdCreator = new AvdCreator(android.sdkDirectory, avdStore())
+        avdCreator.apply {
+            systemImage = 'system-images;android-24;default;x86_64'
+            sdcardSizeMb = 200
+            addProperties(['hw.ramSize': 800, 'vm.heapSize': 128])
+            screenDensity = 'xhdpi'
         }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'delete', 'global', 'transition_animation_scale'
+        avdCreator.reuseOrCreateAvd(determineEnvironment())
+}
+
+def reuseRunningOrStartEmulator() {
+    def proc
+    def device
+
+    try {
+        // try to access an already running emulator
+        device = androidDevice()
+    } catch (DeviceNotFoundException e) {
+        // A specific deivce was specified that does not exist
+        throw e
+    } catch (NoDeviceExcpetion) {
+        // no device running, start one
+        println('Start the emulator!')
+
+        def emulatorStarter = new EmulatorStarter(android.sdkDirectory, {
+            showWindow = !Utils.isRunningOnJenkins()
+            resolution = '768x1280'
+            language = 'en'
+            country = 'US'
+        })
+
+        proc = emulatorStarter.start(avdStore().readAvdName(), determineEnvironment())
+
+        try {
+            device = androidDevice(adb().waitForSerial())
+        } catch(NoDeviceExcpetion e) {
+            proc.waitForOrKill(1)
+            throw e
         }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'delete', 'global', 'animator_duration_scale'
+    }
+
+    try {
+        println("Using device ${device.androidSerial}")
+        device.waitForBooted()
+    } catch (BootIncompleteExcpetion e) {
+        proc?.waitForOrKill(1)
+        throw e
+    }
+}
+
+task startEmulator() {
+    description 'Starts the android emulator'
+    group 'android'
+
+    doLast {
+        reuseOrCreateAvd()
+        reuseRunningOrStartEmulator()
+    }
+}
+
+task retrieveLogcat() {
+    description 'Retrieves the logcat.txt from the device.'
+    group 'android'
+
+    doLast {
+        def device = androidDevice()
+        def logcat = new File(project.rootDir, 'logcat.txt')
+        device.writeLogcat(logcat)
+    }
+}
+
+task stopEmulator() {
+    description 'Stops the android emulator'
+    group 'android'
+
+    doLast {
+        try {
+            def device = androidDevice()
+            device.command(['emu', 'kill']).verbose().execute()
+            device.waitForStopped()
+        } catch (NoDeviceException) {
+            // already stopped
         }
     }
 }

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Adb.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Adb.groovy
@@ -1,0 +1,73 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class Adb {
+    File adbExe
+
+    Adb(File adbExe) {
+        this.adbExe = adbExe
+    }
+
+    CommandBuilder command() {
+        new CommandBuilder(adbExe)
+    }
+
+    List<String> getAndroidDevices() {
+        List<String> deviceIds = []
+        command().addArguments(['devices']).execute().eachLine { line ->
+            line = line.trim()
+            def i = line.indexOf('\tdevice')
+            if (i > 0) {
+                deviceIds << line.substring(0, i)
+            }
+        }
+        deviceIds
+    }
+
+    String getAndroidSerial() {
+        def availableDevices = getAndroidDevices()
+        def androidSerial = System.getenv('ANDROID_SERIAL')
+
+        if (androidSerial?.trim() && !availableDevices.contains(androidSerial)) {
+            throw new DeviceNotFoundException("Device ${androidSerial} not found")
+        } else if (availableDevices.size() == 0) {
+            throw new NoDeviceExcpetion("No connected devices!")
+        } else {
+            androidSerial = availableDevices.first()
+        }
+
+        return androidSerial.toString().trim()
+    }
+
+    String waitForSerial(int timeout=60) {
+        for (int i = 0; i < timeout; ++i) {
+            try {
+                return getAndroidSerial()
+            } catch (NoDeviceExcpetion) {
+                sleep(1000)
+            }
+        }
+        return getAndroidSerial()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidDevice.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidDevice.groovy
@@ -1,0 +1,111 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class AndroidDevice {
+    Adb adb
+    String androidSerial
+
+    AndroidDevice(Adb adb, String androidSerial = null) {
+        this.adb = adb
+        this.androidSerial = androidSerial ?: adb.getAndroidSerial()
+    }
+
+    /**
+     * @return A command builder with the given command and using the serial to run on the device
+     */
+    CommandBuilder command(List additionalParameters) {
+        adb.command().addArguments(['-s', androidSerial]).addArguments(additionalParameters)
+    }
+
+    void setGlobalSetting(String setting_name, def value) {
+        command(['shell', 'settings', 'put', 'global', setting_name, value.toString()]).verbose().execute()
+    }
+
+    void deleteGlobalSetting(String setting_name) {
+        command(['shell', 'settings', 'delete', 'global', setting_name]).verbose().execute()
+    }
+
+    void writeLogcat(File logcat) {
+        if (!stillRunning()) {
+            println("WARNING: Cannot retrieve logcat from '$androidSerial'.")
+            return
+        }
+        logcat.withOutputStream { os ->
+            command(['logcat', '-d']).executeAsynchronously().waitForProcessOutput(os, os)
+        }
+    }
+
+    void waitForBooted() {
+        println("Waiting for device $androidSerial to be booted.")
+        for (int i = 0; i < 60; ++i) {
+            def result = command(['shell', 'getprop', 'sys.boot_completed']).execute().trim()
+            if (result == "1") {
+                println("Deivce $androidSerial booted successfully.")
+                return
+            }
+
+            sleep(1000)
+        }
+        throw new BootIncompleteExcpetion("The boot of device $androidSerial did not complete.")
+    }
+
+    void waitForStopped() {
+        println("Wait for device $androidSerial to stop.")
+        for (int i = 0; i < 30; ++i) {
+            if (!stillRunning()) {
+                // device could not be found, thus it is stopped
+                return
+            }
+            sleep(1000)
+        }
+
+        // If it turns out that the emulator fails to be killed often consider killing
+        // the emulator via OS commands.
+        // Similar to what was done in buildScritps/
+        throw new ResourceException("Failed to stop device $androidSerial.")
+    }
+
+    void install(File apk) {
+        println("Installing '$apk'")
+        command(['install', apk]).verbose().execute()
+    }
+
+    void disableAnimationsGlobally() {
+        println("Disabling animations for device $androidSerial.")
+        setGlobalSetting('window_animation_scale', '0.0')
+        setGlobalSetting('transition_animation_scale', '0.0')
+        setGlobalSetting('animator_duration_scale', '0.0',)
+    }
+
+    void resetAnimationsGlobally() {
+        println("Resetting animations for device $androidSerial.")
+        deleteGlobalSetting('window_animation_scale')
+        deleteGlobalSetting('transition_animation_scale')
+        deleteGlobalSetting('animator_duration_scale')
+    }
+
+    private boolean stillRunning() {
+        adb.getAndroidDevices().contains(androidSerial)
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AvdCreator.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AvdCreator.groovy
@@ -1,0 +1,132 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+/**
+ * Creates an avd with the given settings.
+ *
+ * Users can specify additional command line arguments (addArguments) and
+ * hardware properties (addProperty).
+ * The hardware properties are then written to the avd config file.
+ */
+@TypeChecked
+class AvdCreator {
+    String systemImage
+    Integer sdcardSizeMb
+    private static Map screenDensityLookup = ['ldpi': '120', 'mdpi': '160', 'tvdpi': '213',
+                                              'hdpi': '240', 'xhdpi': '320', 'xxhdpi': '480',
+                                              'xxxhdpi': '640']
+    private static String screenDensityName = 'hw.lcd.density'
+    private Map properties = [:]
+    private List arguments = []
+    private AvdStore avdStore
+    private File sdkDirectory
+
+    /**
+     * Creates an AvdCreator with the given closure.
+     *
+     * You can call functions of AvdCreator from within the closure
+     * and access parameters.
+     *
+     * For example:
+     * def avdCreator = new AvdCreator {
+     *     systemImage = 'system-images;android-24;default;x86_64'
+     *     sdcardSizeMb = 200
+     * }
+     *
+     * @param closure
+     */
+    AvdCreator(File sdkDirectory, AvdStore avdStore) {
+        this.sdkDirectory = sdkDirectory
+        this.avdStore = avdStore
+    }
+
+    AvdCreator apply(Closure settings) {
+        settings = (Closure)settings.clone()
+        settings.delegate = this
+        settings.resolveStrategy = Closure.DELEGATE_FIRST
+        settings()
+        this
+    }
+
+    void setScreenDensity(String density) {
+        if (density in screenDensityLookup) {
+            properties[screenDensityName] = screenDensityLookup[density]
+        } else if (density.isNumber()) {
+            properties[screenDensityName] = density
+        } else {
+            throw new InputMismatchException("'$density' is not a valid density")
+        }
+    }
+
+    String getScreenDensity() {
+        return properties[screenDensityName]
+    }
+
+    void addArguments(List arguments) {
+        this.arguments += arguments
+    }
+
+    void addProperties(Map properties) {
+        this.properties << properties
+    }
+
+    void createAvd(Map environment) {
+        checkSettings()
+
+        def avdName = avdStore.generateAvdName()
+        def avdmanager = new CommandBuilder(Utils.joinPaths(sdkDirectory, 'tools', 'bin', 'avdmanager'), '.bat')
+
+        avdmanager.addArguments(['create', 'avd', '-f', '-n', avdName])
+        avdmanager.addOptionalArguments(sdcardSizeMb, ['-c', "${sdcardSizeMb}M"])
+        avdmanager.addArguments(['-k', systemImage])
+        avdmanager.addArguments(arguments)
+
+        avdmanager.input('no\r\n').directory(avdStore.avdStore).environment(environment).verbose()
+        avdmanager.execute()
+
+        // update the avd ini-file with the specified properties
+        avdStore.avdConfigFile.setValues(properties)
+    }
+
+    void reuseOrCreateAvd(Map environment) {
+        try {
+            // first check whether an avd exists already
+            avdStore.readAvdName()
+        } catch (NoAvdException e) {
+            println(e.message)
+            println("Create AVD")
+            createAvd(environment)
+        }
+    }
+
+    private void checkSettings() {
+        def throw_if_null = { name, value ->
+            if (!value) {
+                throw new IllegalStateException("Setting '$name' is not specified but needed by createAvd.")
+            }
+        }
+
+        throw_if_null(systemImage, 'systemImage')
+        throw_if_null(screenDensity, 'screenDensity')
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AvdStore.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AvdStore.groovy
@@ -1,0 +1,62 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class AvdStore {
+    File avdStore
+    File lastUsedAvd
+
+    AvdStore(File avdStore) {
+        this.avdStore = avdStore
+        this.lastUsedAvd = new File(avdStore, 'last_unique_avd_name.tmp')
+    }
+
+    String readAvdName() {
+        def checkFile = { File file ->
+            if (!file.exists()) {
+                throw new NoAvdException("$file does not exist.")
+            }
+        }
+
+        checkFile(lastUsedAvd)
+        def name = lastUsedAvd.text.trim()
+        if (name.isEmpty()) {
+            throw new NoAvdException('No AVD configured.')
+        }
+
+        checkFile(new File(avdStore, "${name}.avd"))
+        checkFile(new File(avdStore, "${name}.ini"))
+
+        return name
+    }
+
+    String generateAvdName() {
+        def uuid = UUID.randomUUID().toString()
+        lastUsedAvd.write(uuid)
+        return uuid
+    }
+
+    IniFile getAvdConfigFile() {
+        new IniFile(Utils.joinPaths(avdStore, readAvdName() + '.avd', 'config.ini'))
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/CommandBuilder.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/CommandBuilder.groovy
@@ -1,0 +1,131 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.GradleScriptException
+
+@TypeChecked
+class CommandBuilder {
+    File exe
+    File workingDirectory
+    Map<String, String> environment
+    List arguments = []
+    String input
+    boolean verbose = false
+
+    CommandBuilder(File exe) {
+        this.exe = exe
+    }
+
+    CommandBuilder(File exe, String winEnding) {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            this.exe = new File(exe.absolutePath + winEnding)
+        } else {
+            this.exe = exe
+        }
+    }
+
+    CommandBuilder directory(File workingDirectory) {
+        this.workingDirectory = workingDirectory
+        this
+    }
+
+    CommandBuilder environment(Map<String, String> environment) {
+        this.environment = environment
+        this
+    }
+
+    CommandBuilder addArguments(List arguments ) {
+        this.arguments += arguments
+        this
+    }
+
+    CommandBuilder addOptionalArguments(def shouldAdd, List arguments) {
+        if (shouldAdd) {
+            this.arguments += arguments
+        }
+        this
+    }
+
+    CommandBuilder verbose() {
+        verbose = true
+        this
+    }
+
+    CommandBuilder input(String input) {
+        this.input = input
+        this
+    }
+
+    String execute(long timeoutSecs=30) {
+        def proc = executeInternal()
+
+        def stdout = verbose ? new PrintStreamAndStringBuilder(System.out) : new ByteArrayOutputStream()
+        def stderr = verbose ? new PrintStreamAndStringBuilder(System.err) : new ByteArrayOutputStream()
+
+        proc.consumeProcessOutput(stdout, stderr)
+        proc.waitForOrKill(timeoutSecs * 1000)
+
+        if (proc.exitValue()) {
+            throw new GradleScriptException("Failed to execute ${commandLine().join(' ')} " +
+                    "exit code ${proc.exitValue()} Err:\n$stdout\nText:\n$stderr", null)
+        }
+
+        stdout.toString()
+    }
+
+    /**
+     * Starts a job in the background.
+     *
+     * When verbose is activated the process output will be forwarded to stdout/stderr.
+     * @note You have to handle the process output yourself if you do not activate verbose.
+     *       Thus you have to call consumeProcessOutput or waitForProcessOutput.
+     *       Otherwise the internal buffers can be filled, which will lead to the process failing!
+     */
+    Process executeAsynchronously() {
+        def proc = executeInternal()
+        if (verbose) {
+            proc.consumeProcessOutput(new PrintStream(System.out, true), new PrintStream(System.err, true))
+        }
+
+        proc
+    }
+
+    List commandLine() {
+        [exe] + arguments
+    }
+
+    private Process executeInternal() {
+        def cmd = commandLine()
+        if (verbose) {
+            println("Executing: ${cmd.join(' ')}")
+        }
+
+        def proc = cmd.execute(environment?.collect { k, v -> "$k=$v"}, workingDirectory)
+
+        if (input) {
+            proc << input
+        }
+
+        proc
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorStarter.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorStarter.groovy
@@ -1,0 +1,71 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class EmulatorStarter {
+    File sdkDirectory
+    String skin = ''
+    String language = ''
+    String country = ''
+    boolean showWindow = false
+    boolean keepUserData = false
+    List<String> additionalCliOpts = ['-gpu', 'swiftshader_indirect', '-no-boot-anim', '-noaudio']
+
+    EmulatorStarter(File sdkDirectory) {
+        this.sdkDirectory = sdkDirectory
+    }
+
+    EmulatorStarter(File sdkDirectory, Closure settings) {
+        this.sdkDirectory = sdkDirectory
+        settings = (Closure)settings.clone()
+        settings.delegate = this
+        settings.resolveStrategy = Closure.DELEGATE_FIRST
+        settings()
+    }
+
+    String getResoluation() {
+        skin
+    }
+
+    void setResolution(String resolution) {
+        skin = resolution
+    }
+
+    /**
+     * Starts the emulator asynchronously without checking for success.
+     * @return EmulatorStarter process
+     */
+    Process start(String avdName, Map environment) {
+        def emulator = new CommandBuilder(Utils.joinPaths(sdkDirectory, 'emulator', 'emulator'), '.exe')
+
+        emulator.addArguments(['-avd', avdName])
+        emulator.addOptionalArguments(skin, ['-skin', skin])
+        emulator.addOptionalArguments(language, ['-prop', "persist.sys.language=$language"])
+        emulator.addOptionalArguments(country, ['-prop', "persist.sys.country=$country"])
+        emulator.addOptionalArguments(!showWindow, ['-no-window'])
+        emulator.addOptionalArguments(!keepUserData, ['-wipe-data'])
+        emulator.addArguments(additionalCliOpts)
+
+        emulator.environment(environment).verbose().executeAsynchronously()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Exceptions.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Exceptions.groovy
@@ -1,0 +1,48 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.InheritConstructors
+import groovy.transform.TypeChecked
+
+@TypeChecked
+@InheritConstructors
+class AndroidResourceException extends ResourceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class NoAvdException extends AndroidResourceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class NoDeviceExcpetion extends AndroidResourceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class DeviceNotFoundException extends NoDeviceExcpetion {
+}
+
+@TypeChecked
+@InheritConstructors
+class BootIncompleteExcpetion extends AndroidResourceException {
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/IniFile.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/IniFile.groovy
@@ -1,0 +1,62 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class IniFile {
+    File iniFile
+
+    IniFile(File iniFile) {
+        this.iniFile = iniFile
+    }
+
+    /**
+     * Adds values to the ini files.
+     *
+     * Existing elements are updated in the order they are found.
+     * Remaing elements are added in alphabetical order.
+     */
+    void setValues(Map values) {
+        def remainingSorted = new TreeMap(values)
+
+        // first update existing elements without changing their order
+        def contents = iniFile.text.readLines().collect { String line ->
+            def parts = line.split('=')
+            if (parts.size() == 2) {
+                def k = parts[0].trim()
+                if (k in values) {
+                    line = "$k=${values[k]}"
+                    remainingSorted.remove(k)
+                }
+            }
+
+            line
+        }
+
+        // now add the remaining elements in alphabetical order
+        contents += remainingSorted.collect { k, v ->
+            "$k=$v".toString()
+        }
+
+        iniFile.write(contents.join('\n'))
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/PrintStreamAndStringBuilder.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/PrintStreamAndStringBuilder.groovy
@@ -1,0 +1,56 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class PrintStreamAndStringBuilder extends OutputStream {
+    PrintStream os
+    ByteArrayOutputStream stringBuffer
+
+    PrintStreamAndStringBuilder(PrintStream os) {
+        this.os = os
+        this.stringBuffer = new ByteArrayOutputStream()
+    }
+
+
+    @Override
+    void write(int i) throws IOException {
+        os.write(i)
+        stringBuffer.write(i)
+    }
+
+    @Override
+    void write(byte[] var1) throws IOException {
+        os.write(var1, 0, var1.length);
+        stringBuffer.write(var1, 0, var1.length);
+    }
+
+    @Override
+    void write(byte[] var1, int var2, int var3) throws IOException {
+        os.write(var1, var2, var3)
+        stringBuffer.write(var1, var2, var3)
+    }
+
+    String toString() {
+        stringBuffer.toString()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Utils.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Utils.groovy
@@ -1,0 +1,36 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class Utils {
+    static boolean isRunningOnJenkins() {
+        'JENKINS_URL' in System.getenv()
+    }
+
+    static File joinPaths(File file, String... paths) {
+        paths.each{ String path ->
+            file = new File(file, path)
+        }
+        return file
+    }
+}


### PR DESCRIPTION
* Three new adb_tasks were added: startEmulator, stopEmulator, and retrieveLogcat
* startEmulator creates an avd if necessary and the starts the emulator.
  An already running emulator is reused.
* retrieveLogcat downloads the logcat.txt file from the device.
* The buildScripts are kept around until the Android SDK can be
  installed via gradle, see JENKINS-217.
* The Jenkinsfile uses the gradle tasks directly.
  This makes it more transparent of what is happening.
  It is the task's job to work correctly on both Jenkins and locally.
* Much of the groovy code is type checked during compilation.
  As a result not all tasks need to be run to find errors in buildSrc.
  This can also be seen as preparation to move buildSrc into its
  own gradle plugin.

Note: Does currently not support running multiple emulators at the same time.
      The avd name is not used to look up the pid of a running emulator.
      Of course when you use docker you can run multiple instances at once.

Note2: This is an initial PR. PRs in the following weeks will add further steps like installing the SDK or handling multiple images. It is here to see if the solution is feasible per se.
The changes were tested on both Linux and Windows though.

@redeamer please also check the changes.