### PR TITLE
PAINTROID-39: Fix menus slide buggy

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ScrollingViewIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ScrollingViewIntegrationTest.java
@@ -1,3 +1,22 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.catrobat.paintroid.test.espresso;
 
 import android.graphics.PointF;
@@ -22,9 +41,9 @@ import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getStatusb
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getSurfaceHeight;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getSurfacePointFromScreenPoint;
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getSurfaceWidth;
-import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.selectTool;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchCenterMiddle;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchLongAt;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -34,14 +53,16 @@ public class ScrollingViewIntegrationTest {
 
 	@Rule
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
+	private int drawerEdgeSize;
 
 	@Before
 	public void setUp() {
-		selectTool(ToolType.BRUSH);
+		float displayDensity = launchActivityRule.getActivity().getResources().getDisplayMetrics().density;
+		drawerEdgeSize = (int) (20 * displayDensity + 0.5f);
 	}
 
 	@Test
-	public void testScrollingViewDrawTool() throws NoSuchFieldException, IllegalAccessException {
+	public void testScrollingViewDrawTool() {
 
 		final int perspectiveScale = 5;
 		PaintroidApplication.perspective.setScale(perspectiveScale);
@@ -49,8 +70,8 @@ public class ScrollingViewIntegrationTest {
 		float surfaceWidth = getSurfaceWidth();
 		float surfaceHeight = getSurfaceHeight();
 
-		float xRight = surfaceWidth - 1;
-		float xLeft = 1;
+		float xRight = surfaceWidth - 1 - drawerEdgeSize;
+		float xLeft = 1 + drawerEdgeSize;
 		float xMiddle = surfaceWidth / 2;
 
 		final float actionBarHeight = getActionbarHeight();
@@ -69,6 +90,9 @@ public class ScrollingViewIntegrationTest {
 		PointF bottomRight = new PointF(xRight, yBottom);
 		PointF bottomLeft = new PointF(xLeft, yBottom);
 		PointF topRight = new PointF(xRight, yTop);
+
+		onToolBarView()
+				.performSelectTool(ToolType.BRUSH);
 
 		longpressOnPointAndCheckIfCanvasPointHasNotChanged(middle);
 
@@ -81,28 +105,10 @@ public class ScrollingViewIntegrationTest {
 		longpressOnPointAndCheckIfCanvasPointHasChangedInXAndY(topLeft);
 		longpressOnPointAndCheckIfCanvasPointHasChangedInXAndY(bottomLeft);
 		longpressOnPointAndCheckIfCanvasPointHasChangedInXAndY(topRight);
-
-//		dragAndCheckIfCanvasHasMovedInXOrY(middle, rightMiddle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(rightMiddle, middle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(middle, leftMiddle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(leftMiddle, middle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(middle, topMiddle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(topMiddle, middle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(middle, bottomMiddle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(bottomMiddle, middle);
-
-//		dragAndCheckIfCanvasHasMovedInXAndY(middle, topRight);
-//		dragAndCheckIfCanvasHasMovedInXAndY(topRight, middle);
-//		dragAndCheckIfCanvasHasMovedInXAndY(middle, bottomRight);
-//		dragAndCheckIfCanvasHasMovedInXAndY(bottomRight, middle);
-//		dragAndCheckIfCanvasHasMovedInXAndY(middle, bottomLeft);
-//		dragAndCheckIfCanvasHasMovedInXAndY(bottomLeft, middle);
-//		dragAndCheckIfCanvasHasMovedInXAndY(middle, topLeft);
-//		dragAndCheckIfCanvasHasMovedInXAndY(topLeft, middle);
 	}
 
 	@Test
-	public void testScrollingViewCursorTool() throws NoSuchFieldException, IllegalAccessException {
+	public void testScrollingViewCursorTool() {
 		final int perspectiveScale = 5;
 		PaintroidApplication.perspective.setScale(perspectiveScale);
 
@@ -130,7 +136,8 @@ public class ScrollingViewIntegrationTest {
 		PointF bottomLeft = new PointF(xLeft, yBottom);
 		PointF topRight = new PointF(xRight, yTop);
 
-		selectTool(ToolType.CURSOR);
+		onToolBarView()
+				.performSelectTool(ToolType.CURSOR);
 
 		longpressOnPointAndCheckIfCanvasPointHasNotChanged(rightMiddle);
 		longpressOnPointAndCheckIfCanvasPointHasNotChanged(leftMiddle);
@@ -145,19 +152,6 @@ public class ScrollingViewIntegrationTest {
 		dragAndCheckIfCanvasHasMovedInXOrY(topMiddle, middle);
 		dragAndCheckIfCanvasHasMovedInXOrY(topMiddle, bottomMiddle);
 		dragAndCheckIfCanvasHasMovedInXOrY(bottomMiddle, middle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(rightMiddle, leftMiddle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(leftMiddle, middle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(leftMiddle, rightMiddle);
-//		dragAndCheckIfCanvasHasMovedInXOrY(rightMiddle, middle);
-
-//		dragAndCheckIfCanvasHasMovedInXAndY(bottomLeft, topRight);
-//		dragAndCheckIfCanvasHasMovedInXAndY(topRight, middle);
-//		dragAndCheckIfCanvasHasMovedInXAndY(topRight, bottomLeft);
-//		dragAndCheckIfCanvasHasMovedInXAndY(bottomLeft, middle);
-//		dragAndCheckIfCanvasHasMovedInXAndY(bottomRight, topLeft);
-//		dragAndCheckIfCanvasHasMovedInXAndY(topLeft, middle);
-//		dragAndCheckIfCanvasHasMovedInXAndY(topLeft, bottomRight);
-//		dragAndCheckIfCanvasHasMovedInXAndY(bottomRight, middle);
 
 		onView(isRoot()).perform(touchCenterMiddle());
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
@@ -40,6 +40,7 @@ import static org.catrobat.paintroid.tools.ToolType.PIPETTE;
 import static org.catrobat.paintroid.tools.ToolType.TRANSFORM;
 
 public class DrawingSurfaceListener implements OnTouchListener {
+	private static final float DRAWER_EDGE_SIZE = 20;
 	private TouchMode touchMode;
 
 	private float pointerDistance;
@@ -48,13 +49,18 @@ public class DrawingSurfaceListener implements OnTouchListener {
 	private float xMidPoint;
 	private float yMidPoint;
 
-	private PointF touchPoint;
+	private PointF canvasTouchPoint;
+	private PointF eventTouchPoint;
+	private boolean ignoreTouch;
+	private int drawerEdgeSize;
 
-	public DrawingSurfaceListener(AutoScrollTask autoScrollTask) {
+	public DrawingSurfaceListener(AutoScrollTask autoScrollTask, float displayDensity) {
 		this.touchMode = TouchMode.DRAW;
 		this.autoScrollTask = autoScrollTask;
+		drawerEdgeSize = (int) (DRAWER_EDGE_SIZE * displayDensity + 0.5f);
 
-		touchPoint = new PointF();
+		canvasTouchPoint = new PointF();
+		eventTouchPoint = new PointF();
 	}
 
 	private float calculatePointerDistance(MotionEvent event) {
@@ -74,30 +80,41 @@ public class DrawingSurfaceListener implements OnTouchListener {
 		DrawingSurface drawingSurface = (DrawingSurface) view;
 		Perspective perspective = PaintroidApplication.perspective;
 
-		touchPoint.x = event.getX();
-		touchPoint.y = event.getY();
-		perspective.convertToCanvasFromSurface(touchPoint);
+		canvasTouchPoint.x = event.getX();
+		canvasTouchPoint.y = event.getY();
+		eventTouchPoint.x = canvasTouchPoint.x;
+		eventTouchPoint.y = canvasTouchPoint.y;
+
+		perspective.convertToCanvasFromSurface(canvasTouchPoint);
 
 		switch (event.getAction()) {
 			case MotionEvent.ACTION_DOWN:
-				currentTool.handleTouch(touchPoint, MotionEvent.ACTION_DOWN);
+				if (eventTouchPoint.x < drawerEdgeSize || view.getWidth() - eventTouchPoint.x < drawerEdgeSize) {
+					ignoreTouch = true;
+					return true;
+				}
 
-				autoScrollTask.setEventPoint(event.getX(), event.getY());
+				currentTool.handleTouch(canvasTouchPoint, MotionEvent.ACTION_DOWN);
+
+				autoScrollTask.setEventPoint(eventTouchPoint.x, eventTouchPoint.y);
 				autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
 				autoScrollTask.start();
 
 				break;
 			case MotionEvent.ACTION_MOVE:
+				if (ignoreTouch) {
+					return true;
+				}
 				if (event.getPointerCount() == 1) {
 					if (touchMode == TouchMode.PINCH) {
 						break;
 					}
 
 					touchMode = TouchMode.DRAW;
-					autoScrollTask.setEventPoint(event.getX(), event.getY());
+					autoScrollTask.setEventPoint(eventTouchPoint.x, eventTouchPoint.y);
 					autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
 
-					currentTool.handleTouch(touchPoint, MotionEvent.ACTION_MOVE);
+					currentTool.handleTouch(canvasTouchPoint, MotionEvent.ACTION_MOVE);
 				} else {
 					if (autoScrollTask.isRunning()) {
 						autoScrollTask.stop();
@@ -125,12 +142,17 @@ public class DrawingSurfaceListener implements OnTouchListener {
 				break;
 			case MotionEvent.ACTION_UP:
 			case MotionEvent.ACTION_CANCEL:
+				if (ignoreTouch) {
+					ignoreTouch = false;
+					return true;
+				}
+
 				if (autoScrollTask.isRunning()) {
 					autoScrollTask.stop();
 				}
 
 				if (touchMode == TouchMode.DRAW) {
-					currentTool.handleTouch(touchPoint, MotionEvent.ACTION_UP);
+					currentTool.handleTouch(canvasTouchPoint, MotionEvent.ACTION_UP);
 				} else {
 					currentTool.resetInternalState(StateChange.MOVE_CANCELED);
 				}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -88,7 +88,8 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 
 		Handler handler = new Handler(Looper.getMainLooper());
 		AutoScrollTask autoScrollTask = new AutoScrollTask(handler, new AutoScrollTaskCallbackImpl());
-		DrawingSurfaceListener drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask);
+		float density = getResources().getDisplayMetrics().density;
+		DrawingSurfaceListener drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask, density);
 		setOnTouchListener(drawingSurfaceListener);
 	}
 


### PR DESCRIPTION
* Ignore clicks starting in range of drawer edges
  * This uses the same border width constants as the support library
    navigation drawer
* Add unit tests verifying this behaviour
* Adapt espresso tests