### PR TITLE
PAINTROID-2: Fix crash in layer menu

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.java
@@ -30,10 +30,6 @@ public interface LayerContracts {
 
 		void removeLayer();
 
-		void onLongClickLayerAtPosition(int position, LayerViewHolder viewHolder);
-
-		void onClickLayerAtPosition(int position, LayerViewHolder viewHolder);
-
 		void setAdapter(LayerContracts.Adapter layerAdapter);
 
 		void invalidate();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.java
@@ -77,22 +77,6 @@ public class LayerAdapter extends BaseAdapter implements LayerContracts.Adapter 
 
 		viewHolders.put(position, viewHolder);
 		presenter.onBindLayerViewHolderAtPosition(position, viewHolder);
-
-		convertView.setOnLongClickListener(new View.OnLongClickListener() {
-			@Override
-			public boolean onLongClick(View v) {
-				presenter.onLongClickLayerAtPosition(position, viewHolder);
-				return true;
-			}
-		});
-
-		convertView.setOnClickListener(new View.OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				presenter.onClickLayerAtPosition(position, viewHolder);
-			}
-		});
-
 		return convertView;
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.paintroid.ui.dragndrop;
 
+import android.view.View;
+
 public interface DragAndDropPresenter {
 	int swapItemsVisually(int position, int swapWith);
 
@@ -31,4 +33,8 @@ public interface DragAndDropPresenter {
 	void reorderItems(int position, int swapWith);
 
 	void markMergeable(int position, int mergeWith);
+
+	void onLongClickLayerAtPosition(int position, View view);
+
+	void onClickLayerAtPosition(int position, View view);
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/ListItemLongClickHandler.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/ListItemLongClickHandler.java
@@ -27,4 +27,6 @@ import android.view.View;
 
 public interface ListItemLongClickHandler {
 	void handleOnItemLongClick(int position, View view);
+
+	void stopDragging();
 }

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
@@ -51,5 +51,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/pocketpaint_layer_side_nav_button_add"
+        android:splitMotionEvents="false"
         tools:listitem="@layout/pocketpaint_item_layer" />
 </RelativeLayout>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
@@ -264,14 +264,12 @@ public class LayerPresenterTest {
 
 	@Test
 	public void testOnLongClickLayerAtPosition() {
-		LayerViewHolder layerViewHolder = mock(LayerViewHolder.class);
 		View view = mock(View.class);
-		when(layerViewHolder.getView()).thenReturn(view);
 		layerModel.addLayerAt(0, mock(Layer.class));
 		layerModel.addLayerAt(1, mock(Layer.class));
 
 		createPresenter();
-		layerPresenter.onLongClickLayerAtPosition(0, layerViewHolder);
+		layerPresenter.onLongClickLayerAtPosition(0, view);
 
 		verify(listItemLongClickHandler).handleOnItemLongClick(0, view);
 		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
@@ -279,18 +277,30 @@ public class LayerPresenterTest {
 
 	@Test
 	public void testOnLongClickLayerAtPositionWhenOnlyOneLayer() {
-		LayerViewHolder layerViewHolder = mock(LayerViewHolder.class);
+		View view = mock(View.class);
 		layerModel.addLayerAt(0, mock(Layer.class));
 
 		createPresenter();
-		layerPresenter.onLongClickLayerAtPosition(0, layerViewHolder);
+		layerPresenter.onLongClickLayerAtPosition(0, view);
+
+		verifyZeroInteractions(listItemLongClickHandler, commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
+	}
+
+	@Test
+	public void testOnLongClickLayerAtPositionWhenPositionOutOfBounds() {
+		View view = mock(View.class);
+		layerModel.addLayerAt(0, mock(Layer.class));
+		layerModel.addLayerAt(1, mock(Layer.class));
+
+		createPresenter();
+		layerPresenter.onLongClickLayerAtPosition(2, view);
 
 		verifyZeroInteractions(listItemLongClickHandler, commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
 	}
 
 	@Test
 	public void testOnClickLayerAtPositionWhenDeselected() {
-		LayerViewHolder layerViewHolder = mock(LayerViewHolder.class);
+		View view = mock(View.class);
 		layerModel.addLayerAt(0, mock(Layer.class));
 		layerModel.addLayerAt(1, mock(Layer.class));
 		layerModel.setCurrentLayer(layerModel.getLayerAt(1));
@@ -298,20 +308,35 @@ public class LayerPresenterTest {
 		when(commandFactory.createSelectLayerCommand(0)).thenReturn(command);
 
 		createPresenter();
-		layerPresenter.onClickLayerAtPosition(0, layerViewHolder);
+		layerPresenter.onClickLayerAtPosition(0, view);
 
 		verify(commandManager).addCommand(command);
 	}
 
 	@Test
 	public void testOnClickLayerAtPositionWhenAlreadySelected() {
-		LayerViewHolder layerViewHolder = mock(LayerViewHolder.class);
+		View view = mock(View.class);
 		Layer layer = mock(Layer.class);
 		layerModel.addLayerAt(0, layer);
 		layerModel.setCurrentLayer(layer);
 
 		createPresenter();
-		layerPresenter.onClickLayerAtPosition(0, layerViewHolder);
+		layerPresenter.onClickLayerAtPosition(0, view);
+
+		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
+	}
+
+	@Test
+	public void testOnClickLayerAtPositionWhenPositionOutOfBounds() {
+		View view = mock(View.class);
+		Layer firstLayer = mock(Layer.class);
+		Layer secondLayer = mock(Layer.class);
+		layerModel.addLayerAt(0, firstLayer);
+		layerModel.addLayerAt(1, secondLayer);
+		layerModel.setCurrentLayer(firstLayer);
+
+		createPresenter();
+		layerPresenter.onClickLayerAtPosition(2, view);
 
 		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
 	}
@@ -454,6 +479,10 @@ public class LayerPresenterTest {
 
 	@Test
 	public void testMarkMergeable() {
+		Layer firstLayer = mock(Layer.class);
+		Layer secondLayer = mock(Layer.class);
+		layerModel.addLayerAt(0, firstLayer);
+		layerModel.addLayerAt(1, secondLayer);
 		LayerViewHolder layerViewHolder = mock(LayerViewHolder.class);
 		when(layerAdapter.getViewHolderAt(1)).thenReturn(layerViewHolder);
 
@@ -461,6 +490,14 @@ public class LayerPresenterTest {
 		layerPresenter.markMergeable(0, 1);
 
 		verify(layerViewHolder).setMergable();
+		verifyZeroInteractions(commandManager, layerMenuViewHolder, listItemLongClickHandler);
+	}
+
+	@Test
+	public void testMarkMergeableWhenPositionInvalidDoesNothing() {
+		createPresenter();
+		layerPresenter.markMergeable(0, 1);
+
 		verifyZeroInteractions(commandManager, layerMenuViewHolder, listItemLongClickHandler);
 	}
 


### PR DESCRIPTION
* Handle click and longclick events in the listview instead of the item views
* Disable `SplitMotionEvents` in listview
* Adapt tests
* Invalidate listview on touchup properly