### PR TITLE
PAINTROID-49: Fix crash from callback while in background

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.java
@@ -41,6 +41,8 @@ public interface CommandManager {
 
 	void setInitialStateCommand(Command command);
 
+	boolean isBusy();
+
 	interface CommandListener {
 		void commandPreExecute();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.java
@@ -138,6 +138,11 @@ public class DefaultCommandManager implements CommandManager {
 		initialStateCommand = command;
 	}
 
+	@Override
+	public boolean isBusy() {
+		return false;
+	}
+
 	private void notifyCommandExecuted() {
 		for (CommandListener listener : commandListeners) {
 			listener.commandPostExecute();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -465,6 +465,10 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		navigationDrawerViewHolder.setVersion(BuildConfig.VERSION_NAME);
 
 		view.initializeActionBar(model.isOpenedFromCatroid());
+
+		if (!commandManager.isBusy()) {
+			navigator.dismissIndeterminateProgressDialog();
+		}
 	}
 
 	private void exitFullScreen() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -136,7 +136,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 		Fragment fragment = getIndeterminateProgressFragment();
 		if (fragment != null) {
 			AppCompatDialogFragment dialog = (AppCompatDialogFragment) fragment;
-			dialog.dismiss();
+			dialog.dismissAllowingStateLoss();
 		}
 	}
 


### PR DESCRIPTION
* Dismiss `IndeterminateProgressDialog` with `dismissAllowingStateLoss`
* Add a `isBusy` flag to `CommandManager`, dismiss in `onCreate` if state was lost (e.g. activity was in background)
* Reject commands while the async command manager is already busy (This fixes a different bug, that appeared when pressing e.g. rotate and mirror buttons at the same time)