### PR TITLE
PAINT-317: Fix crash in WelcomeActivity

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/ActivityRecreationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/ActivityRecreationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.espresso.intro;
+
+import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.test.espresso.intro.util.WelcomeActivityIntentsTestRule;
+import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+import static org.catrobat.paintroid.test.espresso.util.IntroUtils.getPageIndexFromLayout;
+import static org.catrobat.paintroid.test.espresso.util.UiMatcher.checkDotsColors;
+
+@RunWith(Parameterized.class)
+public class ActivityRecreationTest {
+	@Rule
+	public WelcomeActivityIntentsTestRule activityRule = new WelcomeActivityIntentsTestRule();
+
+	@Parameter
+	public String name;
+
+	@Parameter(1)
+	public int layout;
+
+	@Parameter(2)
+	public int textView;
+
+	@Parameters(name = "{0}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{"Welcome", R.layout.pocketpaint_slide_intro_welcome, R.id.pocketpaint_intro_welcome_text},
+				{"Tools", R.layout.pocketpaint_slide_intro_tools, R.id.pocketpaint_intro_tools_textview},
+				{"Possibilities", R.layout.pocketpaint_slide_intro_possibilities, R.id.pocketpaint_intro_possibilities_textview},
+				{"Landscape", R.layout.pocketpaint_slide_intro_landscape, R.id.pocketpaint_intro_landscape_text},
+				{"Getstarted", R.layout.pocketpaint_slide_intro_getstarted, R.id.pocketpaint_intro_started_text}
+				});
+	}
+
+	@Test
+	public void testToolsPageDoesNotCrashAfterRecreate() {
+		int toolsPageIndex = getPageIndexFromLayout(activityRule.getLayouts(), layout);
+		EspressoUtils.changeIntroPage(toolsPageIndex);
+
+		activityRule.recreateActivity();
+
+		onView(withId(textView))
+				.check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testToolsPageRestoreDotsColor() {
+		int toolsPageIndex = getPageIndexFromLayout(activityRule.getLayouts(), layout);
+		EspressoUtils.changeIntroPage(toolsPageIndex);
+
+		activityRule.recreateActivity();
+
+		int colorActive = activityRule.getColorActive();
+		int colorInactive = activityRule.getColorInactive();
+
+		onView(withId(R.id.pocketpaint_layout_dots))
+				.check(matches(checkDotsColors(toolsPageIndex, colorActive, colorInactive)));
+	}
+}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/util/WelcomeActivityIntentsTestRule.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/util/WelcomeActivityIntentsTestRule.java
@@ -22,8 +22,10 @@ package org.catrobat.paintroid.test.espresso.intro.util;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
+import android.support.v4.content.ContextCompat;
 import android.util.LayoutDirection;
 
+import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.WelcomeActivity;
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
 import org.catrobat.paintroid.test.espresso.util.LanguageSupport;
@@ -56,11 +58,11 @@ public class WelcomeActivityIntentsTestRule extends IntentsTestRule<WelcomeActiv
 	}
 
 	public int getColorActive() {
-		return getActivity().colorActive;
+		return ContextCompat.getColor(getActivity(), R.color.pocketpaint_welcome_dot_active);
 	}
 
 	public int getColorInactive() {
-		return getActivity().colorInactive;
+		return ContextCompat.getColor(getActivity(), R.color.pocketpaint_welcome_dot_inactive);
 	}
 
 	@Override
@@ -93,5 +95,17 @@ public class WelcomeActivityIntentsTestRule extends IntentsTestRule<WelcomeActiv
 
 		Context targetContext = InstrumentationRegistry.getTargetContext();
 		LanguageSupport.setLocale(targetContext, new Locale("en"));
