### PR TITLE
Renames shouldInstallEverythingAbove to install.

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -22,6 +22,8 @@ import org.catrobat.gradle.EmulatorsPlugin
 apply plugin: EmulatorsPlugin
 
 emulators {
+    install project.hasProperty('installSdk')
+
     dependencies {
         sdk()
         ndk()
@@ -41,8 +43,6 @@ emulators {
             country = 'US'
         }
     }
-
-    shouldInstallEverythingAbove(project.hasProperty('installSdk'))
 }
 
 apply plugin: 'com.android.library'

--- a/buildSrc/src/main/groovy/org/catrobat/gradle/Installer.groovy
+++ b/buildSrc/src/main/groovy/org/catrobat/gradle/Installer.groovy
@@ -96,7 +96,7 @@ class Installer {
 
     Installer writeLicenseFiles() {
         File licencesDir = new File(androidSdk, 'licenses')
-        licencesDir.mkdir()
+        licencesDir.mkdirs()
         if (!licencesDir.exists()) {
             throw new ResourceException("The license directory could not be created: $licencesDir")
         }


### PR DESCRIPTION
In contrast to shouldInstallEverythingAbove the install function can be
called at any place in the emulators closure.