### PR TITLE
PAINTROID-10, JENKINS-251 Moves many responsibilities to the Dockerfile.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,43 +11,15 @@ pipeline {
 			// corresponding user can be added. This is needed to provide the jenkins user inside
 			// the container for the ssh-agent to work.
 			// Another way would be to simply map the passwd file, but would spoil additional information
-			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-			// Currently there are two different NDK behaviors in place, one to keep NDK r16b, which
-			// was needed because of the removal of armeabi and MIPS support and one to always use the
-			// latest NDK, which is the suggestion from the NDK documentations.
-			// Therefore two different SDK locations on the host are currently in place:
-			// NDK r16b  : /var/local/container_shared/android-sdk
-			// NDK latest: /var/local/container_shared/android-sdk-ndk-latest
-			// As android-sdk was used from the beginning and is already 'released' this can't be changed
-			// to eg android-sdk-ndk-r16b and must be kept to the previously used value
-			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk-ndk-latest:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+			// Also hand in the group id of kvm to allow using /dev/kvm.
+			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+			// Ensure that each executor has its own gradle cache to not affect other builds
+			// that run concurrently.
+			args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle'
 		}
 	}
 
 	environment {
-		//////// Define environment variables to point to the correct locations inside the container ////////
-		//////////// Most likely not edited by the developer
-		ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-		// Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-		ANDROID_HOME = "/usr/local/android-sdk"
-		ANDROID_SDK_HOME = "/"
-		// Needed for compatibiliby to current Jenkins-wide Envs
-		// Can be removed, once all builds are migrated to Pipeline
-		ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-		ANDROID_NDK = ""
-		// This is important, as we want the keep our gradle cache, but we can't share it between containers
-		// the cache could only be shared if the gradle instances could comunicate with each other
-		// imho keeping the cache per executor will have the least space impact
-		GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-		// Otherwise user.home returns ? for java applications
-		JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
-
-		//// jenkins-android-helper related variables
-		// set to any value to debug jenkins_android* scripts
-		ANDROID_EMULATOR_HELPER_DEBUG = ""
-		// get stdout of called subprocesses immediately
-		PYTHONUNBUFFERED = "true"
-
 		//////// Build specific variables ////////
 		//////////// May be edited by the developer on changing the build steps
 		// modulename
@@ -71,20 +43,11 @@ pipeline {
 		buildDiscarder(logRotator(numToKeepStr: '30'))
 	}
 
-    triggers {
-        cron(env.BRANCH_NAME == 'develop' ? '@midnight' : '')
-    }
+	triggers {
+		cron(env.BRANCH_NAME == 'develop' ? '@midnight' : '')
+	}
 
 	stages {
-		stage('Setup Android SDK') {
-			steps {
-				// Install Android SDK
-				lock("update-android-sdk-on-${env.NODE_NAME}") {
-					sh './gradlew -PinstallSdk'
-				}
-			}
-		}
-
 		stage('Static Analysis') {
 			steps {
 				sh './gradlew clean pmd checkstyle lint'
@@ -123,7 +86,7 @@ pipeline {
 					junit '**/*TEST*.xml'
 					step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: "$JAVA_SRC/coverage*.xml", failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false, failNoReports: false])
 
-					sh './gradlew stopEmulator clearAvdStore'
+					sh './gradlew stopEmulator'
 					archiveArtifacts 'logcat.txt'
 				}
 			}

--- a/docker/Dockerfile.jenkins
+++ b/docker/Dockerfile.jenkins
@@ -1,16 +1,81 @@
 FROM openjdk:8-jdk
 
-LABEL maintainer="contact@catrobat.org"
+# Android Dependencies
+# --------------------
+# Adapt the paramters below to change the dependencies.
+#
 
-## Default values for the arguments to be passed from the Jenkinsfile.
-## Those contain the uid and gid of the Jenkins user, and are used to
-## create this user inside of the container, needed for eg ssh-agent to work
+# Android SDK 26.1.1
+ARG ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
+
+# Android NDK r18b
+ARG ANDROID_NDK_URL="https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip"
+
+ARG SDKMANAGER_PACKAGES="build-tools;27.0.3 platforms;android-26 cmake;3.6.4111459 system-images;android-24;default;x86_64 emulator platform-tools"
+
+
+# Arguments, Environment
+# ----------------------
+#
+
+# Default values for the arguments to be passed from the Jenkinsfile.
+# Those contain the uid and gid of the Jenkins user, and are used to
+# create this user inside of the container, needed for eg ssh-agent to work
 ARG USER_ID=1000
 ARG GROUP_ID=1000
+ARG KVM_GROUP_ID=999
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		lsof \
-		python3 \
-	&& rm -rf /var/lib/apt/lists/*
-## add the 'Jenkins' user
-RUN groupadd -g $GROUP_ID user && useradd -M -u $USER_ID -g $GROUP_ID -d / -s /usr/sbin/nologin user
+# Environment variables that are needed by the build job.
+
+ENV ANDROID_SDK_ROOT=/home/user/android/sdk
+ENV ANDROID_AVD_HOME=/home/user/avds
+
+# Deprecated: Still used by gradle, once gradle respects ANDROID_SDK_ROOT, this can be removed
+ENV ANDROID_HOME=$ANDROID_SDK_ROOT
+
+ARG _SDKMANAGER=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
+
+# User Management
+# ---------------
+#
+
+# add the 'Jenkins' user
+# Add group of the user used by Jenkins during building.
+RUN if [ ! $(getent group $GROUP_ID) ]; then groupadd -g $GROUP_ID user; fi
+
+RUN groupadd -g $KVM_GROUP_ID kvm
+
+# Add the user used by Jenkins during building.
+RUN useradd -m -u $USER_ID -g $GROUP_ID -G $KVM_GROUP_ID -s /usr/sbin/nologin user
+
+# Run all other commands as user
+USER user
+
+RUN mkdir -p $ANDROID_AVD_HOME
+
+
+# Android SDK
+# ------------------
+#
+RUN curl $ANDROID_SDK_URL --output /tmp/android_sdk.zip \
+  && mkdir -p $ANDROID_SDK_ROOT \
+  && unzip -d $ANDROID_SDK_ROOT /tmp/android_sdk.zip \
+  && rm /tmp/android_sdk.zip
+
+
+# Android NDK
+# ----------------
+#
+RUN if [ ! -z "$ANDROID_NDK_URL" ]; then \
+    curl $ANDROID_NDK_URL --output /tmp/android_ndk.zip \
+    && mkdir -p $ANDROID_SDK_ROOT /tmp/ndk \
+    && unzip -d /tmp/ndk /tmp/android_ndk.zip \
+    && mv /tmp/ndk/* $ANDROID_SDK_ROOT/ndk-bundle \
+    && rm /tmp/android_ndk.zip; \
+  fi
+
+
+# Installing SDK Packages
+# -----------------------
+#
+RUN if [ ! -z "$SDKMANAGER_PACKAGES" ]; then yes | $_SDKMANAGER $SDKMANAGER_PACKAGES; fi


### PR DESCRIPTION
* Install Android SDK/NDK and packages in Docker image

  This makes clear what dependencies are used.
  When new SDK/NDK versions are released the Paintroid developers can
  decide when to migrate to the newer versions.
  This is especially useful when newer versions cause issues,
  like the last NDK release.
* Sets ANDROID_SDK_ROOT and ANDROID_HOME inside of the Docker image.
  All the other android related environment varaibles are not needed anymore.
* The user inside docker ('user') now has its home placed at '/home/user'
  instead of '/'.
  This solves many issues:
  * Now $HOME is writable and all its content can be read.
  * As a result environment variables or paths that are derived from $HOME
    work automatically.
  * GRADLE_USER_HOME does not need to be set, instead the external gradle
    cache is mounted to /home/user/.gradle which is picked-up by gradle automatically.
    Note: Since the gradle cache is not relocatable (it hard-codes paths)
          the existing /var/local/container_shared/gradle cannot be used.
          Instead /var/local/container_shared/gradle_cache is used.
  * No need to mount .android, emulator_console_auth_token, and analytics.settings.
    They are created automatically.
  * No need to set JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/" as $HOME/.java
    is now writable.
* The setup stage is not necessary since everything should be provided
  in the Docker container.
* No need to call clearAvdStore manually since ANDROID_AVD_HOME points to
  a directory inside of the containers.
  Thus when the container is stopped everything is cleared automatically.
* Allow to specify id of the kvm group as build paramter.
  That way you can build the docker image locally
* Since the jenkins-android-helper scripts are not used to manage the emulator
  the references to ANDROID_EMULATOR_HELPER_DEBUG and PYTHONUNBUFFERED
  are not needed anymore.