+	}
+
+	public void recreateActivity() {
+		InstrumentationRegistry.getInstrumentation().runOnMainSync(
+				new Runnable() {
+					@Override
+					public void run() {
+						getActivity().recreate();
+					}
+				}
+		);
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
@@ -46,10 +46,8 @@ import static org.catrobat.paintroid.intro.helper.WelcomeActivityHelper.reverseA
 
 public class WelcomeActivity extends AppCompatActivity {
 
-	@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-	public int colorActive;
-	@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-	public int colorInactive;
+	private int colorActive;
+	private int colorInactive;
 	@VisibleForTesting
 	public ViewPager viewPager;
 	private LinearLayout dotsLayout;
@@ -57,9 +55,8 @@ public class WelcomeActivity extends AppCompatActivity {
 	public int[] layouts;
 	private Button btnSkip;
 	private Button btnNext;
-	ViewPager.OnPageChangeListener viewPagerPageChangeListener = new ViewPager.OnPageChangeListener() {
+	ViewPager.OnPageChangeListener viewPagerPageChangeListener = new ViewPager.SimpleOnPageChangeListener() {
 		int pos;
-		int state;
 
 		@Override
 		public void onPageSelected(int position) {
@@ -73,37 +70,28 @@ public class WelcomeActivity extends AppCompatActivity {
 				btnNext.setText(R.string.next);
 				btnSkip.setVisibility(View.VISIBLE);
 			}
-
-			if (layouts[position] == R.layout.pocketpaint_slide_intro_tools) {
-
-				View layout = findViewById(R.id.pocketpaint_intro_tools_bottom_bar);
-				LinearLayout mToolsLayout = layout.findViewById(R.id.pocketpaint_tools_layout);
-				final View fadeView = findViewById(R.id.pocketpaint_intro_tools_textview);
-
-				TapTargetBottomBar tapTargetBottomBar = new TapTargetBottomBar(mToolsLayout,
-						fadeView, WelcomeActivity.this, R.id.pocketpaint_intro_tools_bottom_bar);
-
-				tapTargetBottomBar.initTargetView();
-			}
-		}
-
-		@Override
-		public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-			pos = position;
 		}
 
 		@Override
 		public void onPageScrollStateChanged(int state) {
-			this.state = state;
-			if (state == ViewPager.SCROLL_STATE_IDLE
-					&& layouts[pos] == R.layout.pocketpaint_slide_intro_possibilities) {
-				View layout = findViewById(R.id.pocketpaint_intro_possibilites_topbar);
-				LinearLayout view = layout.findViewById(R.id.pocketpaint_top_bar_buttons);
-				final View fadeView = findViewById(R.id.pocketpaint_intro_possibilities_textview);
+			if (state == ViewPager.SCROLL_STATE_IDLE) {
+				if (layouts[pos] == R.layout.pocketpaint_slide_intro_possibilities) {
+					View layout = findViewById(R.id.pocketpaint_intro_possibilites_topbar);
+					LinearLayout view = layout.findViewById(R.id.pocketpaint_top_bar_buttons);
+					final View fadeView = findViewById(R.id.pocketpaint_intro_possibilities_textview);
 
-				TapTargetTopBar target = new TapTargetTopBar(view, fadeView,
-						WelcomeActivity.this, R.id.pocketpaint_intro_possibilities_bottom_bar);
-				target.initTargetView();
+					TapTargetTopBar target = new TapTargetTopBar(view, fadeView,
+							WelcomeActivity.this, R.id.pocketpaint_intro_possibilities_bottom_bar);
+					target.initTargetView();
+				} else if (layouts[pos] == R.layout.pocketpaint_slide_intro_tools) {
+					View layout = findViewById(R.id.pocketpaint_intro_tools_bottom_bar);
+					LinearLayout view = layout.findViewById(R.id.pocketpaint_tools_layout);
+					final View fadeView = findViewById(R.id.pocketpaint_intro_tools_textview);
+
+					TapTargetBottomBar target = new TapTargetBottomBar(view, fadeView,
+							WelcomeActivity.this, R.id.pocketpaint_intro_tools_bottom_bar);
+					target.initTargetView();
+				}
 			}
 		}
 	};


### PR DESCRIPTION
* Move page selection handling to `onPageScrollStateChanged`
* This stops the crashes, but after recreation the listeners get discarded.
  Switching pages will recreate them, I guess this is still better than
  having crashes.