### PR TITLE
JENKINS-236 Activate JaCoCo for tests only if -PenableCoverage is spe…

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -58,7 +58,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
         debug {
-            testCoverageEnabled = true
+            testCoverageEnabled = project.hasProperty('enableCoverage')
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ ext {
     androidMinSdkVersion = 17
     androidTargetSdkVersion = 22
 
-    androidVersionCode = 21
-    androidVersionName = '2.0.1'
+    androidVersionCode = 22
+    androidVersionName = '2.1.0'
 }
 
 allprojects {

--- a/buildScripts/build_helper_run_tests_on_emulator
+++ b/buildScripts/build_helper_run_tests_on_emulator
@@ -43,7 +43,7 @@ if len(sys.argv) > 1:
 build_helper_functions.bring_emulator_in_running_state()
 
 ## RUN tests
-test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), 'clean', 'adbDisableAnimationsGlobally', 'createDebugCoverageReport', 'adbResetAnimationsGlobally', '-Pjenkins' ]
+test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), '-PenableCoverage', 'clean', 'adbDisableAnimationsGlobally', 'createDebugCoverageReport', 'adbResetAnimationsGlobally', '-Pjenkins' ]
 if test_runner_arg is not None and test_runner_arg != "":
     test_runner_cmd = test_runner_cmd + [ test_runner_arg ]
 

--- a/buildScripts/build_step_run_unit_tests__all_tests
+++ b/buildScripts/build_step_run_unit_tests__all_tests
@@ -19,7 +19,7 @@ The environment variable ANDROID_SDK_ROOT needs to be set.""")
 build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
 
 ## RUN tests
-test_runner_cmd = [ build_helper_functions.get_relative_gradle_name(), '-Pjenkins', 'clean', 'jacocoTestDebugUnitTestReport' ]
+test_runner_cmd = [ build_helper_functions.get_relative_gradle_name(), '-Pjenkins', '-PenableCoverage', 'clean', 'jacocoTestDebugUnitTestReport' ]
 
 print("Calling: " + " ".join(test_runner_cmd))
 return_code = subprocess.run( test_runner_cmd, cwd=os.environ['REPO_DIR'] ).returncode


### PR DESCRIPTION
…cified in the gradle call.

Unfortunately running JaCoCo leads to a worse experience debugging the code.
The debugger does not show the value of variables anymore.
This is a known issue, see also https://issuetracker.google.com/issues/37019591

The property -PenableCoverage is set by Jenkins builds automatically.
No debugger needed there. ;)
Manually running tests in Android Studio with code coverage still works
and is not affected by this change.