### PR TITLE
PAINTROID-59: Sans Serif now default font for Texttool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolFontSpinnerTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolFontSpinnerTest.java
@@ -38,6 +38,7 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withSpinnerText;
 
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.hasTypeFace;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.withIndex;
@@ -76,5 +77,14 @@ public class TextToolFontSpinnerTest {
 
 		onView(withIndex(withId(android.R.id.text1), 4))
 				.check(matches(hasTypeFace(stcFontFace)));
+	}
+
+	@Test
+	public void checkIfSansSerifIsDefaultSpinnerFont() {
+		onToolBarView()
+				.performSelectTool(ToolType.TEXT);
+
+		onView(withId(R.id.pocketpaint_text_tool_dialog_spinner_font))
+				.check(matches(withSpinnerText("Sans Serif")));
 	}
 }

--- a/Paintroid/src/main/res/values/arrays.xml
+++ b/Paintroid/src/main/res/values/arrays.xml
@@ -44,9 +44,9 @@
 
     <!-- PocketPaint font chooser options -->
     <string-array name="pocketpaint_main_text_tool_fonts">
+        <item>@string/text_tool_dialog_font_sans_serif</item>
         <item>@string/text_tool_dialog_font_monospace</item>
         <item>@string/text_tool_dialog_font_serif</item>
-        <item>@string/text_tool_dialog_font_sans_serif</item>
         <item>@string/text_tool_dialog_font_dubai</item>
         <item>@string/text_tool_dialog_font_arabic_stc</item>
     </string-array>


### PR DESCRIPTION
## Link to ticket
https://jira.catrob.at/browse/PAINTROID-59 ![](https://img.shields.io/jira/issue/https/jira.catrob.at/PAINTROID-59.svg)

## Description