### PR TITLE
PAINTROID-60: Fix inconsistent padding

### DIFF
--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_fill_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_fill_tool.xml
@@ -29,51 +29,33 @@
 
     <TextView
         android:id="@+id/pocketpaint_fill_tool_dialog_color_tolerance_input_text_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
+        style="@style/PocketPaintToolSubtitle"
         android:labelFor="@+id/pocketpaint_fill_tool_dialog_color_tolerance_input"
-        android:text="@string/fill_tool_dialog_color_tolerance_title"
-        android:textAllCaps="true"
-        android:textColor="@color/pocketpaint_colorAccent"
-        android:textStyle="bold"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="24dip" />
+        android:text="@string/fill_tool_dialog_color_tolerance_title" />
 
-    <View style="@style/PocketPaintDividerHorizontal"/>
+    <View style="@style/PocketPaintToolSectionDivider"/>
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="28dp"
-        android:weightSum="5"
-        android:orientation="horizontal" >
+        style="@style/PocketPaintToolSection" >
 
         <SeekBar
             android:id="@+id/pocketpaint_color_tolerance_seek_bar"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="4"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dp"
-            android:layout_marginTop="16dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:max="100"
-            android:minHeight="30dip"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="24dp" />
+            android:minHeight="30dip"/>
+
+        <Space style="@style/PocketPaintToolHorizontalSpace"/>
 
         <EditText
             android:id="@+id/pocketpaint_fill_tool_dialog_color_tolerance_input"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:inputType="number"
-            android:layout_marginBottom="5dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginEnd="10dp"
             android:textCursorDrawable="@null"
+            android:minEms="3"
             android:imeOptions="actionDone"
-            android:layout_weight="1"
             android:saveEnabled="false"
             android:textSize="14sp"
             android:textStyle="bold"

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_shapes.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_shapes.xml
@@ -17,152 +17,116 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/pocketpaint_outline_view_text_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
-        android:text="@string/dialog_brush_width_text"
-        android:textAllCaps="true"
-        android:textColor="@color/pocketpaint_main_rectangle_tool_accent_color"
-        android:textStyle="bold"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="24dip" />
+        style="@style/PocketPaintToolSubtitle"
+        android:text="@string/dialog_brush_width_text" />
 
     <View
-        style="@style/PocketPaintDividerHorizontal"
+        style="@style/PocketPaintToolSectionDivider"
         android:id="@+id/pocketpaint_outline_view_border" />
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:weightSum="5"
+        style="@style/PocketPaintToolSection"
         android:orientation="horizontal" >
 
         <SeekBar
             android:id="@+id/pocketpaint_shape_stroke_width_seek_bar"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="4"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dip"
-            android:layout_marginTop="16dp"
-            android:max="100"
-            android:minHeight="30dip"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="24dp" />
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:max="100" />
+
+        <Space style="@style/PocketPaintToolHorizontalSpace" />
 
         <EditText
             android:id="@+id/pocketpaint_shape_outline_edit"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:inputType="number"
             android:imeOptions="actionDone"
             android:textColor="@color/pocketpaint_colorAccent"
             android:textSize="14sp"
             android:textStyle="bold"
+            android:minEms="3"
             tools:ignore="LabelFor" />
     </LinearLayout>
 
     <TextView
         android:id="@+id/pocketpaint_shape_tool_fill_outline"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/shape_tool_dialog_fill_title"
-        android:textAllCaps="true"
-        android:textColor="@color/pocketpaint_colorAccent"
-        android:textStyle="bold"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="24dip" />
+        style="@style/PocketPaintToolSubtitle"
+        android:text="@string/shape_tool_dialog_fill_title"  />
 
-    <View style="@style/PocketPaintDividerHorizontal"/>
+    <View style="@style/PocketPaintToolSectionDivider"/>
 
     <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        style="@style/PocketPaintToolSection"
         android:layout_gravity="center"
-        android:orientation="horizontal" >
+        android:layout_width="wrap_content">
 
         <ImageButton
             android:id="@+id/pocketpaint_shape_ibtn_fill"
             style="@style/PocketPaintSelectableButton"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:padding="16dp"
+            android:layout_height="wrap_content"
             android:src="@drawable/ic_pocketpaint_rectangle" />
 
         <ImageButton
             android:id="@+id/pocketpaint_shape_ibtn_outline"
             style="@style/PocketPaintSelectableButton"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:padding="16dp"
+            android:layout_height="wrap_content"
             android:src="@drawable/ic_pocketpaint_rectangle_out" />
     </LinearLayout>
+
     <TextView
         android:id="@+id/pocketpaint_shape_tool_dialog_title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/shape_tool_dialog_rect_title"
