### PR TITLE
JENKINS-252 Clear the AVD store in the workspace after every build.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
 					junit '**/*TEST*.xml'
 					step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: "$JAVA_SRC/coverage*.xml", failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false, failNoReports: false])
 
-					sh './gradlew stopEmulator'
+					sh './gradlew stopEmulator clearAvdStore'
 					archiveArtifacts 'logcat.txt'
 				}
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
         classpath 'com.novoda:bintray-release:0.8.1'
-        classpath 'org.catrobat.gradle.androidemulators:android-emulators-gradle:1.0.1'
+        classpath 'org.catrobat.gradle.androidemulators:android-emulators-gradle:1.1.0'
     }
 }
 


### PR DESCRIPTION
The AVDs are recreated for every build anyway.
Thus keeping the AVDs around to clear them on the next build only
increases the harddrive requirements of the slaves.
And since we already had nearly full disks it is better to clean the AVDs.

In the case of Paintroid this safes roughly 820 MB per job.