### PR TITLE
PAINTROID-55: Disable autoscroll in fullscreen

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -474,12 +474,14 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 
 	@Override
 	public void enterFullScreen() {
+		drawingSurface.disableAutoScroll();
 		getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
 		getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 	}
 
 	@Override
 	public void exitFullScreen() {
+		drawingSurface.enableAutoScroll();
 		getWindow().addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 		getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
@@ -53,6 +53,7 @@ public class DrawingSurfaceListener implements OnTouchListener {
 	private PointF eventTouchPoint;
 	private boolean ignoreTouch;
 	private int drawerEdgeSize;
+	private boolean autoScroll = true;
 
 	public DrawingSurfaceListener(AutoScrollTask autoScrollTask, float displayDensity) {
 		this.touchMode = TouchMode.DRAW;
@@ -72,6 +73,17 @@ public class DrawingSurfaceListener implements OnTouchListener {
 	private void calculateMidPoint(MotionEvent event) {
 		xMidPoint = (event.getX(0) + event.getX(1)) / 2f;
 		yMidPoint = (event.getY(0) + event.getY(1)) / 2f;
+	}
+
+	public void enableAutoScroll() {
+		autoScroll = true;
+	}
+
+	public void disableAutoScroll() {
+		autoScroll = false;
+		if (autoScrollTask.isRunning()) {
+			autoScrollTask.stop();
+		}
 	}
 
 	@Override
@@ -96,9 +108,11 @@ public class DrawingSurfaceListener implements OnTouchListener {
 
 				currentTool.handleTouch(canvasTouchPoint, MotionEvent.ACTION_DOWN);
 
-				autoScrollTask.setEventPoint(eventTouchPoint.x, eventTouchPoint.y);
-				autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
-				autoScrollTask.start();
+				if (autoScroll) {
+					autoScrollTask.setEventPoint(eventTouchPoint.x, eventTouchPoint.y);
+					autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
+					autoScrollTask.start();
+				}
 
 				break;
 			case MotionEvent.ACTION_MOVE:
@@ -111,8 +125,10 @@ public class DrawingSurfaceListener implements OnTouchListener {
 					}
 
 					touchMode = TouchMode.DRAW;
-					autoScrollTask.setEventPoint(eventTouchPoint.x, eventTouchPoint.y);
-					autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
+					if (autoScroll) {
+						autoScrollTask.setEventPoint(eventTouchPoint.x, eventTouchPoint.y);
+						autoScrollTask.setViewDimensions(view.getWidth(), view.getHeight());
+					}
 
 					currentTool.handleTouch(canvasTouchPoint, MotionEvent.ACTION_MOVE);
 				} else {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -62,6 +62,7 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 
 	private DrawingSurfaceThread drawingThread;
 	private LayerContracts.Model layerModel;
+	private DrawingSurfaceListener drawingSurfaceListener;
 
 	public DrawingSurface(Context context, AttributeSet attrSet) {
 		super(context, attrSet);
@@ -89,7 +90,7 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 		Handler handler = new Handler(Looper.getMainLooper());
 		AutoScrollTask autoScrollTask = new AutoScrollTask(handler, new AutoScrollTaskCallbackImpl());
 		float density = getResources().getDisplayMetrics().density;
-		DrawingSurfaceListener drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask, density);
+		drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask, density);
 		setOnTouchListener(drawingSurfaceListener);
 	}
 
@@ -149,6 +150,14 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 			surfaceDirty = true;
 			surfaceLock.notify();
 		}
+	}
+
+	public void enableAutoScroll() {
+		drawingSurfaceListener.enableAutoScroll();
+	}
+
+	public void disableAutoScroll() {
+		drawingSurfaceListener.disableAutoScroll();
 	}
 
 	public synchronized void setBitmap(Bitmap bitmap) {

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DrawingSurfaceListenerTest {
 
 	private static final float DISPLAY_DENSITY = 1.5f;
@@ -411,5 +411,23 @@ public class DrawingSurfaceListenerTest {
 		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
 
 		verify(autoScrollTask).stop();
+	}
+
+	@Test
+	public void testDisableAutoScroll() {
+		DrawingSurface drawingSurface = mock(DrawingSurface.class);
+		MotionEvent motionEvent = mock(MotionEvent.class);
+
+		when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_DOWN);
+		when(motionEvent.getX()).thenReturn(41f);
+		when(motionEvent.getY()).thenReturn(5f);
+
+		when(drawingSurface.getWidth()).thenReturn(97);
+		when(drawingSurface.getHeight()).thenReturn(11);
+
+		drawingSurfaceListener.disableAutoScroll();
+		drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
+
+		verify(autoScrollTask, never()).start();
 	}
 }


### PR DESCRIPTION
* Add a `disableAutoScroll` function to drawingSurface and its listener
* Add a unit test to verify the behaviour
* Change `MockitoJUnitRunner` to `MockitoJUnitRunner.silent` to avoid unecessary stubbing warnings