-        android:textAllCaps="true"
-        android:textColor="@color/pocketpaint_colorAccent"
-        android:textStyle="bold"
-        android:layout_marginStart="24dp"
-        android:layout_marginEnd="16dp"/>
+        style="@style/PocketPaintToolSubtitle"
+        android:text="@string/shape_tool_dialog_rect_title" />
 
-    <View style="@style/PocketPaintDividerHorizontal"/>
+    <View style="@style/PocketPaintToolSectionDivider"/>
 
     <LinearLayout
         android:id="@+id/pocketpaint_shapes_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:orientation="horizontal">
+        style="@style/PocketPaintToolSection">
 
         <ImageButton
             android:id="@+id/pocketpaint_shapes_square_btn"
             style="@style/PocketPaintSelectableButton"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:src="@drawable/ic_pocketpaint_rectangle"
-            android:padding="16dp"/>
+            android:src="@drawable/ic_pocketpaint_rectangle" />
 
         <ImageButton
             android:id="@+id/pocketpaint_shapes_circle_btn"
             style="@style/PocketPaintSelectableButton"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:padding="16dp"
             android:src="@drawable/ic_pocketpaint_circle"/>
 
         <ImageButton
             android:id="@+id/pocketpaint_shapes_heart_btn"
             style="@style/PocketPaintSelectableButton"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:padding="16dp"
             android:src="@drawable/ic_pocketpaint_heart"/>
 
         <ImageButton
             android:id="@+id/pocketpaint_shapes_star_btn"
             style="@style/PocketPaintSelectableButton"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:src="@drawable/ic_pocketpaint_star"
-            android:padding="16dp"/>
+            android:src="@drawable/ic_pocketpaint_star"/>
     </LinearLayout>
 
-</merge>
+</LinearLayout>

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
@@ -33,87 +33,62 @@
         android:layout_height="wrap_content" />
 
     <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
-        android:text="@string/dialog_brush_width_text"
-        android:textAllCaps="true"
-        android:textColor="@color/pocketpaint_colorAccent"
-        android:textStyle="bold"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="24dip" />
+        style="@style/PocketPaintToolSubtitle"
+        android:text="@string/dialog_brush_width_text" />
 
-    <View style="@style/PocketPaintDividerHorizontal"/>
+    <View style="@style/PocketPaintToolSectionDivider"/>
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:weightSum="5"
-        android:orientation="horizontal" >
+        style="@style/PocketPaintToolSection">
 
         <SeekBar
             android:id="@+id/pocketpaint_stroke_width_seek_bar"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="4"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dip"
-            android:layout_marginTop="16dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:max="100"
-            android:minHeight="30dip"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="24dp" />
+            android:minHeight="30dip"/>
+
+        <Space style="@style/PocketPaintToolHorizontalSpace"/>
 
         <EditText
             android:id="@+id/pocketpaint_stroke_width_width_text"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minEms="3"
             android:inputType="number"
             android:imeOptions="actionDone"
             android:saveEnabled="false"
             android:textColor="@color/pocketpaint_colorAccent"
             android:textSize="14sp"
             android:textStyle="bold"
-            tools:ignore="LabelFor" />
+            tools:ignore="LabelFor"
+            tools:text="100" />
     </LinearLayout>
 
     <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/dialog_shape_text"
-        android:textAllCaps="true"
-        android:textColor="@color/pocketpaint_colorAccent"
-        android:textStyle="bold"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="24dip" />
+        style="@style/PocketPaintToolSubtitle"
+        android:text="@string/dialog_shape_text" />
 
-    <View style="@style/PocketPaintDividerHorizontal"/>
+    <View style="@style/PocketPaintToolSectionDivider"/>
 
     <LinearLayout
+        style="@style/PocketPaintToolSection"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:orientation="horizontal" >
+        android:layout_gravity="center">
 
         <ImageButton
             android:id="@+id/pocketpaint_stroke_ibtn_circle"
             style="@style/PocketPaintSelectableButton"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:padding="16dp"
+            android:layout_height="wrap_content"
             android:src="@drawable/ic_pocketpaint_tool_circle" />
 
         <ImageButton
             android:id="@+id/pocketpaint_stroke_ibtn_rect"
             style="@style/PocketPaintSelectableButton"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:padding="16dp"
+            android:layout_height="wrap_content"
             android:src="@drawable/ic_pocketpaint_tool_square" />
     </LinearLayout>
 

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
@@ -17,7 +17,6 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
-
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -33,53 +32,31 @@
         android:focusableInTouchMode="true">
 
         <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="24dip"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="15dp"
