### PR TITLE
PAINT-324: Fix devices with display notch unable to switch tool

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -62,6 +62,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.BaseTool;
 import org.catrobat.paintroid.ui.BottomBarHorizontalScrollView;
 import org.catrobat.paintroid.ui.DrawingSurface;
+import org.catrobat.paintroid.ui.KeyboardListener;
 import org.catrobat.paintroid.ui.LayerAdapter;
 import org.catrobat.paintroid.ui.LayerNavigator;
 import org.catrobat.paintroid.ui.MainActivityInteractor;
@@ -99,6 +100,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 	private MainActivityContracts.Presenter presenter;
 	private DrawerLayoutViewHolder drawerLayoutViewHolder;
 	private Handler handler = new Handler();
+	private KeyboardListener keyboardListener;
 
 	@Override
 	public MainActivityContracts.Presenter getPresenter() {
@@ -190,6 +192,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 		presenter = new MainActivityPresenter(this, model, navigator, interactor, topBarViewHolder,
 				bottomBarViewHolder, drawerLayoutViewHolder, navigationDrawerViewHolder, commandManager);
 
+		keyboardListener = new KeyboardListener(drawerLayout);
 		setTopBarListeners(topBarViewHolder);
 		setBottomBarListeners(bottomBarViewHolder);
 		setNavigationViewListeners(navigationDrawerViewHolder);
@@ -431,9 +434,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 
 	@Override
 	public boolean isKeyboardShown() {
-		View activityView = drawerLayoutViewHolder.drawerLayout;
-		View rootView = activityView.getRootView();
-		return rootView.getHeight() - activityView.getHeight() > 300;
+		return keyboardListener.isSoftKeyboardVisible();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/HSVColorPickerView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/HSVColorPickerView.java
@@ -25,7 +25,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.BitmapShader;
 import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.ComposeShader;
 import android.graphics.LinearGradient;
 import android.graphics.Paint;
 import android.graphics.Point;
@@ -33,7 +32,6 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.RectF;
 import android.graphics.Shader;
-import android.os.Build;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -200,20 +198,12 @@ public class HSVColorPickerView extends View {
 		satShader = new LinearGradient(rect.left, rect.top, rect.right,
 				rect.bottom, Color.WHITE, rgb, Shader.TileMode.CLAMP);
 
-		if (Build.VERSION.SDK_INT >= 28) {
-			ComposeShader mShader = new ComposeShader(valShader, satShader,
-					PorterDuff.Mode.MULTIPLY);
-			satValPaint.setShader(mShader);
-
-			canvas.drawRect(rect, satValPaint);
-		} else {
-			satValPaint.setXfermode(null);
-			satValPaint.setShader(valShader);
-			canvas.drawRect(rect, satValPaint);
-			satValPaint.setShader(satShader);
-			satValPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.MULTIPLY));
-			canvas.drawRect(rect, satValPaint);
-		}
+		satValPaint.setXfermode(null);
+		satValPaint.setShader(valShader);
+		canvas.drawRect(rect, satValPaint);
+		satValPaint.setShader(satShader);
+		satValPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.MULTIPLY));
+		canvas.drawRect(rect, satValPaint);
 
 		Point p = satValToPoint(sat, val);
 		satValTrackerPaint.setColor(0xff000000);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/KeyboardListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/KeyboardListener.java
@@ -1,0 +1,49 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.ui;
+
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewTreeObserver;
+
+public class KeyboardListener {
+	private static final int HEIGHT_THRESHOLD = 300;
+	private boolean isSoftKeyboardVisible;
+
+	public KeyboardListener(final View activityRootView) {
+		activityRootView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+			@Override
+			public void onGlobalLayout() {
+				int heightDifference = activityRootView.getRootView().getHeight() - activityRootView.getHeight();
+				DisplayMetrics displayMetrics = activityRootView.getResources().getDisplayMetrics();
+				isSoftKeyboardVisible = heightDifference > dpToPx(HEIGHT_THRESHOLD, displayMetrics);
+			}
+		});
+	}
+
+	private static float dpToPx(int dpValue, DisplayMetrics displayMetrics) {
+		return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dpValue, displayMetrics);
+	}
+
+	public boolean isSoftKeyboardVisible() {
+		return isSoftKeyboardVisible;
+	}
+}


### PR DESCRIPTION
* Add a reusable `KeyboardListener` class that can be queried for the
  current keyboard status
* Fixed colorpicker not being drawn on `api >= 28`
  * Apparently `api >= 28` still does not support composed shaders, even
    though the documentation claims that there would be support.