### PR TITLE
JENKINS-215, JENKINS-217 Download dependencies, create, start and sto…

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -17,6 +17,34 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import org.catrobat.gradle.EmulatorsPlugin
+
+apply plugin: EmulatorsPlugin
+
+emulators {
+    dependencies {
+        sdk()
+        ndk()
+    }
+
+    emulator 'android24', {
+        avd {
+            systemImage = 'system-images;android-24;default;x86_64'
+            sdcardSizeMb = 200
+            hardwareProperties += ['hw.ramSize': 800, 'vm.heapSize': 128]
+            screenDensity = 'xhdpi'
+        }
+
+        parameters {
+            resolution = '768x1280'
+            language = 'en'
+            country = 'US'
+        }
+    }
+
+    shouldInstallEverythingAbove(project.hasProperty('installSdk'))
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco-android'
 apply plugin: 'checkstyle'

--- a/Paintroid/gradle/adb_tasks.gradle
+++ b/Paintroid/gradle/adb_tasks.gradle
@@ -17,46 +17,21 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-def getAndroidDevices() {
-    def deviceIds = []
-    [ android.getAdbExecutable().absolutePath, 'devices' ].execute().text.eachLine { line ->
-        def matcher = line =~ /^(.*)\tdevice/
-        if (matcher) {
-            deviceIds << matcher[0][1]
-        }
-    }
-    deviceIds
+import org.catrobat.gradle.Adb
+import org.catrobat.gradle.AndroidDevice
+
+Adb adb() {
+    new Adb(android.getAdbExecutable())
 }
 
-def getAndroidSerial() {
-    def availableDevices = getAndroidDevices()
-    def androidSerial = System.getenv('ANDROID_SERIAL')
-
-    if (androidSerial?.trim() && !availableDevices.contains(androidSerial)) {
-        throw new IllegalStateException("Device ${androidSerial} not found")
-    } else if (availableDevices.size() == 0) {
-        throw new IllegalStateException("No connected devices!")
-    } else {
-        androidSerial = availableDevices.first()
-    }
-
-    return androidSerial.toString().trim()
-}
-
-def executeShellCommand(command) {
-    println("executing: ${command}")
-    def process = new ProcessBuilder(command).redirectErrorStream(true).start()
-    process.inputStream.eachLine {println it}
-    process.waitFor()
-    if(process.exitValue() != 0)
-        throw new GradleScriptException("adb exited with exit status ${process.exitValue()}", null)
+def androidDevice(String androidSerial = null) {
+    new AndroidDevice(adb(), androidSerial)
 }
 
 def createAdbInstallTask(variant) {
     task ("commandlineAdbInstall${variant.name.capitalize()}") {
         doLast {
-            def command = [ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'install', variant.outputs[0].outputFile.path ]
-            executeShellCommand(command)
+            androidDevice().install(variant.outputs[0].outputFile.path)
         }
     }
 }
@@ -71,77 +46,27 @@ android.testVariants.all { variant ->
 
 task commandlineAdbRunTests {
     doLast {
-        def command = []
-        command.addAll([ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'shell', 'am', 'instrument', '-w', '-e', 'junitOutputDirectory', '/mnt/sdcard/testresults' ])
-        if (System.properties['noDeviceTests']){
-            command.addAll(['-e', 'notAnnotation', 'org.catrobat.catroid.uitest.annotation.Device'])
-        }
-        if (System.properties['onlyDeviceTests']){
-            command.addAll(['-e', 'annotation', 'org.catrobat.catroid.uitest.annotation.Device'])
-        }
-        if (System.properties['testClass']){
-            command.addAll(['-e', 'class', System.properties['testClass'].toString()])
-        }
-        if (System.properties['testPackage']){
-            command.addAll(['-e', 'package', System.properties['testPackage'].toString()])
-        }
+        def device = androidDevice()
 
-        command.addAll(["${android.defaultConfig.testApplicationId}/${android.defaultConfig.testInstrumentationRunner}".toString()])
-        executeShellCommand(command)
+        def cmd = device.command(['shell', 'am', 'instrument', '-w', '-e', 'junitOutputDirectory', '/mnt/sdcard/testresults'])
+        cmd.addOptionalArguments(System.properties['noDeviceTests'], ['-e', 'notAnnotation', 'org.catrobat.catroid.uitest.annotation.Device'])
+        cmd.addOptionalArguments(System.properties['onlyDeviceTests'], ['-e', 'annotation', 'org.catrobat.catroid.uitest.annotation.Device'])
+        cmd.addOptionalArguments(System.properties['testClass'], ['-e', 'class', System.properties['testClass'].toString()])
+        cmd.addOptionalArguments(System.properties['testPackage'], ['-e', 'package', System.properties['testPackage'].toString()])
+        cmd.addArguments(["${android.defaultConfig.testApplicationId}/${android.defaultConfig.testInstrumentationRunner}".toString()])
+        cmd.verbose().execute(null)
 
-        def adbPath = project.getBuildDir().getPath()+"/adb"
-        def adbTestPath = adbPath+"/test"
-        def adbScreenshotsPath = adbPath+"/robotium_screenshots"
+        def adbPath = project.getBuildDir().getPath() + "/adb"
         file(adbPath).deleteDir()
+
+        def adbTestPath = adbPath + "/test"
         file(adbTestPath).mkdirs()
-        file(adbScreenshotsPath).mkdirs()
+        device.command(['pull', '/sdcard/testresults', adbTestPath]).verbose().execute()
 
-        def testPullCommand = [ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'pull', '/sdcard/testresults', adbTestPath ]
-        def screenshotsPullCommand = [ android.getAdbExecutable().absolutePath, '-s', getAndroidSerial(), 'pull', '/sdcard/Robotium-Screenshots', adbScreenshotsPath ]
-
-        executeShellCommand(testPullCommand)
         try {
-            executeShellCommand(screenshotsPullCommand)
+            def adbScreenshotsPath = adbPath + "/robotium_screenshots"
+            file(adbScreenshotsPath).mkdirs()
+            device.command(['pull', '/sdcard/Robotium-Screenshots', adbScreenshotsPath]).verbose().execute()
         } catch (GradleScriptException) {}
-    }
-}
-
-task adbDisableAnimationsGlobally() {
-    description 'Disables android animations globally on the connected device'
-    group 'android'
-
-    doLast {
-        logger.lifecycle(description)
-
-        def androidSerial = getAndroidSerial()
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'window_animation_scale', '0.0'
-        }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'transition_animation_scale', '0.0'
-        }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'animator_duration_scale', '0.0'
-        }
-    }
-}
-
-task adbResetAnimationsGlobally() {
-    description 'Reset android animations globally on the connected device'
-    group 'android'
-
-    doLast {
-        logger.lifecycle(description)
-
-        def androidSerial = getAndroidSerial()
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'delete', 'global', 'window_animation_scale'
-        }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'delete', 'global', 'transition_animation_scale'
-        }
-        exec {
-            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'delete', 'global', 'animator_duration_scale'
-        }
     }
 }

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Adb.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Adb.groovy
@@ -1,0 +1,73 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class Adb {
+    File adbExe
+
+    Adb(File adbExe) {
+        this.adbExe = adbExe
+    }
+
+    CommandBuilder command() {
+        new CommandBuilder(adbExe)
+    }
+
+    List<String> getAndroidDevices() {
+        List<String> deviceIds = []
+        command().addArguments(['devices']).execute().eachLine { line ->
+            line = line.trim()
+            def i = line.indexOf('\tdevice')
+            if (i > 0) {
+                deviceIds << line.substring(0, i)
+            }
+        }
+        deviceIds
+    }
+
+    String getAndroidSerial() {
+        def availableDevices = getAndroidDevices()
+        def androidSerial = System.getenv('ANDROID_SERIAL')
+
+        if (androidSerial?.trim() && !availableDevices.contains(androidSerial)) {
+            throw new DeviceNotFoundException("Device ${androidSerial} not found")
+        } else if (availableDevices.size() == 0) {
+            throw new NoDeviceException("No connected devices!")
+        } else {
+            androidSerial = availableDevices.first()
+        }
+
+        return androidSerial.toString().trim()
+    }
+
+    String waitForSerial(int timeout=60) {
+        for (int i = 0; i < timeout; ++i) {
+            try {
+                return getAndroidSerial()
+            } catch (NoDeviceException) {
+                sleep(1000)
+            }
+        }
+        return getAndroidSerial()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidDevice.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidDevice.groovy
@@ -1,0 +1,111 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class AndroidDevice {
+    Adb adb
+    String androidSerial
+
+    AndroidDevice(Adb adb, String androidSerial = null) {
+        this.adb = adb
+        this.androidSerial = androidSerial ?: adb.getAndroidSerial()
+    }
+
+    /**
+     * @return A command builder with the given command and using the serial to run on the device
+     */
+    CommandBuilder command(List additionalParameters) {
+        adb.command().addArguments(['-s', androidSerial]).addArguments(additionalParameters)
+    }
+
+    void setGlobalSetting(String setting_name, def value) {
+        command(['shell', 'settings', 'put', 'global', setting_name, value.toString()]).verbose().execute()
+    }
+
+    void deleteGlobalSetting(String setting_name) {
+        command(['shell', 'settings', 'delete', 'global', setting_name]).verbose().execute()
+    }
+
+    void writeLogcat(File logcat) {
+        if (!stillRunning()) {
+            println("WARNING: Cannot retrieve logcat from '$androidSerial'.")
+            return
+        }
+        logcat.withOutputStream { os ->
+            command(['logcat', '-d']).executeAsynchronously().waitForProcessOutput(os, os)
+        }
+    }
+
+    void waitForBooted() {
+        println("Waiting for device $androidSerial to be booted.")
+        for (int i = 0; i < 60; ++i) {
+            def result = command(['shell', 'getprop', 'sys.boot_completed']).execute().trim()
+            if (result == "1") {
+                println("Deivce $androidSerial booted successfully.")
+                return
+            }
+
+            sleep(1000)
+        }
+        throw new BootIncompleteException("The boot of device $androidSerial did not complete.")
+    }
+
+    void waitForStopped() {
+        println("Wait for device $androidSerial to stop.")
+        for (int i = 0; i < 30; ++i) {
+            if (!stillRunning()) {
+                // device could not be found, thus it is stopped
+                return
+            }
+            sleep(1000)
+        }
+
+        // If it turns out that the emulator fails to be killed often consider killing
+        // the emulator via OS commands.
+        // Similar to what was done in buildScripts/
+        throw new ResourceException("Failed to stop device $androidSerial.")
+    }
+
+    void install(File apk) {
+        println("Installing '$apk'")
+        command(['install', apk]).verbose().execute()
+    }
+
+    void disableAnimationsGlobally() {
+        println("Disabling animations for device $androidSerial.")
+        setGlobalSetting('window_animation_scale', '0.0')
+        setGlobalSetting('transition_animation_scale', '0.0')
+        setGlobalSetting('animator_duration_scale', '0.0',)
+    }
+
+    void resetAnimationsGlobally() {
+        println("Resetting animations for device $androidSerial.")
+        deleteGlobalSetting('window_animation_scale')
+        deleteGlobalSetting('transition_animation_scale')
+        deleteGlobalSetting('animator_duration_scale')
+    }
+
+    private boolean stillRunning() {
+        adb.getAndroidDevices().contains(androidSerial)
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidNdk.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidNdk.groovy
@@ -1,0 +1,88 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+/**
+ * Allows to install the Android SDK Tools.
+ */
+@TypeChecked
+class AndroidNdk extends ManualToolDownloader {
+    boolean installLatest = false
+    String latestVersion
+    String packageName = 'ndk-bundle'
+
+    AndroidNdk(File androidSdk, Closure settings = null) {
+        super(androidSdk)
+
+        addVersion('16.1.4479499', {
+            linux('android-ndk-r16b-linux-x86_64.zip', 'bcdea4f5353773b2ffa85b5a9a2ae35544ce88ec5b507301d8cf6a76b765d901')
+            mac('android-ndk-r16b-darwin-x86_64.zip', '9654a692ed97713e35154bfcacb0028fdc368128d636326f9644ed83eec5d88b')
+            windows('android-ndk-r16b-windows-x86_64.zip', '4c6b39939b29dfd05e27c97caf588f26b611f89fe95aad1c987278bd1267b562')
+        }, ['r16b', '16b'])
+
+        if (settings) {
+            apply(settings)
+        }
+    }
+
+    @Override
+    String packageDescription() {
+        'Android NDK'
+    }
+
+    @Override
+    void setVersion(String version) {
+        if (version == 'latest') {
+            installLatest = true
+        } else {
+            installLatest = false
+            super.setVersion(version)
+        }
+    }
+
+    @Override
+    protected void checkInstalled() {
+        String v = version
+        if (installLatest) {
+            if (!latestVersion) {
+                latestVersion = sdkManager.latestVersion(packageName)
+            }
+            v = latestVersion
+        }
+
+        throwOnFailure(sdkManager.isInstalled(packageName, v), "Package [$packageName] version [$v] is not installed!")
+    }
+
+    @Override
+    protected void forceInstall() {
+        println("Installing ${packageDescription()}...")
+
+        if (installLatest) {
+            sdkManager.install([packageName])
+        } else {
+            downloadAndExtract(androidSdk, packageName)
+        }
+        checkInstalled()
+
+        println("Installed ${packageDescription()}.")
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidSdkTools.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AndroidSdkTools.groovy
@@ -1,0 +1,67 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+/**
+ * Allows to install the Android SDK Tools.
+ */
+@TypeChecked
+class AndroidSdkTools extends ManualToolDownloader {
+    String packageName = 'tools'
+
+    AndroidSdkTools(File androidSdk, Closure settings = null) {
+        super(androidSdk)
+
+        addVersion('26.1.1', {
+            linux('sdk-tools-linux-4333796.zip', '92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9')
+            mac('sdk-tools-darwin-4333796.zip', 'ecb29358bc0f13d7c2fa0f9290135a5b608e38434aad9bf7067d0252c160853e')
+            windows('sdk-tools-windows-4333796.zip', '7e81d69c303e47a4f0e748a6352d85cd0c8fd90a5a95ae4e076b5e5f960d3c7a')
+        }, ['latest'])
+
+        if (settings) {
+            apply(settings)
+        }
+    }
+
+    @Override
+    String packageDescription() {
+        'Android SDK Tools'
+    }
+
+    /**
+     * Throws an exception if the tools are not installed (correctly).
+     */
+    @Override
+    protected void checkInstalled() {
+        throwOnFailure(androidSdk.isDirectory(), "[$androidSdk] is not a directory!")
+        throwOnFailure(sdkManager.canExecute(), "[$sdkManager] is not executable!")
+        throwOnFailure(sdkManager.isInstalled(packageName, version), "Package [$packageName] version [$version] is not installed!")
+    }
+
+    @Override
+    protected void forceInstall() {
+        println("Installing ${packageDescription()}...")
+        downloadAndExtract(androidSdk, packageName)
+        checkInstalled()
+        println("Installed ${packageDescription()}.")
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AvdCreator.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AvdCreator.groovy
@@ -1,0 +1,123 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.transform.TypeChecked
+
+/**
+ * Creates an avd with the given settings.
+ *
+ * The hardware properties are written to the avd config file.
+ */
+@TypeChecked
+class AvdCreator {
+    File sdkDirectory
+    Map environment
+    File avdStore
+    File existingAvds
+
+    AvdCreator(File sdkDirectory, Map environment) {
+        this.sdkDirectory = sdkDirectory
+        this.environment = environment
+
+        String avd_home = environment['ANDROID_AVD_HOME']
+        if (!avd_home) {
+            throw new IllegalStateException("The environment does not contain an ANDROID_AVD_HOME.")
+        }
+        this.avdStore = new File(avd_home)
+        this.existingAvds = new File(avdStore, 'avdstore.json')
+    }
+
+    void createAvd(String avdName, AvdSettings settings) {
+        checkSettings(settings)
+
+        storeAvd(avdName, settings)
+
+        def avdmanager = new CommandBuilder(Utils.joinPaths(sdkDirectory, 'tools', 'bin', 'avdmanager'), '.bat')
+
+        avdmanager.addArguments(['create', 'avd', '-f', '-n', avdName])
+        avdmanager.addOptionalArguments(settings.sdcardSizeMb, ['-c', "${settings.sdcardSizeMb}M"])
+        avdmanager.addArguments(['-k', settings.systemImage])
+        avdmanager.addArguments(settings.arguments)
+
+        avdmanager.input('no\r\n').directory(avdStore).environment(environment).verbose()
+        avdmanager.execute()
+
+        // update the avd ini-file with the specified properties
+        def avdConfigFile = new IniFile(Utils.joinPaths(avdStore, avdName + '.avd', 'config.ini'))
+        avdConfigFile.updateValues(settings.hardwareProperties)
+    }
+
+    void reuseOrCreateAvd(String avdName, AvdSettings settings) {
+        if (!containsAvd(avdName, settings)) {
+            println("Create AVD")
+            createAvd(avdName, settings)
+        }
+    }
+
+    private void checkSettings(AvdSettings settings) {
+        def throw_if_null = { name, value ->
+            if (!value) {
+                throw new IllegalStateException("Setting '$name' is not specified but needed by createAvd.")
+            }
+        }
+
+        throw_if_null(settings.systemImage, 'systemImage')
+        throw_if_null(settings.screenDensity, 'screenDensity')
+    }
+
+    private boolean containsAvd(String name, AvdSettings settings) {
+        def avds = readExistingAvds()
+        if (avds[name] != Utils.asMap(settings)) {
+            return false
+        }
+
+        avdDir(name).exists() && avdIni(name).exists()
+    }
+
+    private Map readExistingAvds() {
+        if (!existingAvds.exists() || !existingAvds.canRead()) {
+            return [:]
+        }
+
+        new JsonSlurper().parseText(existingAvds.text) as Map ?: [:]
+    }
+
+    void storeAvd(String name, AvdSettings settings) {
+        println("Storing avd [$name]")
+        avdDir(name).deleteDir()
+        avdIni(name).delete()
+
+        Map avds = readExistingAvds()
+        avds[name] = Utils.asMap(settings)
+        existingAvds.delete()
+        existingAvds << JsonOutput.toJson(avds)
+    }
+
+    private File avdDir(String name) {
+        new File(avdStore, "${name}.avd")
+    }
+
+    private File avdIni(String name) {
+        new File(avdStore, "${name}.ini")
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/AvdSettings.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/AvdSettings.groovy
@@ -1,0 +1,56 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+/**
+ * Settings to use for avd creation.
+ *
+ * Users can specify additional command line arguments and hardware properties.
+ * The hardware properties are then written to the avd config file.
+ *
+ * For how these settings are used see AvdCreator.
+ */
+@TypeChecked
+class AvdSettings {
+    String systemImage
+    Integer sdcardSizeMb
+    Map hardwareProperties = [:]
+    List arguments = []
+    private static Map screenDensityLookup = ['ldpi': '120', 'mdpi': '160', 'tvdpi': '213',
+                                              'hdpi': '240', 'xhdpi': '320', 'xxhdpi': '480',
+                                              'xxxhdpi': '640']
+    private static String screenDensityName = 'hw.lcd.density'
+
+    void setScreenDensity(String density) {
+        if (density in screenDensityLookup) {
+            hardwareProperties[screenDensityName] = screenDensityLookup[density]
+        } else if (density.isNumber()) {
+            hardwareProperties[screenDensityName] = density
+        } else {
+            throw new InputMismatchException("'$density' is not a valid density")
+        }
+    }
+
+    String getScreenDensity() {
+        return hardwareProperties[screenDensityName]
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/CommandBuilder.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/CommandBuilder.groovy
@@ -1,0 +1,127 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.GradleScriptException
+
+@TypeChecked
+class CommandBuilder {
+    File exe
+    File workingDirectory
+    Map<String, String> environment
+    List arguments = []
+    String input
+    boolean verbose = false
+
+    CommandBuilder(File exe) {
+        this.exe = exe
+    }
+
+    CommandBuilder(File exe, String winEnding) {
+        this.exe = Utils.executable(exe, winEnding)
+    }
+
+    CommandBuilder directory(File workingDirectory) {
+        this.workingDirectory = workingDirectory
+        this
+    }
+
+    CommandBuilder environment(Map<String, String> environment) {
+        this.environment = environment
+        this
+    }
+
+    CommandBuilder addArguments(List arguments ) {
+        this.arguments += arguments
+        this
+    }
+
+    CommandBuilder addOptionalArguments(def shouldAdd, List arguments) {
+        if (shouldAdd) {
+            this.arguments += arguments
+        }
+        this
+    }
+
+    CommandBuilder verbose() {
+        verbose = true
+        this
+    }
+
+    CommandBuilder input(String input) {
+        this.input = input
+        this
+    }
+
+    String execute(long timeoutSecs=30) {
+        def proc = executeInternal()
+
+        def stdout = verbose ? new PrintStreamAndStringBuilder(System.out) : new ByteArrayOutputStream()
+        def stderr = verbose ? new PrintStreamAndStringBuilder(System.err) : new ByteArrayOutputStream()
+
+        proc.consumeProcessOutput(stdout, stderr)
+        proc.waitForOrKill(timeoutSecs * 1000)
+
+        if (proc.exitValue()) {
+            throw new GradleScriptException("Failed to execute ${commandLine().join(' ')} " +
+                    "exit code ${proc.exitValue()} Err:\n$stdout\nText:\n$stderr", null)
+        }
+
+        stdout.toString()
+    }
+
+    /**
+     * Starts a job in the background.
+     *
+     * When verbose is activated the process output will be forwarded to stdout/stderr.
+     * @note You have to handle the process output yourself if you do not activate verbose.
+     *       Thus you have to call consumeProcessOutput or waitForProcessOutput.
+     *       Otherwise the internal buffers can be filled, which will lead to the process failing!
+     */
+    Process executeAsynchronously() {
+        def proc = executeInternal()
+        if (verbose) {
+            proc.consumeProcessOutput(new PrintStream(System.out, true), new PrintStream(System.err, true))
+        }
+
+        proc
+    }
+
+    List commandLine() {
+        [exe] + arguments
+    }
+
+    private Process executeInternal() {
+        def cmd = commandLine()
+        if (verbose) {
+            println("Executing: ${cmd.join(' ')}")
+        }
+
+        def proc = cmd.execute(environment?.collect { k, v -> "$k=$v"}, workingDirectory)
+
+        if (input) {
+            proc << input
+        }
+
+        proc
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/DependenciesExtension.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/DependenciesExtension.groovy
@@ -1,0 +1,72 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class DependenciesExtension {
+    List<String> packages = []
+    Closure sdkSettings
+    Closure ndkSettings
+
+    void apply(Closure settings) {
+        Utils.applySettings(settings, this)
+    }
+
+    /**
+     * Specify that the Android NDK should be installed.
+     * @param settings Settings for the NDK in a closure, see AndroidNdk.
+     *                 In general you want to use the most recent NDK, thus do not specify
+     *                 a version here unless you have very good reasons.
+     */
+    void ndk(@DelegatesTo(AndroidNdk) Closure settings) {
+        this.ndkSettings = settings
+    }
+
+    /**
+     * Specifies that the latest Android NDK version should be installed.
+     */
+    void ndk() {
+        ndk({ version = 'latest' })
+    }
+
+    /**
+     * @param settings for the SDK in a closure, see AndroidSdkTools.
+     */
+    void sdk(@DelegatesTo(AndroidSdkTools) Closure settings) {
+        this.sdkSettings = settings
+    }
+
+    /**
+     * Specifies that the latest Android SDK Tools version should be installed.
+     */
+    void sdk() {
+        sdk({ version = 'latest' })
+    }
+
+    /**
+     * @param packages exact name of additional packages to install, as listed by the sdkmanager.
+     * @note Do not specify the android emulator image here, use the emulator blocks instead.
+     */
+    void packages(List<String> packages) {
+        this.packages += packages
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorExtension.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorExtension.groovy
@@ -1,0 +1,46 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class EmulatorExtension {
+    AvdSettings avdSettings
+    List<Closure> emulatorParameters = []
+
+    /**
+     * @param avdSettings settings of the avd to create, see AvdSettings.
+     *        They are then used as input for AvdCreator.
+     */
+    void avd(@DelegatesTo(AvdSettings) Closure avdSettings) {
+        if (!this.avdSettings) {
+            this.avdSettings = new AvdSettings()
+        }
+        Utils.applySettings(avdSettings, this.avdSettings)
+    }
+
+    /**
+     * @param emulatorParameters parameters to start the emulator with, see EmulatorStarter
+     */
+    void parameters(@DelegatesTo(EmulatorStarter) Closure emulatorParameters) {
+        this.emulatorParameters << emulatorParameters
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorStarter.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorStarter.groovy
@@ -1,0 +1,63 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class EmulatorStarter {
+    File sdkDirectory
+    String skin = ''
+    String language = ''
+    String country = ''
+    boolean showWindow = !Utils.isRunningOnJenkins()
+    boolean keepUserData = false
+    List<String> additionalParameters = ['-gpu', 'swiftshader_indirect', '-no-boot-anim', '-noaudio']
+
+    EmulatorStarter(File sdkDirectory) {
+        this.sdkDirectory = sdkDirectory
+    }
+
+    String getResolution() {
+        skin
+    }
+
+    void setResolution(String resolution) {
+        skin = resolution
+    }
+
+    /**
+     * Starts the emulator asynchronously without checking for success.
+     * @return EmulatorStarter process
+     */
+    Process start(String avdName, Map environment) {
+        def emulator = new CommandBuilder(Utils.joinPaths(sdkDirectory, 'emulator', 'emulator'), '.exe')
+
+        emulator.addArguments(['-avd', avdName])
+        emulator.addOptionalArguments(skin, ['-skin', skin])
+        emulator.addOptionalArguments(language, ['-prop', "persist.sys.language=$language"])
+        emulator.addOptionalArguments(country, ['-prop', "persist.sys.country=$country"])
+        emulator.addOptionalArguments(!showWindow, ['-no-window'])
+        emulator.addOptionalArguments(!keepUserData, ['-wipe-data'])
+        emulator.addArguments(additionalParameters)
+
+        emulator.environment(environment).verbose().executeAsynchronously()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorsPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorsPlugin.groovy
@@ -1,0 +1,32 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class EmulatorsPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        def extension = project.extensions.create('emulators', EmulatorsPluginExtension)
+        new EmulatorsPluginTasks(project, extension).registerTasks()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorsPluginExtension.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorsPluginExtension.groovy
@@ -1,0 +1,137 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import org.gradle.api.InvalidUserDataException
+
+/**
+ * Handles installation of dependencies and setup of emulators.
+ *
+ * @note Installation of dependencies only happens for those statements above a call to
+ *       shouldInstallEverythingAbove()
+ *       The installation is performed directly in the configuration step.
+ *       This is necessary since some gradle plugins fail to run if the NDK is not installed yet.
+ *
+ *       It might be that in the future this separate handling is not necessary anymore.
+ *       To figure out if it is still necessary
+ *       1) deactivate the installation via calling installEverythingAbove(false)
+ *       2) remove the directory ANDROID_SDK_ROOT
+ *       3) run gradle without a task
+ *       If the build succeeds than the hack can be removed and installation of dependencies
+ *       can become a regular task.
+ *
+ *       To avoid issues on Jenkins and slower performance locally make shouldInstallEverythingAbove
+ *       dynamic:
+ *          shouldInstallEverythingAbove(project.hasProperty('installSdk'))
+ */
+@TypeChecked
+class EmulatorsPluginExtension {
+    boolean installEverythingBelow = false
+    Map<String, EmulatorExtension> emulatorLookup = [:]
+    Map<String, Closure> emulatorTemplates = [:]
+    DependenciesExtension dependencies = new DependenciesExtension()
+
+    void dependencies(@DelegatesTo(DependenciesExtension) Closure settings) {
+        Utils.applySettings(settings, dependencies)
+    }
+
+    /**
+     * The description of the emulator to create.
+     * @param name The name the emulator should be referenced within gradle.
+     *             This is also the name of the avd.
+     * @param settings of the emulator
+     * @example
+     *  emulator 'android24', {
+     *      avd {
+     *          systemImage = 'system-images;android-24;default;x86_64'
+     *          // ...
+     *          // see AvdCreator for the possible parameters
+     *      }
+     *
+     *      parameters {
+     *          // see EmulatorStarter for the possible parameters
+     *      }
+     *  }
+     */
+    void emulator(String name, @DelegatesTo(EmulatorExtension) Closure settings) {
+        emulator(name, '', settings)
+    }
+
+    /**
+     * Like emulator(String, Closure) only that a settings template can be specified.
+     * @param name
+     * @param templateName Name of the emulatorTemplate to use. When empty no template is used.
+     * @param settings
+     */
+    void emulator(String name, String templateName, @DelegatesTo(EmulatorExtension) Closure settings) {
+        if (emulatorLookup.containsKey(name)) {
+            throw new InvalidUserDataException("There is already an emulator named [$name]!")
+        }
+
+        Closure templateSettings = emulatorTemplates[templateName]
+        if (templateName && !templateSettings) {
+            throw new InvalidUserDataException("Unknown template name [$templateName] specified!")
+        }
+
+        def e = new EmulatorExtension()
+        if (templateSettings) {
+            Utils.applySettings(templateSettings, e)
+        }
+        Utils.applySettings(settings, e)
+        emulatorLookup[name] = e
+
+        if (!e.avdSettings || !e.emulatorParameters) {
+            throw new InvalidUserDataException("Specify both an 'avd' and a 'parameters' block for [$name]!")
+        }
+    }
+
+    /**
+     * Add a named settings template for the emulator.
+     * This template can then be used in the emulator call.
+     * As a result you can put common avd settings and emulator parameters into a template
+     * instead of duplicating them.
+     * @param name the template settings should be referenced with.
+     * @param settings
+     */
+    void emulatorTemplate(String name, @DelegatesTo(EmulatorExtension) Closure settings) {
+        if (emulatorTemplates.containsKey(name)) {
+            throw new InvalidUserDataException("There is already an emulator template named [$name]!")
+        }
+        emulatorTemplates[name] = settings
+    }
+
+    void shouldInstallEverythingAbove(boolean performInstallation) {
+        if (!performInstallation) {
+            return
+        }
+
+        def installer = new Installer()
+
+        installer.writeLicenseFiles()
+        installer.installSdk(dependencies.sdkSettings)
+        installer.installNdk(dependencies.ndkSettings)
+        installer.installPackages(dependencies.packages)
+
+        emulatorLookup.each { k, v ->
+            installer.installImage(v.avdSettings.systemImage)
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorsPluginTasks.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/EmulatorsPluginTasks.groovy
@@ -1,0 +1,212 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+@TypeChecked
+class EmulatorsPluginTasks {
+    Project project
+    EmulatorsPluginExtension ext
+
+    EmulatorsPluginTasks(Project project, EmulatorsPluginExtension ext) {
+        this.project = project
+        this.ext = ext
+    }
+
+    void registerTasks() {
+        registerRetrieveLogcatTask()
+        registerStartEmulatorTask()
+        registerStopEmulatorTask()
+        registerAdbDisableAnimationsGloballyTask()
+        registerSdbResetAnimationsGloballyTask()
+    }
+
+
+    private void registerRetrieveLogcatTask() {
+        registerTask('retrieveLogcat', {
+            description = 'Retrieves the logcat.txt from the device.'
+            group = 'android'
+
+            doLast {
+                def device = androidDevice()
+                def logcat = new File(project.rootDir, 'logcat.txt')
+                device.writeLogcat(logcat)
+            }
+        })
+    }
+
+    private void registerStartEmulatorTask() {
+        registerTask('startEmulator', {
+            description = 'Starts the android emulator. Use -Pemulator or EMULATOR_OVERRIDE to specify the emulator to use.'
+            group = 'android'
+
+            doLast {
+                def emulatorName = emulatorName()
+                def emulatorExt = lookupEmulator(emulatorName)
+
+                def avdCreator = new AvdCreator(sdkDirectory(), determineEnvironment())
+                avdCreator.reuseOrCreateAvd(emulatorName, emulatorExt.avdSettings)
+                reuseRunningOrStartEmulator(emulatorName)
+            }
+        })
+    }
+
+    private void registerStopEmulatorTask() {
+        registerTask('stopEmulator', {
+            description = 'Stops the android emulator'
+            group = 'android'
+
+            doLast {
+                try {
+                    def device = androidDevice()
+                    device.command(['emu', 'kill']).verbose().execute()
+                    device.waitForStopped()
+                } catch (NoDeviceException) {
+                    // already stopped
+                }
+            }
+        })
+    }
+
+
+    private void registerAdbDisableAnimationsGloballyTask() {
+        registerTask('adbDisableAnimationsGlobally', {
+            description = 'Disables android animations globally on the connected device'
+            group = 'android'
+
+            doLast {
+                logger.lifecycle(description)
+                androidDevice().disableAnimationsGlobally()
+            }
+        })
+    }
+
+    private void registerSdbResetAnimationsGloballyTask() {
+        registerTask('adbResetAnimationsGlobally', {
+            description = 'Reset android animations globally on the connected device'
+            group = 'android'
+
+            doLast {
+                logger.lifecycle(description)
+                androidDevice().resetAnimationsGlobally()
+            }
+        })
+    }
+
+    private void registerTask(String name, @DelegatesTo(Task) Closure settings) {
+        project.task(name, settings)
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    private File sdkDirectory() {
+        project.android.sdkDirectory
+    }
+
+    private String emulatorName() {
+        String name = System.getenv()["EMULATOR_OVERRIDE"] ?: project.properties["emulator"]
+        if (name) {
+            return name
+        }
+
+        if (ext.emulatorLookup.size() != 1) {
+            throw new InvalidUserDataException("Specify the emulator to use. Available emulators: ${ext.emulatorLookup.keySet()}")
+        }
+
+        ext.emulatorLookup.keySet().iterator().next()
+    }
+
+    private EmulatorExtension lookupEmulator(String name) {
+        if (!ext.emulatorLookup.containsKey(name)) {
+            throw new InvalidUserDataException("There is no emulator named [$name]!")
+        }
+
+        ext.emulatorLookup[name]
+    }
+
+    /**
+     * Ensure that any function here works both on local machines as well as one Jenkins.
+     *
+     * This is done by setting the needed environment variables.
+     */
+    private Map<String, String> determineEnvironment() {
+        def env = new HashMap(System.getenv())
+
+        def fallbackEnv = {k, v ->
+            if (!env.containsKey(k)) {
+                println("ENV: Setting unspecified $k to [$v]")
+                env[k.toString()] = v.toString()
+            }
+        }
+
+        fallbackEnv('ANDROID_AVD_HOME', env['WORKSPACE'] ?: project.rootDir.toPath())
+        env
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    private Adb adb() {
+        new Adb(project.android.getAdbExecutable())
+    }
+
+    private AndroidDevice androidDevice(String androidSerial = null) {
+        new AndroidDevice(adb(), androidSerial)
+    }
+
+    private void reuseRunningOrStartEmulator(String emulatorName) {
+        def proc
+        def device
+
+        try {
+            // try to access an already running emulator
+            device = androidDevice()
+        } catch (DeviceNotFoundException e) {
+            // A specific device was specified that does not exist
+            throw e
+        } catch (NoDeviceException) {
+            // no device running, start one
+            println('Start the emulator!')
+
+            def emulatorStarter = new EmulatorStarter(sdkDirectory())
+            lookupEmulator(emulatorName).emulatorParameters.each {
+                Utils.applySettings(it, emulatorStarter)
+            }
+            proc = emulatorStarter.start(emulatorName, determineEnvironment())
+
+            try {
+                device = androidDevice(adb().waitForSerial())
+            } catch(NoDeviceException e) {
+                proc.waitForOrKill(1)
+                throw e
+            }
+        }
+
+        try {
+            println("Using device ${device.androidSerial}")
+            device.waitForBooted()
+        } catch (BootIncompleteException e) {
+            proc?.waitForOrKill(1)
+            throw e
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Exceptions.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Exceptions.groovy
@@ -1,0 +1,53 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.InheritConstructors
+import groovy.transform.TypeChecked
+
+@TypeChecked
+@InheritConstructors
+class AndroidResourceException extends ResourceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class NoAvdException extends AndroidResourceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class NoDeviceException extends AndroidResourceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class DeviceNotFoundException extends NoDeviceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class BootIncompleteException extends AndroidResourceException {
+}
+
+@TypeChecked
+@InheritConstructors
+class ToolException extends AndroidResourceException {
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/IniFile.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/IniFile.groovy
@@ -1,0 +1,62 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class IniFile {
+    File iniFile
+
+    IniFile(File iniFile) {
+        this.iniFile = iniFile
+    }
+
+    /**
+     * Adds values to the ini files.
+     *
+     * Existing elements are updated in the order they are found.
+     * Remaining elements are added in alphabetical order.
+     */
+    void updateValues(Map values) {
+        def remainingSorted = new TreeMap(values)
+
+        // first update existing elements without changing their order
+        def contents = iniFile.text.readLines().collect { String line ->
+            def parts = line.split('=')
+            if (parts.size() == 2) {
+                def k = parts[0].trim()
+                if (k in values) {
+                    line = "$k=${values[k]}"
+                    remainingSorted.remove(k)
+                }
+            }
+
+            line
+        }
+
+        // now add the remaining elements in alphabetical order
+        contents += remainingSorted.collect { k, v ->
+            "$k=$v".toString()
+        }
+
+        iniFile.write(contents.join('\n'))
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Installer.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Installer.groovy
@@ -1,0 +1,116 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.resources.ResourceException
+import org.gradle.internal.impldep.org.apache.commons.lang.SystemUtils
+
+/**
+ * Handles installation of SDK, NDK, images and further modules.
+ */
+@TypeChecked
+class Installer {
+    File androidSdk
+    SdkManager sdkManager
+
+    Installer(File androidSdk = null) {
+        if (androidSdk) {
+            this.androidSdk = androidSdk
+        } else {
+            String sdkRoot = System.getenv()['ANDROID_SDK_ROOT']
+            if (!sdkRoot) {
+                throw new ResourceException("Environment variable ANDROID_SDK_ROOT is not set!")
+            }
+            this.androidSdk = new File(sdkRoot)
+        }
+        this.sdkManager = new SdkManager(this.androidSdk)
+    }
+
+    Installer installSdk(Closure sdkSettings) {
+        if (sdkSettings) {
+            new AndroidSdkTools(androidSdk, sdkSettings).install()
+        }
+        this
+    }
+
+    Installer installNdk(Closure ndkSettings) {
+        if (ndkSettings) {
+            new AndroidNdk(androidSdk, ndkSettings).install()
+        }
+        this
+    }
+
+    Installer installImage(String image) {
+        if (!image) {
+            return this
+        }
+
+        def packages = ['emulator', image]
+
+        def match = image =~ /system-images;android-(\d+);([^;]+)/
+        if (!match) {
+            throw new InvalidUserDataException("The image [$image] seems to have a wrong structure!")
+        }
+
+        if (match.group(2) == 'google_apis') {
+            def version = match.group(1)
+
+            // between api level 15 and 24 there is an explicit add-ons package for google apis listed
+            if ((15..24).contains(version as Integer)) {
+                packages << "add-ons;addon-google_apis-google-$version".toString()
+            }
+        }
+
+        installPackages(packages)
+    }
+
+    Installer installPackages(List<String> packages) {
+        if (!packages) {
+            return this
+        }
+
+        println("Installing packages [$packages] to [$androidSdk]")
+        sdkManager.install(packages)
+        this
+    }
+
+    Installer writeLicenseFiles() {
+        File licencesDir = new File(androidSdk, 'licenses')
+        licencesDir.mkdir()
+        if (!licencesDir.exists()) {
+            throw new ResourceException("The license directory could not be created: $licencesDir")
+        }
+
+        def createLicense = { String fileName, String license ->
+            File licenseFile = new File(licencesDir, fileName)
+            if (!licenseFile.exists()) {
+                licenseFile << license
+            }
+        }
+
+        createLicense('android-sdk-license', '\nd56f5187479451eabf01fb78af6dfcb131a6481e')
+        createLicense('android-sdk-preview-license', '\n84831b9409646a918e30573bab4c9c91346d8abd')
+
+        this
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/ManualToolDownloader.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/ManualToolDownloader.groovy
@@ -1,0 +1,158 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.resources.ResourceException
+
+/**
+ * Class that handles manually downloading potentially outdated Android tools like the SDK and the NDK.
+ *
+ * sdkmanager often only supports the most recent version of a tool.
+ * As a result if an older version is needed the correct zip files for the used operating
+ * system have to be downloaded manually.
+ * All this is handled by ManualToolDownloader.
+ *
+ * For usage subclass for your own tool and add all the versions you support.
+ */
+@TypeChecked
+abstract class ManualToolDownloader {
+    File androidSdk
+    SdkManager sdkManager
+    String baseUrl = 'https://dl.google.com/android/repository'
+    URL url
+    String sha256sum
+    String version
+    Map<String, String> versionLookup = [:]
+    Map<String, Closure<Void>> versions = [:]
+
+    ManualToolDownloader(File androidSdk) {
+        this.androidSdk = androidSdk
+        this.sdkManager = new SdkManager(this.androidSdk)
+    }
+
+    void apply(Closure settings) {
+        Utils.applySettings(settings, this)
+    }
+
+    void linux(String name, String sha256sum) {
+        shouldSetUrl(Os.FAMILY_UNIX, name, sha256sum)
+    }
+
+    void mac(String name, String sha256sum) {
+        shouldSetUrl(Os.FAMILY_MAC, name, sha256sum)
+    }
+
+    void windows(String name, String sha256sum) {
+        shouldSetUrl(Os.FAMILY_WINDOWS, name, sha256sum)
+    }
+
+    void addVersion(String version, Closure<Void> closure, List<String> aliases = []) {
+        versions[version] = closure
+        aliases.each { String alias ->
+            versionLookup[alias] = version
+        }
+    }
+
+    void setVersion(String version) {
+        version = versionLookup[version] ?: version
+        def settings = versions[version]
+        if (!settings) {
+            throw new ToolException("${packageDescription()} version [$version] is not supported " +
+                    "(supported: ${versions.keySet() + versionLookup.keySet()}, manually add the version you want!")
+        }
+
+        this.version = version
+        apply(settings)
+    }
+
+    /**
+     * Performs an installation if the tool was not correctly installed yet.
+     */
+    void install() {
+        try {
+            checkInstalled()
+            println("${packageDescription()} installed already.")
+        } catch (ToolException) {
+            forceInstall()
+        }
+    }
+
+    abstract String packageDescription()
+
+    /**
+     * Throws a ToolException when the tool is not installed.
+     */
+    abstract protected void checkInstalled()
+
+    abstract protected void forceInstall()
+
+    protected void download(File destination) {
+        println("Downloading $url to $destination ...")
+        destination.withOutputStream { out ->
+            url.withInputStream { from ->
+                out << from
+            }
+        }
+        println("Downloaded $url")
+
+        println("Checking checksum ...")
+        if (sha256sum && Utils.checksum(destination, 'SHA-256') != sha256sum) {
+            throw new ResourceException("Faulty checksum for $destination!")
+        }
+    }
+
+    /**
+     * @param destination The destination to extract the downloaded zip file to. Will be cleared before.
+     */
+    protected void downloadAndExtract(File parentDirectory, String directoryName) {
+        if (!url) {
+            throw new ResourceException("No url provided to download. Use all of the linux/max/windows functions!")
+        }
+
+        File destination = new File(parentDirectory, directoryName)
+        println("Removing $destination if it exists.")
+        if (!destination.deleteDir()) {
+            throw new ResourceException("Could not delete [$destination]")
+        }
+
+        def temp = File.createTempFile('zipDownloader', null)
+        download(temp)
+
+        parentDirectory.mkdirs()
+        Unzipper.unzip(temp, parentDirectory)
+        temp.delete()
+    }
+
+    protected void throwOnFailure(boolean success, String message) {
+        if (!success) {
+            throw new ToolException(message)
+        }
+    }
+
+    private void shouldSetUrl(String osFamily, String name, String sha256sum) {
+        if (Os.isFamily(osFamily)) {
+            url = new URL(baseUrl + "/" + name)
+            this.sha256sum = sha256sum
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/PrintStreamAndStringBuilder.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/PrintStreamAndStringBuilder.groovy
@@ -1,0 +1,56 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+
+@TypeChecked
+class PrintStreamAndStringBuilder extends OutputStream {
+    PrintStream os
+    ByteArrayOutputStream stringBuffer
+
+    PrintStreamAndStringBuilder(PrintStream os) {
+        this.os = os
+        this.stringBuffer = new ByteArrayOutputStream()
+    }
+
+
+    @Override
+    void write(int i) throws IOException {
+        os.write(i)
+        stringBuffer.write(i)
+    }
+
+    @Override
+    void write(byte[] var1) throws IOException {
+        os.write(var1, 0, var1.length)
+        stringBuffer.write(var1, 0, var1.length)
+    }
+
+    @Override
+    void write(byte[] var1, int var2, int var3) throws IOException {
+        os.write(var1, var2, var3)
+        stringBuffer.write(var1, var2, var3)
+    }
+
+    String toString() {
+        stringBuffer.toString()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/SdkManager.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/SdkManager.groovy
@@ -1,0 +1,80 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import org.gradle.api.resources.ResourceException
+
+/**
+ * Handles the interaction with the sdkmanager executable.
+ */
+@TypeChecked
+class SdkManager {
+    File sdkManager
+
+    SdkManager(File androidSdk) {
+        this.sdkManager = Utils.executable(Utils.joinPaths(new File(androidSdk, 'tools'), 'bin', 'sdkmanager'), '.bat')
+    }
+
+    String toString() {
+        sdkManager.toString()
+    }
+
+    void install(List<String> packages) {
+        if (packages) {
+            new CommandBuilder(sdkManager).addArguments(packages).input('y\n').verbose().execute(30 * 60)
+        }
+    }
+
+    boolean canExecute() {
+        sdkManager.canExecute()
+    }
+
+    boolean isInstalled(String packageName, String version) {
+        String result = new CommandBuilder(sdkManager).addArguments(['--list']).execute()
+        String installedPackages = result.substring(result.indexOf('Installed packages:'),
+                result.indexOf('Available Packages:'))
+
+        def lineOfPackage = installedPackages.readLines().find { it.trim().startsWith(packageName + ' ') }
+        if (!lineOfPackage) {
+            return false
+        }
+
+        def columns = lineOfPackage.split('\\|')
+        return columns.size() == 4 && columns[1].trim() == version
+    }
+
+    String latestVersion(String packageName) {
+        String result = new CommandBuilder(sdkManager).addArguments(['--list']).execute()
+        String availablePackages = result.substring(result.indexOf('Available Packages:'))
+
+        def lineOfPackage = availablePackages.readLines().find { it.trim().startsWith(packageName + ' ') }
+        if (!lineOfPackage) {
+            throw new ResourceException("Package [$packageName] is not available via sdkmanager!")
+        }
+
+        def columns = lineOfPackage.split('\\|')
+        if (columns.size() != 3) {
+            throw new ResourceException("The sdkmanager output format changed! Cannot parse line [$lineOfPackage]!")
+        }
+
+        columns[1].trim()
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Unzipper.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Unzipper.groovy
@@ -1,0 +1,45 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.apache.tools.ant.taskdefs.condition.Os
+
+/**
+ * Unfortunately the Java and Groovy unzip solutions do not keep file permissions on linux.
+ * Thus call 'unzip' directly on Linux and Mac and use ant on Windows
+ */
+@TypeChecked
+class Unzipper {
+    static void unzip(File zipFile, File destinationDir) {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            antUnzip(zipFile, destinationDir)
+        } else {
+            new CommandBuilder(new File('unzip')).addArguments([zipFile]).directory(destinationDir).execute()
+        }
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    private static void antUnzip(File zipFile, File destinationDir) {
+        def ant = new AntBuilder()
+        ant.unzip(src: zipFile, dest: destinationDir)
+    }
+}

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Utils.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Utils.groovy
@@ -1,0 +1,70 @@
+/**
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2018 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.gradle
+
+import groovy.transform.TypeChecked
+import org.apache.tools.ant.taskdefs.condition.Os
+
+@TypeChecked
+class Utils {
+    static boolean isRunningOnJenkins() {
+        'JENKINS_URL' in System.getenv()
+    }
+
+    static File joinPaths(File file, String... paths) {
+        paths.each{ String path ->
+            file = new File(file, path)
+        }
+        return file
+    }
+
+    static File executable(File exe, String winEnding) {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            return new File(exe.absolutePath + winEnding)
+        } else {
+            return exe
+        }
+    }
+
+    static void applySettings(Closure settings, Object target) {
+        settings = (Closure) settings.clone()
+        settings.delegate = target
+        settings.resolveStrategy = Closure.DELEGATE_FIRST
+        settings()
+    }
+
+    static String checksum(File file, String type) {
+        def digest = java.security.MessageDigest.getInstance("SHA-256")
+        file.eachByte(4096) { buffer, length ->
+            digest.update(buffer, 0, length)
+        }
+        digest.digest().encodeHex() as String
+    }
+
+    static Map asMap(Object object) {
+        Map properties = object.properties
+
+        properties.remove('class')
+        properties.remove('declaringClass')
+        properties.remove('metaClass')
+
+        properties
+    }
+}


### PR DESCRIPTION
…p emulator via gradle.

* Adds an own gradle plugin to handle interaction with the emulator.
* The android sdk/ndk can be installed when calling -PinstallSdk.
  This is done in the configuration step, to ensure that the plugins
  have all the information they need.
* Three new adb_tasks were added: startEmulator, stopEmulator, and retrieveLogcat
* startEmulator creates an avd if necessary and the starts the emulator.
  An already running emulator is reused.
  Use -Pemulator or the environment variable EMULATOR_OVERRIDE to specify the
  emulator to use.
* The emulator as well as the dependencies can be specified in a DSL in
  the build.gradle script.
  Multiple emulators can be added via emulator, furthermore templates can
  be specified via emulatorTemplate to share commong parts of emulators.
* Changing the specification of an emulator leads to the emulator being recreated.
* retrieveLogcat downloads the logcat.txt file from the device.
* The buildScripts are kept for now in cases issues arise.
* The Jenkinsfile uses the gradle tasks directly.
  This makes it more transparent of what is happening.
  It is the task's job to work correctly on both Jenkins and locally.
* Much of the groovy code is type checked during compilation.
  As a result not all tasks need to be run to find errors in buildSrc.
  This can also be seen as preparation to move buildSrc into its
  own gradle plugin that then lives in its own repo.

Note: Does currently not support running multiple emulators at the same time.
      The avd name is not used to look up the pid of a running emulator.
      Of course when you use docker you can run multiple instances at once.