-            android:layout_marginBottom="4dp"
-            android:text="@string/text_tool_dialog_format_options"
-            android:textAllCaps="true"
-            android:textColor="@color/pocketpaint_colorAccent"
-            android:textStyle="bold" />
+            style="@style/PocketPaintToolSubtitle"
+            android:text="@string/text_tool_dialog_format_options"/>
 
-        <View style="@style/PocketPaintDividerHorizontal"/>
+        <View style="@style/PocketPaintToolSectionDivider"/>
 
         <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:weightSum="4.0"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="10dp"
-            android:gravity="center">
+            style="@style/PocketPaintToolSection">
 
             <Spinner
                 android:id="@+id/pocketpaint_text_tool_dialog_spinner_font"
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2.5"/>
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+
+            <Space style="@style/PocketPaintToolHorizontalSpace"/>
 
             <Spinner
                 android:id="@+id/pocketpaint_text_tool_dialog_spinner_text_size"
-                android:layout_weight="1.5"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_marginStart="5dp"
-                android:layout_marginEnd="5dp"/>
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
         </LinearLayout>
 
         <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="4dp"
-            android:layout_marginBottom="10dp">
+            style="@style/PocketPaintToolSection"
+            android:layout_marginTop="10dp">
 
             <ToggleButton
                 android:id="@+id/pocketpaint_text_tool_dialog_toggle_underlined"
@@ -110,28 +87,15 @@
         </LinearLayout>
 
         <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="24dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="0dp"
-            android:layout_marginBottom="4dp"
-            android:text="@string/text_tool_dialog_input_title"
-            android:textAllCaps="true"
-            android:textColor="@color/pocketpaint_colorAccent"
-            android:textStyle="bold" />
+            style="@style/PocketPaintToolSubtitle"
+            android:text="@string/text_tool_dialog_input_title"/>
 
-        <View style="@style/PocketPaintDividerHorizontal"/>
+        <View style="@style/PocketPaintToolSectionDivider"/>
 
         <EditText
+            style="@style/PocketPaintToolSection"
             android:id="@+id/pocketpaint_text_tool_dialog_input_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
             android:inputType="textMultiLine"
-            android:layout_marginStart="30dp"
-            android:layout_marginEnd="30dp"
-            android:layout_marginTop="10dp"
-            android:layout_marginBottom="4dp"
             android:textCursorDrawable="@null"
             android:hint="@string/text_tool_dialog_input_hint"
             android:imeOptions="flagNoExtractUi"/>

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_transform_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_transform_tool.xml
@@ -18,6 +18,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -28,163 +29,94 @@
         android:orientation="vertical">
 
         <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="24dip"
-            android:layout_marginTop="0dp"
-            android:text="@string/transform_tool_auto_crop_text"
-            android:textAllCaps="true"
-            android:textColor="@color/pocketpaint_colorAccent"
-            android:textStyle="bold" />
+            style="@style/PocketPaintToolSubtitle"
+            android:text="@string/transform_tool_auto_crop_text" />
 
-        <View style="@style/PocketPaintDividerHorizontal"/>
+        <View style="@style/PocketPaintToolSectionDivider"/>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:layout_margin="15dp"
-            android:layout_marginBottom="10dp"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal"
-            android:weightSum="5"
-            android:baselineAligned="false">
-
-            <TableRow
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:layout_gravity="center_vertical"
-                android:orientation="horizontal">
+        <LinearLayout style="@style/PocketPaintToolSection">
 
             <ImageButton
                 android:id="@+id/pocketpaint_transform_auto_crop_btn"
                 style="?android:borderlessButtonStyle"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_weight="1"
-                android:minHeight="0dp"
-                android:padding="2dp"
                 android:src="@drawable/ic_pocketpaint_tool_resize_adjust"
                 android:theme="@style/PocketPaintHighlightColorTheme" />
-            </TableRow>
 
-            <TableRow
+            <Space style="@style/PocketPaintToolHorizontalSpace" />
+
+            <TextView
+                android:id="@+id/pocketpaint_transform_width_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:labelFor="@+id/pocketpaint_transform_width_value"
+                android:text="@string/transform_width_text"
+                android:textSize="14sp" />
+
+            <EditText
+                android:id="@+id/pocketpaint_transform_width_value"
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2"
-                android:weightSum="2.5"
-                android:layout_gravity="center_vertical"
-                android:orientation="horizontal">
+                android:layout_height="wrap_content"
+                android:layout_weight="4"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:textAlignment="textEnd"
+                android:textColor="@color/pocketpaint_colorAccent"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                tools:text="100" />
 
