### PR TITLE
PAINTROID-8: Fix failing jenkins builds due to repo order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         // CAUTION
@@ -47,7 +47,7 @@ ext {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }


### PR DESCRIPTION
Apparently gradle tries to use the dependencies from the first repository offering this file.
The google repo should be the preferred repo.

See https://jenkins.catrob.at/job/Paintroid/job/develop/329/console for an example of a failing build.