### PR TITLE
JENKINS-250 Ensure that build errors are found when running the device tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
 				// Run device tests
 				sh '''
 					./gradlew startEmulator adbDisableAnimationsGlobally
-					./gradlew -PenableCoverage -Pjenkins clean createDebugCoverageReport || true
+					./gradlew -PenableCoverage -Pjenkins clean createDebugCoverageReport
 					./gradlew adbResetAnimationsGlobally retrieveLogcat
 				'''
 				// Convert the JaCoCo coverate to the Cobertura XML file format.


### PR DESCRIPTION
Using "|| true" here would mean that compile errors would not be found.
The original goal of continuing a build for flaky tests is not as important
as detecting compile errors.
Furthermore the build can be continued already when using the ignoreFailures
gradle setting on tests if that really was an issue.