-                <TextView
-                    android:id="@+id/pocketpaint_transform_width_text"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:labelFor="@+id/pocketpaint_transform_width_value"
-                    android:layout_weight="1"
-                    android:text="@string/transform_width_text"
-                    android:textSize="14sp" />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:text="@string/pixel" />
 
-                <EditText
-                    android:id="@+id/pocketpaint_transform_width_value"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:imeOptions="actionDone"
-                    android:inputType="number"
-                    android:layout_weight="1"
-                    android:textColor="@color/pocketpaint_colorAccent"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
+            <Space style="@style/PocketPaintToolHorizontalSpace"
+                android:layout_width="16dp" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:textSize="14sp"
-                    android:layout_weight="0.5"
-                    android:text="@string/pixel" />
+            <TextView
+                android:id="@+id/pocketpaint_transform_height_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:labelFor="@+id/pocketpaint_transform_height_value"
+                android:text="@string/transform_height_text"
+                android:textSize="14sp" />
 
-            </TableRow>
-
-            <TableRow
+            <EditText
+                android:id="@+id/pocketpaint_transform_height_value"
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="2"
-                android:weightSum="2.5"
-                android:orientation="horizontal">
+                android:layout_height="wrap_content"
+                android:layout_weight="4"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:textAlignment="textEnd"
+                android:textColor="@color/pocketpaint_colorAccent"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                tools:text="100" />
 
-                <TextView
-                    android:id="@+id/pocketpaint_transform_height_text"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:labelFor="@+id/pocketpaint_transform_height_value"
-                    android:layout_weight="1"
-                    android:text="@string/transform_height_text"
-                    android:textSize="14sp" />
-
-                <EditText
-                    android:id="@+id/pocketpaint_transform_height_value"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:imeOptions="actionDone"
-                    android:layout_weight="1"
-                    android:inputType="number"
-                    android:textColor="@color/pocketpaint_colorAccent"
-                    android:textSize="14sp"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:layout_weight="0.5"
-                    android:textSize="14sp"
-                    android:text="@string/pixel" />
-            </TableRow>
-
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:text="@string/pixel" />
         </LinearLayout>
 
         <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="24dip"
-            android:layout_marginTop="5dp"
-            android:text="@string/button_transform"
-            android:textAllCaps="true"
-            android:textColor="@color/pocketpaint_colorAccent"
-            android:textStyle="bold" />
+            style="@style/PocketPaintToolSubtitle"
+            android:text="@string/button_transform" />
 
-        <View style="@style/PocketPaintDividerHorizontal"/>
+        <View style="@style/PocketPaintToolSectionDivider"/>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:layout_margin="15dp"
-            android:layout_marginBottom="10dp"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal"
-            android:weightSum="4">
-
+        <LinearLayout style="@style/PocketPaintToolSection">
             <ImageButton
                 android:id="@+id/pocketpaint_transform_rotate_left_btn"
                 style="?android:borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:layout_weight="1"
-                android:minHeight="0dp"
-                android:padding="2dp"
                 android:src="@drawable/ic_pocketpaint_tool_rotate_left"
                 android:theme="@style/PocketPaintHighlightColorTheme" />
 
@@ -193,10 +125,7 @@
                 style="?android:borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:layout_weight="1"
-                android:minHeight="0dp"
-                android:padding="2dp"
                 android:src="@drawable/ic_pocketpaint_rotate_right"
                 android:theme="@style/PocketPaintHighlightColorTheme" />
 
@@ -205,10 +134,7 @@
                 style="?android:borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:layout_weight="1"
-                android:minHeight="0dp"
-                android:padding="2dp"
                 android:src="@drawable/ic_pocketpaint_tool_flip_vertical"
                 android:theme="@style/PocketPaintHighlightColorTheme" />
 
@@ -217,14 +143,9 @@
                 style="?android:borderlessButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:layout_weight="1"
-                android:minHeight="0dp"
-                android:padding="2dp"
                 android:src="@drawable/ic_pocketpaint_tool_flip_horizontal"
                 android:theme="@style/PocketPaintHighlightColorTheme" />
-
-
         </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_tool_options.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_tool_options.xml
@@ -17,33 +17,22 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/pocketpaint_layout_tool_options"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:visibility="visible">
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/pocketpaint_layout_tool_options_name"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dip"
-        android:layout_marginTop="8dp"
-        android:textAllCaps="true"
-        android:textSize="20sp"
-        android:textColor="@color/pocketpaint_colorAccent"
-        android:textStyle="bold"
-        tools:text="@tools:sample/lorem"/>
+        style="@style/PocketPaintToolTitle"
+        tools:text="Tool name"/>
 
     <LinearLayout
         android:id="@+id/pocketpaint_layout_tool_specific_options"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
         android:orientation="vertical">
     </LinearLayout>
