### PR TITLE
PAINTROID-1: Fix crash when second MainActivity in same process

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
@@ -28,11 +28,11 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.dialog.colorpicker.HSVColorPickerView;
 import org.catrobat.paintroid.dialog.colorpicker.PresetSelectorView;
 import org.catrobat.paintroid.dialog.colorpicker.RgbSelectorView;
+import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,6 +52,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getMainActivity;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.withBackground;
 import static org.catrobat.paintroid.test.espresso.util.UiMatcher.withBackgroundColor;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ColorPickerViewInteraction.onColorPickerView;
@@ -74,6 +75,10 @@ public class LandscapeIntegrationTest {
 				.performSelectTool(ToolType.BRUSH);
 
 		setOrientation(SCREEN_ORIENTATION_LANDSCAPE);
+	}
+
+	private Tool getCurrentTool() {
+		return getMainActivity().toolReference.get();
 	}
 
 	@Test
@@ -127,9 +132,9 @@ public class LandscapeIntegrationTest {
 			onToolBarView()
 					.performSelectTool(toolType);
 
-			assertEquals(toolType, PaintroidApplication.currentTool.getToolType());
+			assertEquals(toolType, getCurrentTool().getToolType());
 
-			if (!PaintroidApplication.currentTool.getToolOptionsAreShown()) {
+			if (!getCurrentTool().getToolOptionsAreShown()) {
 				onToolBarView()
 						.performClickSelectedToolButton();
 			}
@@ -160,7 +165,7 @@ public class LandscapeIntegrationTest {
 					.performSelectTool(toolType);
 
 			setOrientation(SCREEN_ORIENTATION_PORTRAIT);
-			assertEquals(toolType, PaintroidApplication.currentTool.getToolType());
+			assertEquals(toolType, getCurrentTool().getToolType());
 			setOrientation(SCREEN_ORIENTATION_LANDSCAPE);
 		}
 	}
@@ -194,7 +199,7 @@ public class LandscapeIntegrationTest {
 					.performClickColorPickerPresetSelectorButton(i);
 
 			if (colors[i] != Color.TRANSPARENT) {
-				int selectedColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+				int selectedColor = getCurrentTool().getDrawPaint().getColor();
 				assertEquals(colors[i], selectedColor);
 
 				onView(withId(R.id.color_chooser_button_ok))

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
@@ -29,10 +29,10 @@ import android.support.test.runner.AndroidJUnit4;
 import android.view.Gravity;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.junit.After;
 import org.junit.Before;
@@ -87,9 +87,13 @@ public class ToolOnBackPressedIntegrationTest {
 			Manifest.permission.READ_EXTERNAL_STORAGE);
 
 	private File saveFile = null;
+	private ToolReference toolReference;
 
 	@Before
 	public void setUp() {
+		MainActivity activity = launchActivityRule.getActivity();
+		toolReference = activity.toolReference;
+
 		onToolBarView()
 				.performSelectTool(ToolType.BRUSH);
 	}
@@ -164,7 +168,7 @@ public class ToolOnBackPressedIntegrationTest {
 
 		Espresso.pressBack();
 
-		assertEquals(PaintroidApplication.currentTool.getToolType(), ToolType.BRUSH);
+		assertEquals(toolReference.get().getToolType(), ToolType.BRUSH);
 	}
 
 	@Test
@@ -178,14 +182,14 @@ public class ToolOnBackPressedIntegrationTest {
 
 		Espresso.pressBack();
 
-		assertEquals(PaintroidApplication.currentTool.getToolType(), ToolType.CURSOR);
+		assertEquals(toolReference.get().getToolType(), ToolType.CURSOR);
 
 		onView(withId(R.id.pocketpaint_main_tool_options)).check(matches(not(isDisplayed())));
 		onView(withId(R.id.pocketpaint_layout_tool_options_name)).check(matches(not(isDisplayed())));
 
 		Espresso.pressBack();
 
-		assertEquals(PaintroidApplication.currentTool.getToolType(), ToolType.BRUSH);
+		assertEquals(toolReference.get().getToolType(), ToolType.BRUSH);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -28,11 +28,12 @@ import android.support.test.runner.AndroidJUnit4;
 import android.widget.Button;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.dialog.colorpicker.HSVColorPickerView;
 import org.catrobat.paintroid.dialog.colorpicker.PresetSelectorView;
 import org.catrobat.paintroid.dialog.colorpicker.RgbSelectorView;
+import org.catrobat.paintroid.tools.ToolReference;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,6 +81,12 @@ public class ColorDialogIntegrationTest {
 
 	@Rule
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
+	private ToolReference toolReference;
+
+	@Before
+	public void setUp() {
+		toolReference = launchActivityRule.getActivity().toolReference;
+	}
 
 	private int getColorById(int colorId) {
 		return launchActivityRule.getActivity().getResources().getColor(colorId);
@@ -124,7 +131,7 @@ public class ColorDialogIntegrationTest {
 					.performClickColorPickerPresetSelectorButton(counterColors);
 
 			int arrayColor = presetColors.getColor(counterColors, Color.BLACK);
-			int selectedColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+			int selectedColor = toolReference.get().getDrawPaint().getColor();
 
 			assertEquals("Color in array and selected color not the same", arrayColor, selectedColor);
 
@@ -158,7 +165,7 @@ public class ColorDialogIntegrationTest {
 
 	@Test
 	public void testColorPickerDialogOnBackPressedSelectedColorShouldNotChange() {
-		int expectedSelectedColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		int expectedSelectedColor = toolReference.get().getDrawPaint().getColor();
 
 		onColorPickerView()
 				.performOpenColorPicker();
@@ -179,7 +186,7 @@ public class ColorDialogIntegrationTest {
 		// Close color picker dialog
 		onView(isRoot()).perform(pressBack());
 
-		int currentSelectedColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		int currentSelectedColor = toolReference.get().getDrawPaint().getColor();
 		assertNotEquals("Selected color has not changed", expectedSelectedColor, currentSelectedColor);
 	}
 
@@ -213,7 +220,7 @@ public class ColorDialogIntegrationTest {
 		onView(withId(R.id.color_chooser_rgb_alpha_value)).check(matches(isDisplayed()));
 		onView(allOf(withText(TEXT_PERCENT_SIGN), hasSibling(withId(R.id.color_chooser_rgb_alpha_value)))).check(matches(isDisplayed()));
 
-		int currentSelectColor = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		int currentSelectColor = toolReference.get().getDrawPaint().getColor();
 
 		onView(withId(R.id.color_chooser_rgb_red_value)).check(matches(withText(Integer.toString(Color.red(currentSelectColor)))));
 		onView(withId(R.id.color_chooser_rgb_green_value)).check(matches(withText(Integer.toString(Color.green(currentSelectColor)))));
@@ -252,7 +259,7 @@ public class ColorDialogIntegrationTest {
 		onView(withId(R.id.color_chooser_color_rgb_seekbar_blue)).perform(touchCenterRight());
 		onView(withId(R.id.color_chooser_color_rgb_seekbar_alpha)).perform(touchCenterRight());
 
-		assertEquals("Selected color is not blue", PaintroidApplication.currentTool.getDrawPaint().getColor(), Color.BLUE);
+		assertEquals("Selected color is not blue", toolReference.get().getDrawPaint().getColor(), Color.BLUE);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/FillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/FillToolIntegrationTest.java
@@ -26,10 +26,10 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.test.espresso.util.BitmapLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.FillTool;
 import org.catrobat.paintroid.ui.Perspective;
@@ -65,10 +65,13 @@ public class FillToolIntegrationTest {
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
 
 	private Perspective perspective;
+	private ToolReference toolReference;
 
 	@Before
 	public void setUp() {
-		perspective = launchActivityRule.getActivity().perspective;
+		MainActivity mainActivity = launchActivityRule.getActivity();
+		perspective = mainActivity.perspective;
+		toolReference = mainActivity.toolReference;
 
 		onToolBarView()
 				.performSelectTool(ToolType.FILL);
@@ -142,7 +145,7 @@ public class FillToolIntegrationTest {
 
 	@Test
 	public void testFillToolOptionsDialog() {
-		FillTool fillTool = (FillTool) PaintroidApplication.currentTool;
+		FillTool fillTool = (FillTool) toolReference.get();
 		assertEquals(
 				"Wrong fill tool member value for color tolerance",
 				fillTool.getToleranceAbsoluteValue(FillTool.DEFAULT_TOLERANCE_IN_PERCENT),
@@ -175,7 +178,7 @@ public class FillToolIntegrationTest {
 
 	@Test
 	public void testFillToolDialogAfterToolSwitch() {
-		FillTool fillTool = (FillTool) PaintroidApplication.currentTool;
+		FillTool fillTool = (FillTool) toolReference.get();
 
 		onToolBarView()
 				.performClickSelectedToolButton();

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
@@ -27,14 +27,14 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.test.espresso.util.BitmapLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
-import org.catrobat.paintroid.tools.implementation.GeometricFillTool;
+import org.catrobat.paintroid.tools.implementation.ShapeTool;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,12 +65,14 @@ public class RectangleFillToolIntegrationTest {
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
 	private Workspace workspace;
 	private Perspective perspective;
+	private ToolReference toolReference;
 
 	@Before
 	public void setUp() {
 		MainActivity activity = launchActivityRule.getActivity();
 		workspace = activity.workspace;
 		perspective = activity.perspective;
+		toolReference = activity.toolReference;
 
 		onToolBarView()
 				.performSelectTool(ToolType.BRUSH);
@@ -81,7 +83,7 @@ public class RectangleFillToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 
-		BaseToolWithRectangleShape rectangleFillTool = (BaseToolWithRectangleShape) PaintroidApplication.currentTool;
+		BaseToolWithRectangleShape rectangleFillTool = (BaseToolWithRectangleShape) toolReference.get();
 		float rectWidth = rectangleFillTool.boxWidth;
 		float rectHeight = rectangleFillTool.boxHeight;
 		PointF rectPosition = rectangleFillTool.toolPosition;
@@ -98,9 +100,9 @@ public class RectangleFillToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 		onShapeToolOptionsView()
-				.performSelectShape(GeometricFillTool.BaseShape.OVAL);
+				.performSelectShape(ShapeTool.BaseShape.OVAL);
 
-		BaseToolWithRectangleShape ellipseTool = (BaseToolWithRectangleShape) PaintroidApplication.currentTool;
+		BaseToolWithRectangleShape ellipseTool = (BaseToolWithRectangleShape) toolReference.get();
 		float rectHeight = ellipseTool.boxHeight;
 
 		onToolBarView()
@@ -140,7 +142,7 @@ public class RectangleFillToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 
-		BaseToolWithRectangleShape rectangleFillTool = (BaseToolWithRectangleShape) PaintroidApplication.currentTool;
+		BaseToolWithRectangleShape rectangleFillTool = (BaseToolWithRectangleShape) toolReference.get();
 
 		Bitmap drawingBitmap = rectangleFillTool.drawingBitmap;
 		int colorInRectangle = drawingBitmap.getPixel(drawingBitmap.getWidth() / 2, drawingBitmap.getHeight() / 2);
@@ -155,7 +157,7 @@ public class RectangleFillToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 
-		BaseToolWithRectangleShape rectangleFillTool = (BaseToolWithRectangleShape) PaintroidApplication.currentTool;
+		BaseToolWithRectangleShape rectangleFillTool = (BaseToolWithRectangleShape) toolReference.get();
 
 		Bitmap drawingBitmap = rectangleFillTool.drawingBitmap;
 		int colorInRectangle = drawingBitmap.getPixel(drawingBitmap.getWidth() / 2, drawingBitmap.getHeight() / 2);
@@ -180,14 +182,14 @@ public class RectangleFillToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 		onShapeToolOptionsView()
-				.performSelectShape(GeometricFillTool.BaseShape.RECTANGLE);
+				.performSelectShape(ShapeTool.BaseShape.RECTANGLE);
 		selectShapeTypeAndDraw(false, Color.TRANSPARENT);
 
 		onToolBarView()
 				.performClickSelectedToolButton();
 
 		onShapeToolOptionsView()
-				.performSelectShape(GeometricFillTool.BaseShape.OVAL);
+				.performSelectShape(ShapeTool.BaseShape.OVAL);
 		selectShapeTypeAndDraw(true, Color.TRANSPARENT);
 	}
 
@@ -196,7 +198,7 @@ public class RectangleFillToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 		onShapeToolOptionsView()
-				.performSelectShape(GeometricFillTool.BaseShape.HEART);
+				.performSelectShape(ShapeTool.BaseShape.HEART);
 		selectShapeTypeAndDraw(false, Color.BLACK);
 	}
 
@@ -206,7 +208,7 @@ public class RectangleFillToolIntegrationTest {
 				.performSelectTool(ToolType.SHAPE);
 
 		onShapeToolOptionsView()
-				.performSelectShape(GeometricFillTool.BaseShape.HEART);
+				.performSelectShape(ShapeTool.BaseShape.HEART);
 
 		onToolBarView()
 				.performCloseToolOptions();
@@ -214,7 +216,7 @@ public class RectangleFillToolIntegrationTest {
 		onToolProperties()
 				.setColor(Color.TRANSPARENT);
 
-		BaseToolWithRectangleShape tool = (BaseToolWithRectangleShape) PaintroidApplication.currentTool;
+		BaseToolWithRectangleShape tool = (BaseToolWithRectangleShape) toolReference.get();
 		Bitmap drawingBitmap = tool.drawingBitmap;
 		int width = drawingBitmap.getWidth();
 		int height = drawingBitmap.getHeight();
@@ -238,16 +240,16 @@ public class RectangleFillToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 		onShapeToolOptionsView()
-				.performSelectShape(GeometricFillTool.BaseShape.RECTANGLE);
+				.performSelectShape(ShapeTool.BaseShape.RECTANGLE);
 		selectShapeTypeAndDraw(true, Color.BLACK);
 
 		onToolBarView()
 				.performOpenToolOptions();
 		onShapeToolOptionsView()
-				.performSelectShape(GeometricFillTool.BaseShape.HEART);
+				.performSelectShape(ShapeTool.BaseShape.HEART);
 		selectShapeTypeAndDraw(true, Color.TRANSPARENT);
 
-		BaseToolWithRectangleShape tool = (BaseToolWithRectangleShape) PaintroidApplication.currentTool;
+		BaseToolWithRectangleShape tool = (BaseToolWithRectangleShape) toolReference.get();
 		Bitmap drawingBitmap = tool.drawingBitmap;
 		int boxWidth = drawingBitmap.getWidth();
 		int boxHeight = drawingBitmap.getHeight();
@@ -266,7 +268,7 @@ public class RectangleFillToolIntegrationTest {
 	}
 
 	public void selectShapeTypeAndDraw(boolean changeColor, int color) {
-		BaseToolWithRectangleShape tool = (BaseToolWithRectangleShape) PaintroidApplication.currentTool;
+		BaseToolWithRectangleShape tool = (BaseToolWithRectangleShape) toolReference.get();
 		PointF centerPointTool = tool.toolPosition;
 
 		PointF pointUnderTest = new PointF(centerPointTool.x, centerPointTool.y);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
@@ -28,10 +28,10 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.UiInteractions;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
@@ -76,6 +76,7 @@ public class StampToolIntegrationTest {
 
 	private Workspace workspace;
 	private Perspective perspective;
+	private ToolReference toolReference;
 
 	@Before
 	public void setUp() {
@@ -84,6 +85,7 @@ public class StampToolIntegrationTest {
 		MainActivity activity = launchActivityRule.getActivity();
 		workspace = activity.workspace;
 		perspective = activity.perspective;
+		toolReference = activity.toolReference;
 	}
 
 	@Test
@@ -96,7 +98,7 @@ public class StampToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.STAMP);
 
-		StampTool stampTool = (StampTool) PaintroidApplication.currentTool;
+		StampTool stampTool = (StampTool) toolReference.get();
 
 		stampTool.toolPosition.set(surfaceCenterPoint);
 		stampTool.boxWidth = SQUARE_LENGTH;
@@ -170,7 +172,7 @@ public class StampToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.STAMP);
 
-		StampTool stampTool = (StampTool) PaintroidApplication.currentTool;
+		StampTool stampTool = (StampTool) toolReference.get();
 		PointF toolPosition = new PointF(surfaceCenterPoint.x, surfaceCenterPoint.y - Y_CLICK_OFFSET);
 		stampTool.toolPosition.set(toolPosition);
 
@@ -213,7 +215,7 @@ public class StampToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.STAMP);
 
-		StampTool stampTool = (StampTool) PaintroidApplication.currentTool;
+		StampTool stampTool = (StampTool) toolReference.get();
 		PointF toolPosition = new PointF(perspective.surfaceCenterX, perspective.surfaceCenterY);
 		stampTool.toolPosition.set(toolPosition);
 		stampTool.boxWidth = (int) (bitmapWidth * STAMP_RESIZE_FACTOR);
@@ -245,13 +247,13 @@ public class StampToolIntegrationTest {
 				.performSelectTool(ToolType.STAMP);
 
 		Bitmap emptyBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
-				PaintroidApplication.currentTool).drawingBitmap);
+				toolReference.get()).drawingBitmap);
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION, tapStampLong));
 
 		Bitmap expectedBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
-				PaintroidApplication.currentTool).drawingBitmap);
+				toolReference.get()).drawingBitmap);
 
 		assertFalse(expectedBitmap.sameAs(emptyBitmap));
 
@@ -259,7 +261,7 @@ public class StampToolIntegrationTest {
 				.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
 		Bitmap actualBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
-				PaintroidApplication.currentTool).drawingBitmap);
+				toolReference.get()).drawingBitmap);
 
 		assertTrue(expectedBitmap.sameAs(actualBitmap));
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
@@ -34,11 +34,11 @@ import android.widget.Spinner;
 import android.widget.ToggleButton;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.contract.LayerContracts;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.MainActivityHelper;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.TextTool;
 import org.catrobat.paintroid.ui.Perspective;
@@ -113,6 +113,7 @@ public class TextToolIntegrationTest {
 	private Perspective perspective;
 	private LayerContracts.Model layerModel;
 	private MainActivity activity;
+	private ToolReference toolReference;
 
 	@Before
 	public void setUp() {
@@ -120,10 +121,12 @@ public class TextToolIntegrationTest {
 		activityHelper = new MainActivityHelper(activity);
 		perspective = activity.perspective;
 		layerModel = activity.layerModel;
+		toolReference = activity.toolReference;
 
 		onToolBarView()
 				.performSelectTool(ToolType.TEXT);
-		textTool = (TextTool) PaintroidApplication.currentTool;
+
+		textTool = (TextTool) toolReference.get();
 
 		textEditText = activity.findViewById(R.id.pocketpaint_text_tool_dialog_input_text);
 		fontSpinner = activity.findViewById(R.id.pocketpaint_text_tool_dialog_spinner_font);
@@ -253,7 +256,7 @@ public class TextToolIntegrationTest {
 
 		activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
-		textTool = (TextTool) PaintroidApplication.currentTool;
+		textTool = (TextTool) toolReference.get();
 
 		assertEquals(TEST_TEXT, textEditText.getText().toString());
 		assertEquals(FONT_SANS_SERIF, fontSpinner.getSelectedItem());

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
@@ -28,12 +28,12 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.contract.LayerContracts;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.MainActivityHelper;
 import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithShape;
@@ -85,6 +85,7 @@ public class TransformToolIntegrationTest {
 
 	private Perspective perspective;
 	private LayerContracts.Model layerModel;
+	private ToolReference toolReference;
 
 	private static void drawPlus(Bitmap bitmap, int lineLength) {
 		int horizontalStartX = bitmap.getWidth() / 4;
@@ -108,38 +109,38 @@ public class TransformToolIntegrationTest {
 		return perspective.getSurfacePointFromCanvasPoint(point);
 	}
 
-	private static float getToolSelectionBoxWidth() {
-		return ((BaseToolWithRectangleShape) PaintroidApplication.currentTool).boxWidth;
+	private float getToolSelectionBoxWidth() {
+		return ((BaseToolWithRectangleShape) toolReference.get()).boxWidth;
 	}
 
-	private static void setToolSelectionBoxWidth(float width) {
-		((BaseToolWithRectangleShape) PaintroidApplication.currentTool).boxWidth = width;
+	private void setToolSelectionBoxWidth(float width) {
+		((BaseToolWithRectangleShape) toolReference.get()).boxWidth = width;
 	}
 
-	private static float getToolSelectionBoxHeight() {
-		return ((BaseToolWithRectangleShape) PaintroidApplication.currentTool).boxHeight;
+	private float getToolSelectionBoxHeight() {
+		return ((BaseToolWithRectangleShape) toolReference.get()).boxHeight;
 	}
 
-	private static void setToolSelectionBoxHeight(float height) {
-		((BaseToolWithRectangleShape) PaintroidApplication.currentTool).boxHeight = height;
+	private void setToolSelectionBoxHeight(float height) {
+		((BaseToolWithRectangleShape) toolReference.get()).boxHeight = height;
 	}
 
-	private static void setToolSelectionBoxDimensions(float width, float height) {
+	private void setToolSelectionBoxDimensions(float width, float height) {
 		BaseToolWithRectangleShape currentTool = (BaseToolWithRectangleShape)
-				PaintroidApplication.currentTool;
+				toolReference.get();
 		currentTool.boxWidth = width;
 		currentTool.boxHeight = height;
 	}
 
-	private static PointF getToolPosition() {
-		return ((BaseToolWithShape) PaintroidApplication.currentTool).toolPosition;
+	private PointF getToolPosition() {
+		return ((BaseToolWithShape) toolReference.get()).toolPosition;
 	}
 
-	private static void setToolPosition(float x, float y) {
-		((BaseToolWithShape) PaintroidApplication.currentTool).toolPosition.set(x, y);
+	private void setToolPosition(float x, float y) {
+		((BaseToolWithShape) toolReference.get()).toolPosition.set(x, y);
 	}
 
-	private static PointF newPointF(PointF point) {
+	private PointF newPointF(PointF point) {
 		return new PointF(point.x, point.y);
 	}
 
@@ -149,6 +150,7 @@ public class TransformToolIntegrationTest {
 		activityHelper = new MainActivityHelper(activity);
 		perspective = activity.perspective;
 		layerModel = activity.layerModel;
+		toolReference = activity.toolReference;
 
 		displayWidth = activityHelper.getDisplayWidth();
 		displayHeight = activityHelper.getDisplayHeight();
@@ -528,7 +530,7 @@ public class TransformToolIntegrationTest {
 		final Bitmap croppedBitmap = layerModel.getCurrentLayer().getBitmap();
 		final int width = croppedBitmap.getWidth();
 		final int height = croppedBitmap.getHeight();
-		final TransformTool tool = (TransformTool) PaintroidApplication.currentTool;
+		final TransformTool tool = (TransformTool) toolReference.get();
 		assertEquals(0.0f, tool.resizeBoundWidthXLeft, Float.MIN_VALUE);
 		assertEquals(width - 1, tool.resizeBoundWidthXRight, Float.MIN_VALUE);
 		assertEquals(0.0f, tool.resizeBoundHeightYTop, Float.MIN_VALUE);
@@ -733,7 +735,7 @@ public class TransformToolIntegrationTest {
 		final int height = croppedBitmap.getHeight();
 		final int width = croppedBitmap.getWidth();
 
-		final TransformTool tool = (TransformTool) PaintroidApplication.currentTool;
+		final TransformTool tool = (TransformTool) toolReference.get();
 		assertEquals(0.0f, tool.resizeBoundWidthXLeft, Float.MIN_VALUE);
 		assertEquals(width - 1, tool.resizeBoundWidthXRight, Float.MIN_VALUE);
 		assertEquals(0.0f, tool.resizeBoundHeightYTop, Float.MIN_VALUE);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/DrawingSurfaceLocationProvider.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/DrawingSurfaceLocationProvider.java
@@ -24,7 +24,6 @@ import android.support.test.espresso.action.CoordinatesProvider;
 import android.view.View;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithShape;
 
@@ -103,7 +102,7 @@ public enum DrawingSurfaceLocationProvider implements CoordinatesProvider {
 		public float[] calculateCoordinates(View view) {
 			MainActivity mainActivity = getMainActivityFromView(view);
 			Workspace workspace = mainActivity.workspace;
-			PointF toolPosition = ((BaseToolWithShape) PaintroidApplication.currentTool).toolPosition;
+			PointF toolPosition = ((BaseToolWithShape) mainActivity.toolReference.get()).toolPosition;
 			PointF point = workspace.getSurfacePointFromCanvasPoint(toolPosition);
 			return calculateViewOffset(view, point.x, point.y);
 		}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
@@ -19,17 +19,25 @@
 
 package org.catrobat.paintroid.test.espresso.util;
 
+import android.app.Activity;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.PointF;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.espresso.ViewInteraction;
+import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import android.support.test.runner.lifecycle.Stage;
 import android.util.DisplayMetrics;
 import android.view.View;
 
+import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.common.Constants;
 import org.hamcrest.Matcher;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -42,6 +50,18 @@ import static org.junit.Assert.assertNotEquals;
 public final class EspressoUtils {
 
 	public static final int DEFAULT_STROKE_WIDTH = 25;
+
+	public static MainActivity getMainActivity() {
+		final List<Activity> resumedActivities = new ArrayList<>();
+		InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
+			@Override
+			public void run() {
+				Collection<Activity> activitiesInStage = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED);
+				resumedActivities.addAll(activitiesInStage);
+			}
+		});
+		return (MainActivity) resumedActivities.get(0);
+	}
 
 	private EspressoUtils() {
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ShapeToolOptionsViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ShapeToolOptionsViewInteraction.java
@@ -20,7 +20,7 @@
 package org.catrobat.paintroid.test.espresso.util.wrappers;
 
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.tools.implementation.GeometricFillTool;
+import org.catrobat.paintroid.tools.implementation.ShapeTool;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -35,7 +35,7 @@ public final class ShapeToolOptionsViewInteraction extends CustomViewInteraction
 		return new ShapeToolOptionsViewInteraction();
 	}
 
-	public ShapeToolOptionsViewInteraction performSelectShape(GeometricFillTool.BaseShape shape) {
+	public ShapeToolOptionsViewInteraction performSelectShape(ShapeTool.BaseShape shape) {
 		switch (shape) {
 			case RECTANGLE:
 				onView(withId(R.id.pocketpaint_shapes_square_btn))

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.java
@@ -21,7 +21,6 @@ package org.catrobat.paintroid.test.espresso.util.wrappers;
 
 import android.support.test.espresso.ViewInteraction;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.ToolType;
 
@@ -32,6 +31,7 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getMainActivity;
 import static org.hamcrest.Matchers.not;
 
 public final class ToolBarViewInteraction extends CustomViewInteraction {
@@ -45,7 +45,7 @@ public final class ToolBarViewInteraction extends CustomViewInteraction {
 	}
 
 	public ViewInteraction onSelectedToolButton() {
-		return onView(withId(PaintroidApplication.currentTool.getToolType().getToolButtonID()));
+		return onView(withId(getCurrentToolType().getToolButtonID()));
 	}
 
 	public ViewInteraction onToolOptions() {
@@ -61,11 +61,15 @@ public final class ToolBarViewInteraction extends CustomViewInteraction {
 	public ToolBarViewInteraction performSelectTool(ToolType toolType) {
 		onView(withId(toolType.getToolButtonID()))
 				.perform(scrollTo());
-		if (PaintroidApplication.currentTool.getToolType() != toolType) {
+		if (getCurrentToolType() != toolType) {
 			onView(withId(toolType.getToolButtonID()))
 					.perform(click());
 		}
 		return this;
+	}
+
+	private ToolType getCurrentToolType() {
+		return getMainActivity().toolReference.get().getToolType();
 	}
 
 	public ToolBarViewInteraction performOpenToolOptions() {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolPropertiesInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolPropertiesInteraction.java
@@ -27,9 +27,10 @@ import android.support.annotation.ColorRes;
 import android.support.test.InstrumentationRegistry;
 import android.support.v4.content.ContextCompat;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.tools.Tool;
 
+import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getMainActivity;
 import static org.junit.Assert.assertEquals;
 
 public final class ToolPropertiesInteraction extends CustomViewInteraction {
@@ -41,7 +42,7 @@ public final class ToolPropertiesInteraction extends CustomViewInteraction {
 	}
 
 	public ToolPropertiesInteraction checkMatchesColor(@ColorInt int expectedColor) {
-		assertEquals(expectedColor, PaintroidApplication.currentTool.getDrawPaint().getColor());
+		assertEquals(expectedColor, getCurrentTool().getDrawPaint().getColor());
 		return this;
 	}
 
@@ -51,20 +52,24 @@ public final class ToolPropertiesInteraction extends CustomViewInteraction {
 	}
 
 	public ToolPropertiesInteraction checkCap(Cap expectedCap) {
-		Paint strokePaint = PaintroidApplication.currentTool.getDrawPaint();
+		Paint strokePaint = getCurrentTool().getDrawPaint();
 		assertEquals(expectedCap, strokePaint.getStrokeCap());
 		return this;
 	}
 
 	public ToolPropertiesInteraction checkStrokeWidth(float expectedStrokeWidth) {
-		Paint strokePaint = PaintroidApplication.currentTool.getDrawPaint();
+		Paint strokePaint = getCurrentTool().getDrawPaint();
 		assertEquals(expectedStrokeWidth, strokePaint.getStrokeWidth(), Float.MIN_VALUE);
 		return this;
 	}
 
 	public ToolPropertiesInteraction setColor(int color) {
-		PaintroidApplication.currentTool.changePaintColor(color);
+		getCurrentTool().changePaintColor(color);
 		return this;
+	}
+
+	public Tool getCurrentTool() {
+		return getMainActivity().toolReference.get();
 	}
 
 	public ToolPropertiesInteraction setColorResource(@ColorRes int colorResource) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BrushToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BrushToolTest.java
@@ -39,8 +39,8 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseTool;
+import org.catrobat.paintroid.tools.implementation.BrushTool;
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint;
-import org.catrobat.paintroid.tools.implementation.DrawTool;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @RunWith(AndroidJUnit4.class)
-public class DrawToolTests {
+public class BrushToolTest {
 	private static final float MOVE_TOLERANCE = BaseTool.MOVE_TOLERANCE;
 
 	@Rule
@@ -74,7 +74,7 @@ public class DrawToolTests {
 	@Mock
 	private CommandManager commandManager;
 
-	private DrawTool toolToTest;
+	private BrushTool toolToTest;
 	private Paint paint;
 	private ToolPaint toolPaint;
 
@@ -84,7 +84,7 @@ public class DrawToolTests {
 		MainActivity activity = activityTestRule.getActivity();
 		Workspace workspace = activity.workspace;
 		toolPaint = activity.toolPaint;
-		toolToTest = new DrawTool(activity, toolPaint, workspace, commandManager);
+		toolToTest = new BrushTool(activity, toolPaint, workspace, commandManager);
 		paint = new Paint();
 		paint.setColor(Color.BLACK);
 		paint.setStrokeCap(Paint.Cap.ROUND);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
-public class FillToolTests {
+public class FillToolTest {
 	private static final float NO_TOLERANCE = 0.0f;
 	private static final float HALF_TOLERANCE = FillTool.MAX_ABSOLUTE_TOLERANCE / 2.0f;
 	private static final float MAX_TOLERANCE = FillTool.MAX_ABSOLUTE_TOLERANCE;

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
@@ -26,12 +26,12 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.command.CommandManager;
+import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.implementation.GeometricFillTool;
+import org.catrobat.paintroid.tools.implementation.ShapeTool;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +43,7 @@ import org.mockito.junit.MockitoRule;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
-public class GeometricFillToolTests {
+public class ShapeToolTest {
 
 	@Rule
 	public ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class);
@@ -54,10 +54,10 @@ public class GeometricFillToolTests {
 	@Mock
 	private CommandManager commandManager;
 
-	private GeometricFillTool rectangleShapeTool;
-	private GeometricFillTool ovalShapeTool;
-	private GeometricFillTool heartShapeTool;
-	private GeometricFillTool starShapeTool;
+	private ShapeTool rectangleShapeTool;
+	private ShapeTool ovalShapeTool;
+	private ShapeTool heartShapeTool;
+	private ShapeTool starShapeTool;
 
 	@UiThreadTest
 	@Before
@@ -66,17 +66,17 @@ public class GeometricFillToolTests {
 		Workspace workspace = activity.workspace;
 		ToolPaint toolPaint = activity.toolPaint;
 
-		rectangleShapeTool = new GeometricFillTool(activity, toolPaint, workspace, commandManager);
-		rectangleShapeTool.baseShape = GeometricFillTool.BaseShape.RECTANGLE;
+		rectangleShapeTool = new ShapeTool(activity, toolPaint, workspace, commandManager);
+		rectangleShapeTool.baseShape = ShapeTool.BaseShape.RECTANGLE;
 
-		ovalShapeTool = new GeometricFillTool(activity, toolPaint, workspace, commandManager);
-		ovalShapeTool.baseShape = GeometricFillTool.BaseShape.OVAL;
+		ovalShapeTool = new ShapeTool(activity, toolPaint, workspace, commandManager);
+		ovalShapeTool.baseShape = ShapeTool.BaseShape.OVAL;
 
-		heartShapeTool = new GeometricFillTool(activity, toolPaint, workspace, commandManager);
-		heartShapeTool.baseShape = GeometricFillTool.BaseShape.HEART;
+		heartShapeTool = new ShapeTool(activity, toolPaint, workspace, commandManager);
+		heartShapeTool.baseShape = ShapeTool.BaseShape.HEART;
 
-		starShapeTool = new GeometricFillTool(activity, toolPaint, workspace, commandManager);
-		starShapeTool.baseShape = GeometricFillTool.BaseShape.STAR;
+		starShapeTool = new ShapeTool(activity, toolPaint, workspace, commandManager);
+		starShapeTool.baseShape = ShapeTool.BaseShape.STAR;
 	}
 
 	@UiThreadTest
@@ -91,14 +91,14 @@ public class GeometricFillToolTests {
 		toolTypeRect = starShapeTool.getToolType();
 		assertEquals(ToolType.SHAPE, toolTypeRect);
 
-		GeometricFillTool.BaseShape rectangleShape = rectangleShapeTool.getBaseShape();
-		assertEquals(GeometricFillTool.BaseShape.RECTANGLE, rectangleShape);
-		GeometricFillTool.BaseShape ovalShape = ovalShapeTool.getBaseShape();
-		assertEquals(GeometricFillTool.BaseShape.OVAL, ovalShape);
-		GeometricFillTool.BaseShape heartShape = heartShapeTool.getBaseShape();
-		assertEquals(GeometricFillTool.BaseShape.HEART, heartShape);
-		GeometricFillTool.BaseShape starShape = starShapeTool.getBaseShape();
-		assertEquals(GeometricFillTool.BaseShape.STAR, starShape);
+		ShapeTool.BaseShape rectangleShape = rectangleShapeTool.getBaseShape();
+		assertEquals(ShapeTool.BaseShape.RECTANGLE, rectangleShape);
+		ShapeTool.BaseShape ovalShape = ovalShapeTool.getBaseShape();
+		assertEquals(ShapeTool.BaseShape.OVAL, ovalShape);
+		ShapeTool.BaseShape heartShape = heartShapeTool.getBaseShape();
+		assertEquals(ShapeTool.BaseShape.HEART, heartShape);
+		ShapeTool.BaseShape starShape = starShapeTool.getBaseShape();
+		assertEquals(ShapeTool.BaseShape.STAR, starShape);
 	}
 
 	@UiThreadTest
@@ -107,7 +107,9 @@ public class GeometricFillToolTests {
 		Paint red = new Paint();
 		red.setColor(Color.RED);
 		rectangleShapeTool.setDrawPaint(red);
-		int color = PaintroidApplication.currentTool.getDrawPaint().getColor();
+		MainActivity activity = activityTestRule.getActivity();
+		Tool currentTool = activity.toolReference.get();
+		int color = currentTool.getDrawPaint().getColor();
 		assertEquals("Red colour expected", Color.RED, color);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplicationFragment.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/PaintroidApplicationFragment.java
@@ -19,25 +19,20 @@
 
 package org.catrobat.paintroid;
 
-import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.contract.LayerContracts;
-import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolPaint;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.ui.Perspective;
-
-import java.io.File;
 
 public class PaintroidApplicationFragment extends Fragment {
 	private CommandManager commandManager;
-	private Tool currentTool;
+	private ToolReference currentTool;
 	private Perspective perspective;
 	private LayerContracts.Model layerModel;
-	private File cacheDir;
-	private Bitmap checkeredBackgroundBitmap;
 	private ToolPaint toolPaint;
 
 	@Override
@@ -50,51 +45,32 @@ public class PaintroidApplicationFragment extends Fragment {
 		return commandManager;
 	}
 
-	public Tool getCurrentTool() {
+	public void setCommandManager(CommandManager commandManager) {
+		this.commandManager = commandManager;
+	}
+
+	public ToolReference getCurrentTool() {
 		return currentTool;
+	}
+
+	public void setCurrentTool(ToolReference currentTool) {
+		this.currentTool = currentTool;
 	}
 
 	public Perspective getPerspective() {
 		return perspective;
 	}
 
-	public LayerContracts.Model getLayerModel() {
-		return layerModel;
-	}
-
-	public File getCacheDir() {
-		return cacheDir;
-	}
-
-	public Bitmap getCheckeredBackgroundBitmap() {
-		return checkeredBackgroundBitmap;
-	}
-
-	public void setCommandManager(CommandManager commandManager) {
-		this.commandManager = commandManager;
-	}
-
-	public void setCurrentTool(Tool currentTool) {
-		this.currentTool = currentTool;
-		PaintroidApplication.currentTool = this.currentTool;
-	}
-
 	public void setPerspective(Perspective perspective) {
 		this.perspective = perspective;
 	}
 
+	public LayerContracts.Model getLayerModel() {
+		return layerModel;
+	}
+
 	public void setLayerModel(LayerContracts.Model layerModel) {
 		this.layerModel = layerModel;
-	}
-
-	public void setCacheDir(File cacheDir) {
-		this.cacheDir = cacheDir;
-		PaintroidApplication.cacheDir = this.cacheDir;
-	}
-
-	public void setCheckeredBackgroundBitmap(Bitmap checkeredBackgroundBitmap) {
-		this.checkeredBackgroundBitmap = checkeredBackgroundBitmap;
-		PaintroidApplication.checkeredBackgroundBitmap = this.checkeredBackgroundBitmap;
 	}
 
 	public ToolPaint getToolPaint() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/ShapeToolOptionsListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/ShapeToolOptionsListener.java
@@ -29,7 +29,7 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.tools.implementation.GeometricFillTool;
+import org.catrobat.paintroid.tools.implementation.ShapeTool;
 import org.catrobat.paintroid.ui.tools.NumberRangeFilter;
 
 import java.util.Locale;
@@ -72,45 +72,45 @@ public class ShapeToolOptionsListener {
 		outlineWidthEditText.setText(String.format(Locale.getDefault(), "%d", (int) startingOutlineWidth));
 		outlineWidthSeekBar.setProgress(startingOutlineWidth);
 		initializeListeners();
-		setShapeActivated(GeometricFillTool.BaseShape.RECTANGLE);
-		setDrawTypeActivated(GeometricFillTool.ShapeDrawType.FILL);
+		setShapeActivated(ShapeTool.BaseShape.RECTANGLE);
+		setDrawTypeActivated(ShapeTool.ShapeDrawType.FILL);
 	}
 
 	private void initializeListeners() {
 		squareButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				onShapeClicked(GeometricFillTool.BaseShape.RECTANGLE);
+				onShapeClicked(ShapeTool.BaseShape.RECTANGLE);
 			}
 		});
 		circleButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				onShapeClicked(GeometricFillTool.BaseShape.OVAL);
+				onShapeClicked(ShapeTool.BaseShape.OVAL);
 			}
 		});
 		heartButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				onShapeClicked(GeometricFillTool.BaseShape.HEART);
+				onShapeClicked(ShapeTool.BaseShape.HEART);
 			}
 		});
 		starButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				onShapeClicked(GeometricFillTool.BaseShape.STAR);
+				onShapeClicked(ShapeTool.BaseShape.STAR);
 			}
 		});
 		fillButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				onDrawTypeClicked(GeometricFillTool.ShapeDrawType.FILL);
+				onDrawTypeClicked(ShapeTool.ShapeDrawType.FILL);
 			}
 		});
 		outlineButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				onDrawTypeClicked(GeometricFillTool.ShapeDrawType.OUTLINE);
+				onDrawTypeClicked(ShapeTool.ShapeDrawType.OUTLINE);
 			}
 		});
 		outlineWidthSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -155,12 +155,12 @@ public class ShapeToolOptionsListener {
 		});
 	}
 
-	private void onShapeClicked(GeometricFillTool.BaseShape shape) {
+	private void onShapeClicked(ShapeTool.BaseShape shape) {
 		onShapeToolOptionsChangedListener.setToolType(shape);
 		setShapeActivated(shape);
 	}
 
-	private void onDrawTypeClicked(GeometricFillTool.ShapeDrawType drawType) {
+	private void onDrawTypeClicked(ShapeTool.ShapeDrawType drawType) {
 		onShapeToolOptionsChangedListener.setDrawType(drawType);
 		setDrawTypeActivated(drawType);
 	}
@@ -181,7 +181,7 @@ public class ShapeToolOptionsListener {
 		outlineButton.setSelected(false);
 	}
 
-	public void setShapeActivated(GeometricFillTool.BaseShape shape) {
+	public void setShapeActivated(ShapeTool.BaseShape shape) {
 		resetShapeActivated();
 		switch (shape) {
 			case RECTANGLE:
@@ -206,7 +206,7 @@ public class ShapeToolOptionsListener {
 		}
 	}
 
-	public void setDrawTypeActivated(GeometricFillTool.ShapeDrawType drawType) {
+	public void setDrawTypeActivated(ShapeTool.ShapeDrawType drawType) {
 		resetDrawTypeActivated();
 		switch (drawType) {
 			case FILL:
@@ -249,8 +249,8 @@ public class ShapeToolOptionsListener {
 	}
 
 	public interface OnShapeToolOptionsChangedListener {
-		void setToolType(GeometricFillTool.BaseShape shape);
-		void setDrawType(GeometricFillTool.ShapeDrawType drawType);
+		void setToolType(ShapeTool.BaseShape shape);
+		void setDrawType(ShapeTool.ShapeDrawType drawType);
 		void setOutlineWidth(int outlineWidth);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolReference.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolReference.java
@@ -17,17 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid;
+package org.catrobat.paintroid.tools;
 
-import android.graphics.Bitmap;
+public interface ToolReference {
+	Tool get();
 
-import java.io.File;
-
-public final class PaintroidApplication {
-	public static File cacheDir;
-	public static Bitmap checkeredBackgroundBitmap;
-
-	private PaintroidApplication() {
-		throw new IllegalArgumentException();
-	}
+	void set(Tool tool);
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.java
@@ -36,7 +36,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.ui.tools.DrawerPreview;
 
-public class DrawTool extends BaseTool {
+public class BrushTool extends BaseTool {
 
 	@VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
 	public Path pathToDraw;
@@ -46,7 +46,7 @@ public class DrawTool extends BaseTool {
 	@VisibleForTesting
 	public BrushPickerView brushPickerView;
 
-	public DrawTool(Context context, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
+	public BrushTool(Context context, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
 		super(context, toolPaint, workspace, commandManager);
 		pathToDraw = new Path();
 		pathToDraw.incReserve(1);
@@ -207,7 +207,7 @@ public class DrawTool extends BaseTool {
 
 			@Override
 			public ToolType getToolType() {
-				return DrawTool.this.getToolType();
+				return BrushTool.this.getToolType();
 			}
 		});
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
@@ -39,7 +39,7 @@ public class DefaultToolFactory implements ToolFactory {
 
 		switch (toolType) {
 			case BRUSH:
-				tool = new DrawTool(activity, toolPaint, workspace, commandManager);
+				tool = new BrushTool(activity, toolPaint, workspace, commandManager);
 				break;
 			case CURSOR:
 				tool = new CursorTool(activity, toolPaint, workspace, commandManager);
@@ -68,7 +68,7 @@ public class DefaultToolFactory implements ToolFactory {
 				tool = new TransformTool(activity, toolPaint, workspace, commandManager);
 				break;
 			case SHAPE:
-				tool = new GeometricFillTool(activity, toolPaint, workspace, commandManager);
+				tool = new ShapeTool(activity, toolPaint, workspace, commandManager);
 				break;
 			case ERASER:
 				tool = new EraserTool(activity, toolPaint, workspace, commandManager);
@@ -80,7 +80,7 @@ public class DefaultToolFactory implements ToolFactory {
 				tool = new TextTool(activity, toolPaint, workspace, commandManager);
 				break;
 			default:
-				tool = new DrawTool(activity, toolPaint, workspace, commandManager);
+				tool = new BrushTool(activity, toolPaint, workspace, commandManager);
 				break;
 		}
 		tool.setupToolOptions();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolReference.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolReference.java
@@ -17,17 +17,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid;
+package org.catrobat.paintroid.tools.implementation;
 
-import android.graphics.Bitmap;
+import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.tools.ToolReference;
 
-import java.io.File;
+public class DefaultToolReference implements ToolReference {
+	private Tool tool;
 
-public final class PaintroidApplication {
-	public static File cacheDir;
-	public static Bitmap checkeredBackgroundBitmap;
+	@Override
+	public Tool get() {
+		return tool;
+	}
 
-	private PaintroidApplication() {
-		throw new IllegalArgumentException();
+	@Override
+	public void set(Tool tool) {
+		this.tool = tool;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
@@ -29,7 +29,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 
-public class EraserTool extends DrawTool {
+public class EraserTool extends BrushTool {
 
 	@ColorInt
 	private int previousColor = Color.BLACK;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
@@ -43,7 +43,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.helper.Conversion;
 
-public class GeometricFillTool extends BaseToolWithRectangleShape {
+public class ShapeTool extends BaseToolWithRectangleShape {
 
 	private static final boolean ROTATION_ENABLED = true;
 	private static final float SHAPE_OFFSET = 10f;
@@ -61,7 +61,7 @@ public class GeometricFillTool extends BaseToolWithRectangleShape {
 	private float previousBoxWidth;
 	private float previousBoxHeight;
 
-	public GeometricFillTool(Context context, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
+	public ShapeTool(Context context, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
 		super(context, toolPaint, workspace, commandManager);
 
 		setRotationEnabled(ROTATION_ENABLED);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -41,13 +41,13 @@ import android.util.AttributeSet;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.contract.LayerContracts;
 import org.catrobat.paintroid.listener.DrawingSurfaceListener;
 import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTask;
 import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTaskCallback;
 import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 
 import java.util.ListIterator;
@@ -65,6 +65,7 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 	private LayerContracts.Model layerModel;
 	private Perspective perspective;
 	private DrawingSurfaceListener drawingSurfaceListener;
+	private ToolReference toolReference;
 
 	public DrawingSurface(Context context, AttributeSet attrSet) {
 		super(context, attrSet);
@@ -95,7 +96,7 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 		DrawingSurfaceListener.DrawingSurfaceListenerCallback callback = new DrawingSurfaceListener.DrawingSurfaceListenerCallback() {
 			@Override
 			public Tool getCurrentTool() {
-				return PaintroidApplication.currentTool;
+				return toolReference.get();
 			}
 
 			@Override
@@ -117,16 +118,10 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 		setOnTouchListener(drawingSurfaceListener);
 	}
 
-	public void setLayerModel(LayerContracts.Model layerModel) {
+	public void setArguments(LayerContracts.Model layerModel, Perspective perspective, ToolReference toolReference) {
 		this.layerModel = layerModel;
-	}
-
-	public void setPerspective(Perspective perspective) {
 		this.perspective = perspective;
-	}
-
-	public Canvas getCanvas() {
-		throw new IllegalArgumentException();
+		this.toolReference = toolReference;
 	}
 
 	private synchronized void doDraw(Canvas surfaceViewCanvas) {
@@ -156,7 +151,7 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 					surfaceViewCanvas.drawBitmap(iterator.previous().getBitmap(), 0, 0, null);
 				}
 
-				PaintroidApplication.currentTool.draw(surfaceViewCanvas);
+				toolReference.get().draw(surfaceViewCanvas);
 			}
 		}
 	}
@@ -238,11 +233,11 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 		}
 
 		public void handleToolMove(PointF coordinate) {
-			PaintroidApplication.currentTool.handleMove(coordinate);
+			toolReference.get().handleMove(coordinate);
 		}
 
 		public Point getToolAutoScrollDirection(float pointX, float pointY, int screenWidth, int screenHeight) {
-			return PaintroidApplication.currentTool.getAutoScrollDirection(pointX, pointY, screenWidth, screenHeight);
+			return toolReference.get().getAutoScrollDirection(pointX, pointY, screenWidth, screenHeight);
 		}
 
 		public float getPerspectiveScale() {
@@ -258,7 +253,7 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 		}
 
 		public ToolType getCurrentToolType() {
-			return PaintroidApplication.currentTool.getToolType();
+			return toolReference.get().getToolType();
 		}
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -32,7 +32,6 @@ import android.view.Gravity;
 import android.widget.Toast;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.WelcomeActivity;
 import org.catrobat.paintroid.common.Constants;
@@ -46,15 +45,18 @@ import org.catrobat.paintroid.dialog.SaveBeforeFinishDialog.SaveBeforeFinishDial
 import org.catrobat.paintroid.dialog.SaveBeforeLoadImageDialog;
 import org.catrobat.paintroid.dialog.SaveBeforeNewImageDialog;
 import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog;
+import org.catrobat.paintroid.tools.ToolReference;
 
 import static android.app.Activity.RESULT_OK;
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 
 public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	private MainActivity mainActivity;
+	private final ToolReference toolReference;
 
-	public MainActivityNavigator(MainActivity mainActivity) {
+	public MainActivityNavigator(MainActivity mainActivity, ToolReference toolReference) {
 		this.mainActivity = mainActivity;
+		this.toolReference = toolReference;
 	}
 
 	@Override
@@ -62,7 +64,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 		FragmentManager fragmentManager = mainActivity.getSupportFragmentManager();
 		Fragment fragment = fragmentManager.findFragmentByTag(Constants.COLOR_PICKER_DIALOG_TAG);
 		if (fragment == null) {
-			ColorPickerDialog dialog = ColorPickerDialog.newInstance(PaintroidApplication.currentTool.getDrawPaint().getColor());
+			ColorPickerDialog dialog = ColorPickerDialog.newInstance(toolReference.get().getDrawPaint().getColor());
 			setupColorPickerDialogListeners(dialog);
 			dialog.show(fragmentManager, Constants.COLOR_PICKER_DIALOG_TAG);
 		}
@@ -72,7 +74,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 		dialog.addOnColorPickedListener(new ColorPickerDialog.OnColorPickedListener() {
 			@Override
 			public void colorChanged(int color) {
-				PaintroidApplication.currentTool.changePaintColor(color);
+				toolReference.get().changePaintColor(color);
 				mainActivity.getPresenter().setTopBarColor(color);
 			}
 		});

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DrawerPreview.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DrawerPreview.java
@@ -31,7 +31,6 @@ import android.graphics.Shader;
 import android.util.AttributeSet;
 import android.view.View;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.ToolType;
 
@@ -132,7 +131,7 @@ public class DrawerPreview extends View {
 		borderPaint.setColor(Color.BLACK);
 		borderPaint.setAntiAlias(true);
 
-		if (PaintroidApplication.currentTool.getToolType() == ToolType.LINE) {
+		if (callback.getToolType() == ToolType.LINE) {
 			startX = getLeft() + getWidth() / 8 - BORDER;
 			startY = getTop() + getHeight() / 2;
 			endX = getRight() - getWidth() / 8 + BORDER;

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -32,7 +32,6 @@ import android.support.v4.view.GravityCompat;
 import android.util.DisplayMetrics;
 import android.widget.Toast;
 
-import org.catrobat.paintroid.PaintroidApplication;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.CommandManager;
@@ -41,6 +40,7 @@ import org.catrobat.paintroid.dialog.PermissionInfoDialog;
 import org.catrobat.paintroid.iotasks.SaveImageAsync;
 import org.catrobat.paintroid.presenter.MainActivityPresenter;
 import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.ui.Perspective;
@@ -85,7 +85,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class MainActivityPresenterTest {
 	@Mock
 	private MainActivityContracts.MainView view;
@@ -115,6 +115,12 @@ public class MainActivityPresenterTest {
 	private Perspective perspective;
 
 	@Mock
+	private ToolReference toolReference;
+
+	@Mock
+	private Tool tool;
+
+	@Mock
 	private CommandManager commandManager;
 
 	@Mock
@@ -135,7 +141,8 @@ public class MainActivityPresenterTest {
 	@Test
 	public void testSetUp() {
 		verifyZeroInteractions(view, model, navigator, interactor, topBarViewHolder, workspace, perspective,
-				drawerLayoutViewHolder, navigationDrawerViewHolder, commandManager, bottomBarViewHolder);
+				drawerLayoutViewHolder, navigationDrawerViewHolder, commandManager, bottomBarViewHolder,
+				toolReference, tool);
 	}
 
 	@Test
@@ -269,7 +276,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testEnterFullscreenClicked() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.enterFullscreenClicked();
 
@@ -278,13 +285,13 @@ public class MainActivityPresenterTest {
 		verify(view).enterFullscreen();
 		verify(navigationDrawerViewHolder).hideEnterFullscreen();
 		verify(navigationDrawerViewHolder).showExitFullscreen();
-		verify(PaintroidApplication.currentTool).hide();
+		verify(tool).hide();
 		verify(perspective).enterFullscreen();
 	}
 
 	@Test
 	public void testExitFullscreenClicked() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.exitFullscreenClicked();
 
@@ -326,6 +333,7 @@ public class MainActivityPresenterTest {
 	public void testOnNewImageWhenCommandReturnsThenResetPerspective() {
 		DisplayMetrics metrics = mock(DisplayMetrics.class);
 		when(view.getDisplayMetrics()).thenReturn(metrics);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.onNewImage();
 		presenter.onCommandPostExecute();
@@ -412,8 +420,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnBackPressedWhenUntouchedThenFinishActivity() {
-		PaintroidApplication.currentTool = mock(Tool.class);
-		when(PaintroidApplication.currentTool.getToolType()).thenReturn(ToolType.BRUSH);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.BRUSH);
 
 		presenter.onBackPressed();
 
@@ -422,7 +430,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnBackPressedWhenStartDrawerOpenThenCloseDrawer() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 		when(drawerLayoutViewHolder.isDrawerOpen(GravityCompat.START)).thenReturn(true);
 
 		presenter.onBackPressed();
@@ -432,7 +440,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnBackPressedWhenEndDrawerOpenThenCloseDrawer() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 		when(drawerLayoutViewHolder.isDrawerOpen(GravityCompat.END)).thenReturn(true);
 
 		presenter.onBackPressed();
@@ -442,7 +450,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnBackPressedWhenIsFullscreenThenExitFullscreen() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 		when(model.isFullscreen()).thenReturn(true);
 
 		presenter.onBackPressed();
@@ -452,13 +460,12 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnBackPressedWhenToolOptionsShownThenHideToolOptions() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolOptionsAreShown()).thenReturn(true);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolOptionsAreShown()).thenReturn(true);
 
 		presenter.onBackPressed();
 
-		verify(currentTool).toggleShowToolOptions();
+		verify(tool).toggleShowToolOptions();
 	}
 
 	@Test
@@ -481,7 +488,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testUndoClickedThenExecuteUndo() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.undoClicked();
 
@@ -490,7 +497,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testRedoClickedThenExecuteRedo() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.redoClicked();
 
@@ -499,9 +506,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testShowColorPickerClickedWhenColorChangeAllowedThenShowColorPickerDialog() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.BRUSH);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.BRUSH);
 
 		presenter.showColorPickerClicked();
 
@@ -510,9 +516,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testShowColorPickerClickedWhenNoColorChangeAllowedThenIgnore() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.PIPETTE);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.PIPETTE);
 
 		presenter.showColorPickerClicked();
 
@@ -535,7 +540,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnCommandPostExecuteThenSetModelUnsaved() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.onCommandPostExecute();
 
@@ -544,16 +549,16 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnCommandPostExecuteThenResetInternalToolState() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.onCommandPostExecute();
 
-		verify(PaintroidApplication.currentTool).resetInternalState(RESET_INTERNAL_STATE);
+		verify(tool).resetInternalState(RESET_INTERNAL_STATE);
 	}
 
 	@Test
 	public void testOnCommandPostExecuteThenRefreshDrawingSurface() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.onCommandPostExecute();
 
@@ -562,7 +567,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnCommandPostExecuteThenSetUndoRedoButtons() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.onCommandPostExecute();
 
@@ -572,7 +577,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnCommandPostExecuteThenDismissDialog() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.onCommandPostExecute();
 
@@ -588,7 +593,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testInitializeFromCleanStateWhenDefaultThenUnsetSavedPictureUri() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.initializeFromCleanState(null, null);
 
@@ -598,12 +603,11 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testInitializeFromCleanStateWhenDefaultThenResetTool() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.initializeFromCleanState(null, null);
 
-		verify(currentTool).resetInternalState(NEW_IMAGE_LOADED);
+		verify(tool).resetInternalState(NEW_IMAGE_LOADED);
 	}
 
 	@Test
@@ -629,7 +633,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testRestoreStateThenRestoreFragmentListeners() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.restoreState(false, false, false, false, null, null);
 
@@ -640,7 +644,7 @@ public class MainActivityPresenterTest {
 	public void testRestoreStateThenSetModel() {
 		Uri savedPictureUri = mock(Uri.class);
 		Uri cameraImageUri = mock(Uri.class);
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.restoreState(false, false, false, false, savedPictureUri, cameraImageUri);
 
@@ -656,7 +660,7 @@ public class MainActivityPresenterTest {
 	public void testRestoreStateWhenStatesSetThenSetModel() {
 		Uri savedPictureUri = mock(Uri.class);
 		Uri cameraImageUri = mock(Uri.class);
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.restoreState(true, true, true, true, savedPictureUri, cameraImageUri);
 
@@ -670,18 +674,17 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testRestoreStateThenResetTool() {
-		PaintroidApplication.currentTool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
 
 		presenter.restoreState(false, false, false, false, null, null);
 
-		verify(PaintroidApplication.currentTool).resetInternalState(NEW_IMAGE_LOADED);
+		verify(tool).resetInternalState(NEW_IMAGE_LOADED);
 	}
 
 	@Test
 	public void testFinishInitializeThensetUndoRedoButtons() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 
 		presenter.finishInitialize();
 
@@ -691,9 +694,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenUndoAvailableThensetUndoRedoButtons() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 		when(commandManager.isUndoAvailable()).thenReturn(true);
 
 		presenter.finishInitialize();
@@ -704,9 +706,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenRedoAvailableThensetUndoRedoButtons() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 		when(commandManager.isRedoAvailable()).thenReturn(true);
 
 		presenter.finishInitialize();
@@ -717,9 +718,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenNotFullscreenThenRestoreState() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 
 		presenter.finishInitialize();
 
@@ -728,9 +728,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenFullscreenThenRestoreState() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 		when(model.isFullscreen()).thenReturn(true);
 
 		presenter.finishInitialize();
@@ -740,10 +739,9 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeThenRestoreColorButtonColor() {
-		Tool currentTool = mock(Tool.class);
 		Paint paint = mock(Paint.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(paint);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(paint);
 		when(model.isFullscreen()).thenReturn(true);
 		when(paint.getColor()).thenReturn(Color.RED);
 
@@ -754,10 +752,9 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeThenRestoreSelectedTool() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
-		when(currentTool.getToolType()).thenReturn(ToolType.TEXT);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(tool.getToolType()).thenReturn(ToolType.TEXT);
 
 		presenter.finishInitialize();
 
@@ -766,9 +763,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenDefaultThenInitializeActionBarDefault() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 
 		presenter.finishInitialize();
 
@@ -777,9 +773,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenFromCatroidThenInitializeActionBarCatroid() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 		when(model.isOpenedFromCatroid()).thenReturn(true);
 
 		presenter.finishInitialize();
@@ -789,9 +784,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenDefaultThenRemoveCatroidNavigationItems() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 
 		presenter.finishInitialize();
 
@@ -801,9 +795,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testFinishInitializeWhenFromCatroidThenRemoveSaveNavigationItems() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getDrawPaint()).thenReturn(mock(Paint.class));
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(mock(Paint.class));
 		when(model.isOpenedFromCatroid()).thenReturn(true);
 
 		presenter.finishInitialize();
@@ -814,9 +807,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testToolClickedThenCancelAnimation() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.BRUSH);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.BRUSH);
 
 		presenter.toolClicked(ToolType.BRUSH);
 
@@ -825,20 +817,18 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testToolClickedWhenSameToolTypeThenToggleOptions() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.BRUSH);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.BRUSH);
 
 		presenter.toolClicked(ToolType.BRUSH);
 
-		verify(currentTool).toggleShowToolOptions();
+		verify(tool).toggleShowToolOptions();
 	}
 
 	@Test
 	public void testToolClickedWhenKeyboardShownThenHideKeyboard() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.BRUSH);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.BRUSH);
 		when(view.isKeyboardShown()).thenReturn(true);
 
 		presenter.toolClicked(ToolType.ERASER);
@@ -848,9 +838,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testGotFocusThenPlayInitialAnimation() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.PIPETTE);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.PIPETTE);
 
 		presenter.gotFocus();
 
@@ -860,9 +849,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testGotFocusWhenAlreadyPlayedThenScrollToTool() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.ERASER);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.ERASER);
 		when(model.wasInitialAnimationPlayed()).thenReturn(true);
 
 		presenter.gotFocus();
@@ -873,9 +861,8 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testGotFocusWhenGotFocusBeforeThenDoNothing() {
-		Tool currentTool = mock(Tool.class);
-		PaintroidApplication.currentTool = currentTool;
-		when(currentTool.getToolType()).thenReturn(ToolType.LINE);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.LINE);
 
 		presenter.gotFocus();
 		presenter.gotFocus();


### PR DESCRIPTION
* Add a `ToolReference` class, replacing the `public static Tool currentTool`
* Rename `DrawTool` to `BrushTool`
* Rename `GeometricFillTool` to `ShapeTool`
* Rename `.*Tests` classes to `.*Test`
* Fix all failing tests and utility test classes