### PR TITLE
PAINTROID-29 / JENKINS-262: Avoid gradle clean

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
 
 		stage('Static Analysis') {
 			steps {
-				sh './gradlew clean pmd checkstyle lint'
+				sh './gradlew pmd checkstyle lint'
 			}
 
 			post {
@@ -102,16 +102,14 @@ pipeline {
 		stage('Unit and Device tests') {
 			steps {
 				// Run local unit tests
-				sh './gradlew -PenableCoverage -Pjenkins clean jacocoTestDebugUnitTestReport'
+				sh './gradlew -PenableCoverage -Pjenkins jacocoTestDebugUnitTestReport'
 				// Convert the JaCoCo coverate to the Cobertura XML file format.
 				// This is done since the Jenkins JaCoCo plugin does not work well.
 				// See also JENKINS-212 on jira.catrob.at
 				sh "if [ -f '$JACOCO_UNIT_XML' ]; then ./buildScripts/cover2cover.py $JACOCO_UNIT_XML > $JAVA_SRC/coverage1.xml; fi"
-				// ensure that the following test run does not overwrite the results
-				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build ${env.GRADLE_PROJECT_MODULE_NAME}/build-unittest"
 
 				// Run device tests
-				sh './gradlew -PenableCoverage -Pjenkins clean startEmulator adbDisableAnimationsGlobally createDebugCoverageReport'
+				sh './gradlew -PenableCoverage -Pjenkins startEmulator adbDisableAnimationsGlobally createDebugCoverageReport'
 				// Convert the JaCoCo coverate to the Cobertura XML file format.
 				// This is done since the Jenkins JaCoCo plugin does not work well.
 				// See also JENKINS-212 on jira.catrob.at
@@ -131,7 +129,7 @@ pipeline {
 
 		stage('Build Debug-APK') {
 			steps {
-				sh './gradlew clean assembleDebug'
+				sh './gradlew assembleDebug'
 				archiveArtifacts "${env.APK_LOCATION_DEBUG}"
 			}
 		}


### PR DESCRIPTION
At the moment there are calls to gradle clean in the Paintroid-Jenkinsfile.
These are unnecessary since git cleans everything in-between builds.
They slow down the build unnecessary.

Remove these clean steps for Paintroid.