-
 </LinearLayout>

--- a/Paintroid/src/main/res/values/style.xml
+++ b/Paintroid/src/main/res/values/style.xml
@@ -60,13 +60,6 @@
         <item name="android:background">@color/pocketpaint_main_separator_color</item>
     </style>
 
-    <style name="PocketPaintDividerHorizontal" parent="PocketPaintDividerBase">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">2dp</item>
-        <item name="android:layout_marginEnd">16dp</item>
-        <item name="android:layout_marginStart">24dp</item>
-    </style>
-
     <style name="PocketPaintSelectableButton" parent="Base.Widget.AppCompat.Button.Borderless">
         <item name="android:background">@drawable/pocketpaint_attribute_button_selector</item>
     </style>
@@ -74,6 +67,45 @@
     <style name="PocketPaintDrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
         <item name="spinBars">false</item>
         <item name="color">@android:color/white</item>
+    </style>
+
+    <style name="PocketPaintToolTitle" parent="PocketPaintToolSubtitle">
+        <item name="android:layout_marginTop">8dp</item>
+        <item name="android:layout_marginBottom">10dp</item>
+        <item name="android:textSize">20sp</item>
+    </style>
+
+    <style name="PocketPaintToolSubtitle">
+        <item name="android:layout_marginStart">24dp</item>
+        <item name="android:layout_marginEnd">16dp</item>
+        <item name="android:layout_marginTop">8dp</item>
+        <item name="android:layout_marginBottom">4dp</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textColor">@color/pocketpaint_colorAccent</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="PocketPaintToolSectionDivider" parent="PocketPaintDividerBase">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">2dp</item>
+        <item name="android:layout_marginEnd">16dp</item>
+        <item name="android:layout_marginStart">24dp</item>
+        <item name="android:layout_marginBottom">10dp</item>
+    </style>
+
+    <style name="PocketPaintToolSection">
+        <item name="android:layout_marginStart">24dp</item>
+        <item name="android:layout_marginEnd">16dp</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:gravity">center_vertical</item>
+    </style>
+
+    <style name="PocketPaintToolHorizontalSpace">
+        <item name="android:layout_width">8dp</item>
+        <item name="android:layout_height">wrap_content</item>
     </style>
 
     <style name="PocketPaintWelcomeHeader" parent="@android:style/TextAppearance.Large">


### PR DESCRIPTION
* Create several style classes to unify the look of our tool option layouts
* Replace all copy pasted xml with the new styles (less code, greater uniformity)

Brush tool layout
=========

| Before | After |
| --------- | ------ |
| <img src="https://user-images.githubusercontent.com/30626927/53683063-cec5b780-3cfc-11e9-8d4d-f86e8a9acd8f.png" width="256" > | <img src="https://user-images.githubusercontent.com/30626927/53683112-75aa5380-3cfd-11e9-8866-3c501b7a004c.png" width="256" > |

Shapes tool layout
===========
| Before | After |
| --------- | ------ |
 | <img src="https://user-images.githubusercontent.com/30626927/53683129-a8ece280-3cfd-11e9-8a06-198fa875a008.png" width="256" > | <img src="https://user-images.githubusercontent.com/30626927/53683137-bb671c00-3cfd-11e9-8deb-1637fb66eac2.png" width="256" > |

Fill tool  layout
===========
| Before | After |
| --------- | ------ |
 | <img src="https://user-images.githubusercontent.com/30626927/53683153-e5b8d980-3cfd-11e9-8b33-7aeea3dc8c49.png" width="256" > | <img src="https://user-images.githubusercontent.com/30626927/53683157-f0736e80-3cfd-11e9-8669-c7ae9421aeb8.png" width="256" > |

Text tool  layout
===========
| Before | After |
| --------- | ------ |
 | <img src="https://user-images.githubusercontent.com/30626927/53683168-01bc7b00-3cfe-11e9-9ded-1282895df0bd.png" width="256" > | <img src="https://user-images.githubusercontent.com/30626927/53683176-08e38900-3cfe-11e9-8c6f-a4398fb50aa0.png" width="256" > |

Transform tool  layout
===========
| Before | After |
| --------- | ------ |
 | <img src="https://user-images.githubusercontent.com/30626927/53683181-1a2c9580-3cfe-11e9-9c43-45f318036383.png" width="256" > | <img src="https://user-images.githubusercontent.com/30626927/53683185-231d6700-3cfe-11e9-8561-94b9aebf0464.png" width="256" > |


