### PR TITLE
JENKINS-246 Limit resources used by the Paintroid docker container.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,8 @@ pipeline {
 			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
 			// Ensure that each executor has its own gradle cache to not affect other builds
 			// that run concurrently.
-			args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle'
+			args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=7G --cpus=3.5'
+			label 'LimitedEmulator'
 		}
 	}
 

--- a/docker/Dockerfile.jenkins
+++ b/docker/Dockerfile.jenkins
@@ -79,3 +79,13 @@ RUN if [ ! -z "$ANDROID_NDK_URL" ]; then \
 # -----------------------
 #
 RUN if [ ! -z "$SDKMANAGER_PACKAGES" ]; then yes | $_SDKMANAGER $SDKMANAGER_PACKAGES; fi
+
+# Performance related settings for the JVM
+# - Respect the cgroup settings for memory.
+#
+# Note: Usage of _JAVA_OPTIONS is in general discouraged.
+#       This is an internal flag that will be preferred over
+#       JAVA_TOOL_OPTIONS and the command line parameters.
+#       We still use it here to ensure that these settings
+#       are respected, no matter what is configured elsewhere.
+ENV _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"


### PR DESCRIPTION
The container is only allowed to use 7 GB of RAM and 3.5 CPUs.
With the -XX:+UnlockExperimentalVMOptions and -XX:+UseCGroupMemoryLimitForHeap
Java Option these settings are also respected in Java 8.
Thus Java 8 uses fewer threads and also memory.

With the limited resources the build jobs take slightly longer than without
restrictions. Yet this allows to have two executors per node in the future
and therefore improving overall performance.
Furthermore this can be seen as necessary precondition for parallelisation:
If there are only few executors there are not enough resources to actually
parallelise things.

The container will only run on executors that provide the label LimitedEmulator.
Nodes with this label should either have just one executor or should not provide
the Emulator label.
This allows older branches that do not restrict the resources to coexist on
Jenkins without negatively affecting each other.

The slaves have 16 GB of RAM and 4 CPUs (8 threads).
These restrictions enable to run two jobs in parallel, reducing the risk
of them affecting each other negatively.