### PR TITLE
PAINT-327: Fix tests not working on api < 21

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -50,15 +50,18 @@ android {
         versionName rootProject.ext.androidVersionName
         externalNativeBuild.cmake.cppFlags "-fvisibility=hidden"
         ndk.abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
-        multiDexEnabled true
     }
 
     buildTypes {
         release {
-            proguardFiles getDefaultProguardFile('proguard-android.txt')
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {
             testCoverageEnabled = project.hasProperty('enableCoverage')
+            // Multidex is required as espresso and mockito/bytebuddy are adding more functions
+            // than should be allowed by law.
+            // See https://github.com/mockito/mockito/issues/1112
+            multiDexEnabled true
         }
     }
 
@@ -82,6 +85,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.getkeepsafe.taptargetview:taptargetview:1.11.0'
+    debugImplementation 'com.android.support:multidex:1.0.3'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.18.3'

--- a/Paintroid/proguard-rules.pro
+++ b/Paintroid/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/Paintroid/src/debug/AndroidManifest.xml
+++ b/Paintroid/src/debug/AndroidManifest.xml
@@ -17,24 +17,6 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.catrobat.paintroid.app">
-
-    <application
-        android:allowBackup="false"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/pocketpaint_app_name"
-        android:extractNativeLibs="false"
-        android:resizeableActivity="false"
-        tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
-
-        <activity
-            android:name="org.catrobat.paintroid.MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-    </application>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:name="android.support.multidex.MultiDexApplication" />
 </manifest>

--- a/Paintroid/src/main/AndroidManifest.xml
+++ b/Paintroid/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.catrobat.paintroid"
-    android:finishOnTaskLaunch="true"
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -31,31 +30,17 @@
         <activity
             android:name=".WelcomeActivity"
             android:theme="@style/PocketPaintSplashTheme"
-            android:screenOrientation="portrait" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-            </intent-filter>
+            android:screenOrientation="portrait" />
+
+        <activity
+            android:name=".MainActivity"
+            android:theme="@style/PocketPaintSplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.GET_CONTENT" />
 
                 <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
                 <category android:name="android.intent.category.ALTERNATIVE" />
                 <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:mimeType="image/*" />
-            </intent-filter>
-        </activity>
-        <activity
-            android:name=".MainActivity"
-            android:theme="@style/PocketPaintSplashTheme">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.GET_CONTENT" />
-
-                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
-                <category android:name="android.intent.category.ALTERNATIVE" />
 
                 <data android:mimeType="image/*" />
             </intent-filter>

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,11 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        // CAUTION
+        // Increasing the android gradle plugin version number may or may not break the
+        // tests on Kitkat.
+        // See https://github.com/googlesamples/android-testing/issues/179
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
         classpath 'com.novoda:bintray-release:0.8.1'
     }


### PR DESCRIPTION
* Mark only debug builds with `multiDexEnabled`
  * We actually only need it for androidTest builds
    as espresso + support libraries + mockito already need more than 64k functions
* Revert android gradle plugin version back to `3.0.1`
* Add a template proguard config for the `Paintroid` module
* Add the support multidex module to debug builds
* Set the application name to `android.support.multidex.MultiDexApplication`
  for debug builds
* Fix Pocket Paint showing up twice in the app selection for images
* Fix some small issues in the manifest files