### PR TITLE
PAINTROID-70: Prevent crash in intro

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.java
@@ -40,6 +40,7 @@ import org.catrobat.paintroid.intro.TapTargetBottomBar;
 import org.catrobat.paintroid.intro.TapTargetStyle;
 import org.catrobat.paintroid.intro.TapTargetTopBar;
 
+import static org.catrobat.paintroid.common.MainActivityConstants.RESULT_INTRO_MW_NOT_SUPPORTED;
 import static org.catrobat.paintroid.intro.helper.WelcomeActivityHelper.getSpFromDimension;
 import static org.catrobat.paintroid.intro.helper.WelcomeActivityHelper.isRTL;
 import static org.catrobat.paintroid.intro.helper.WelcomeActivityHelper.reverseArray;
@@ -106,6 +107,12 @@ public class WelcomeActivity extends AppCompatActivity {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 			getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
 					| View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+		}
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isInMultiWindowMode()) {
+			setResult(RESULT_INTRO_MW_NOT_SUPPORTED);
+			finish();
+			return;
 		}
 
 		setContentView(R.layout.activity_pocketpaint_welcome);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/MainActivityConstants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/MainActivityConstants.java
@@ -38,14 +38,15 @@ public final class MainActivityConstants {
 
 	public static final int REQUEST_CODE_IMPORTPNG = 1;
 	public static final int REQUEST_CODE_LOAD_PICTURE = 2;
-	public static final int REQUEST_CODE_FINISH = 3;
-	public static final int REQUEST_CODE_LANGUAGE = 4;
+	public static final int REQUEST_CODE_INTRO = 3;
 
 	public static final int PERMISSION_EXTERNAL_STORAGE_SAVE = 1;
 	public static final int PERMISSION_EXTERNAL_STORAGE_SAVE_COPY = 2;
 	public static final int PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW = 3;
 	public static final int PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY = 4;
 	public static final int PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH = 5;
+
+	public static final int RESULT_INTRO_MW_NOT_SUPPORTED = 10;
 
 	@IntDef({SAVE_IMAGE_DEFAULT, SAVE_IMAGE_NEW_EMPTY, SAVE_IMAGE_LOAD_NEW, SAVE_IMAGE_FINISH})
 	@Retention(RetentionPolicy.SOURCE)
@@ -62,7 +63,7 @@ public final class MainActivityConstants {
 	public @interface CreateFileRequestCode {
 	}
 
-	@IntDef({REQUEST_CODE_IMPORTPNG, REQUEST_CODE_LOAD_PICTURE, REQUEST_CODE_FINISH, REQUEST_CODE_LANGUAGE})
+	@IntDef({REQUEST_CODE_IMPORTPNG, REQUEST_CODE_LOAD_PICTURE, REQUEST_CODE_INTRO})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface ActivityRequestCode {
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -30,6 +30,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.util.DisplayMetrics;
 
+import org.catrobat.paintroid.common.MainActivityConstants.ActivityRequestCode;
 import org.catrobat.paintroid.dialog.PermissionInfoDialog;
 import org.catrobat.paintroid.iotasks.CreateFileAsync;
 import org.catrobat.paintroid.iotasks.LoadImageAsync;
@@ -42,13 +43,13 @@ public interface MainActivityContracts {
 	interface Navigator {
 		void showColorPickerDialog();
 
-		void startLoadImageActivity(int requestCode);
+		void startLoadImageActivity(@ActivityRequestCode int requestCode);
 
-		void startImportImageActivity(int requestCode);
+		void startImportImageActivity(@ActivityRequestCode int requestCode);
 
 		void showAboutDialog();
 
-		void startWelcomeActivity();
+		void startWelcomeActivity(@ActivityRequestCode int requestCode);
 
 		void showIndeterminateProgressDialog();
 
@@ -71,8 +72,6 @@ public interface MainActivityContracts {
 		boolean doIHavePermission(String permission);
 
 		void finishActivity();
-
-		void recreateActivity();
 
 		void showSaveBeforeReturnToCatroidDialog();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -82,10 +82,10 @@ import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXT
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW;
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY;
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_COPY;
-import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_FINISH;
 import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_IMPORTPNG;
-import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_LANGUAGE;
+import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_INTRO;
 import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_LOAD_PICTURE;
+import static org.catrobat.paintroid.common.MainActivityConstants.RESULT_INTRO_MW_NOT_SUPPORTED;
 import static org.catrobat.paintroid.common.MainActivityConstants.SAVE_IMAGE_DEFAULT;
 import static org.catrobat.paintroid.common.MainActivityConstants.SAVE_IMAGE_FINISH;
 import static org.catrobat.paintroid.common.MainActivityConstants.SAVE_IMAGE_LOAD_NEW;
@@ -223,7 +223,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void showHelpClicked() {
-		navigator.startWelcomeActivity();
+		navigator.startWelcomeActivity(REQUEST_CODE_INTRO);
 	}
 
 	@Override
@@ -258,29 +258,29 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void handleActivityResult(@ActivityRequestCode int requestCode, int resultCode, Intent data) {
-		if (resultCode != Activity.RESULT_OK) {
-			Log.d(MainActivity.TAG, "handleActivityResult: result not ok, most likely a dialog has been canceled");
-			return;
-		}
-
 		DisplayMetrics metrics = view.getDisplayMetrics();
 		int maxWidth = metrics.widthPixels;
 		int maxHeight = metrics.heightPixels;
 		switch (requestCode) {
 			case REQUEST_CODE_IMPORTPNG:
+				if (resultCode != Activity.RESULT_OK) {
+					return;
+				}
 				Uri selectedGalleryImageUri = data.getData();
 				Tool tool = toolFactory.createTool(ToolType.IMPORTPNG, (Activity) view, commandManager, workspace, toolPaint);
 				switchTool(tool);
 				interactor.loadFile(this, LOAD_IMAGE_IMPORTPNG, maxWidth, maxHeight, selectedGalleryImageUri);
 				break;
-			case REQUEST_CODE_FINISH:
-				navigator.finishActivity();
-				break;
-			case REQUEST_CODE_LANGUAGE:
-				navigator.recreateActivity();
-				break;
 			case REQUEST_CODE_LOAD_PICTURE:
+				if (resultCode != Activity.RESULT_OK) {
+					return;
+				}
 				interactor.loadFile(this, LOAD_IMAGE_DEFAULT, maxWidth, maxHeight, data.getData());
+				break;
+			case REQUEST_CODE_INTRO:
+				if (resultCode == RESULT_INTRO_MW_NOT_SUPPORTED) {
+					navigator.showToast(R.string.pocketpaint_intro_split_screen_not_supported, Toast.LENGTH_LONG);
+				}
 				break;
 			default:
 				view.superHandleActivityResult(requestCode, resultCode, data);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -35,6 +35,7 @@ import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.WelcomeActivity;
 import org.catrobat.paintroid.common.Constants;
+import org.catrobat.paintroid.common.MainActivityConstants.ActivityRequestCode;
 import org.catrobat.paintroid.contract.MainActivityContracts;
 import org.catrobat.paintroid.dialog.AboutDialog;
 import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
@@ -81,7 +82,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	}
 
 	@Override
-	public void startLoadImageActivity(int requestCode) {
+	public void startLoadImageActivity(@ActivityRequestCode int requestCode) {
 		Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 		intent.setType("image/*");
 		intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
@@ -89,7 +90,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	}
 
 	@Override
-	public void startImportImageActivity(int requestCode) {
+	public void startImportImageActivity(@ActivityRequestCode int requestCode) {
 		Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
 		intent.setType("image/*");
 		intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
@@ -97,10 +98,10 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	}
 
 	@Override
-	public void startWelcomeActivity() {
+	public void startWelcomeActivity(@ActivityRequestCode int requestCode) {
 		Intent intent = new Intent(mainActivity.getApplicationContext(), WelcomeActivity.class);
 		intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-		mainActivity.startActivity(intent);
+		mainActivity.startActivityForResult(intent, requestCode);
 	}
 
 	@Override
@@ -184,11 +185,6 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	@Override
 	public void finishActivity() {
 		mainActivity.finish();
-	}
-
-	@Override
-	public void recreateActivity() {
-		mainActivity.recreate();
 	}
 
 	@Override

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -150,4 +150,6 @@
     <string name="pocketpaint_about_url_catrobat_description">About Catrobat</string>
     <string name="pocketpaint_about_url_license" translatable="false">&lt;a href=\"http://developer.catrobat.org/licenses\"&gt;%s&lt;/a&gt;</string>
     <string name="pocketpaint_about_url_catrobat" translatable="false">&lt;a href=\"http://catrobat.org/\"&gt;%s&lt;/a&gt;</string>
+
+    <string name="pocketpaint_intro_split_screen_not_supported">Intro does not support split screen</string>
 </resources>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -61,9 +61,9 @@ import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXT
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW;
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY;
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_COPY;
-import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_FINISH;
-import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_LANGUAGE;
+import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_INTRO;
 import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_LOAD_PICTURE;
+import static org.catrobat.paintroid.common.MainActivityConstants.RESULT_INTRO_MW_NOT_SUPPORTED;
 import static org.catrobat.paintroid.common.MainActivityConstants.SAVE_IMAGE_DEFAULT;
 import static org.catrobat.paintroid.common.MainActivityConstants.SAVE_IMAGE_FINISH;
 import static org.catrobat.paintroid.common.MainActivityConstants.SAVE_IMAGE_LOAD_NEW;
@@ -307,7 +307,7 @@ public class MainActivityPresenterTest {
 	public void testShowHelpClickedThenStartWelcomeActivity() {
 		presenter.showHelpClicked();
 
-		verify(navigator).startWelcomeActivity();
+		verify(navigator).startWelcomeActivity(REQUEST_CODE_INTRO);
 		verifyNoMoreInteractions(navigator);
 	}
 
@@ -373,25 +373,14 @@ public class MainActivityPresenterTest {
 	}
 
 	@Test
-	public void testHandleActivityResultWhenFinishThenFinishActivity() {
+	public void testHandleActivityResultWhenUnhandledAndResultNotOKThenForwardResult() {
 		DisplayMetrics metrics = mock(DisplayMetrics.class);
 		when(view.getDisplayMetrics()).thenReturn(metrics);
 		Intent intent = mock(Intent.class);
 
-		presenter.handleActivityResult(REQUEST_CODE_FINISH, Activity.RESULT_OK, intent);
+		presenter.handleActivityResult(0, Activity.RESULT_CANCELED, intent);
 
-		verify(navigator).finishActivity();
-	}
-
-	@Test
-	public void testHandleActivityResultWhenLanguageThenRecreateActivity() {
-		DisplayMetrics metrics = mock(DisplayMetrics.class);
-		when(view.getDisplayMetrics()).thenReturn(metrics);
-		Intent intent = mock(Intent.class);
-
-		presenter.handleActivityResult(REQUEST_CODE_LANGUAGE, Activity.RESULT_OK, intent);
-
-		verify(navigator).recreateActivity();
+		verify(view).superHandleActivityResult(0, Activity.RESULT_CANCELED, intent);
 	}
 
 	@Test
@@ -411,11 +400,36 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testHandleActivityResultWhenResultNotOkThenDoNothing() {
+		DisplayMetrics metrics = mock(DisplayMetrics.class);
+		when(view.getDisplayMetrics()).thenReturn(metrics);
 		Intent intent = mock(Intent.class);
 
 		presenter.handleActivityResult(0, Activity.RESULT_CANCELED, intent);
 
-		verifyZeroInteractions(view, interactor, navigator);
+		verifyZeroInteractions(interactor, navigator);
+	}
+
+	@Test
+	public void testHandleActivityResultWhenRequestIntroAndResultOKThenDoNothing() {
+		DisplayMetrics metrics = mock(DisplayMetrics.class);
+		when(view.getDisplayMetrics()).thenReturn(metrics);
+		Intent intent = mock(Intent.class);
+
+		presenter.handleActivityResult(REQUEST_CODE_INTRO, Activity.RESULT_OK, intent);
+
+		verifyZeroInteractions(interactor, navigator);
+	}
+
+	@Test
+	public void testHandleActivityResultWhenRequestIntroAndResultSplitScreenNotSupportedThenShowToast() {
+		DisplayMetrics metrics = mock(DisplayMetrics.class);
+		when(view.getDisplayMetrics()).thenReturn(metrics);
+		Intent intent = mock(Intent.class);
+
+		presenter.handleActivityResult(REQUEST_CODE_INTRO, RESULT_INTRO_MW_NOT_SUPPORTED, intent);
+
+		verify(navigator).showToast(R.string.pocketpaint_intro_split_screen_not_supported, Toast.LENGTH_LONG);
+		verifyZeroInteractions(interactor, navigator);
 	}
 
 	@Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="${appName}"
         android:extractNativeLibs="false"
-        android:resizeableActivity="false"
         tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
 
         <activity


### PR DESCRIPTION
## Link to ticket
https://jira.catrob.at/browse/PAINTROID-70 ![](https://img.shields.io/jira/issue/https/jira.catrob.at/PAINTROID-70.svg)

## Description
* Immediately finish intro activity if splitscreen is detected
* Display a toast to notify the user why the intro was closed in main activity
* Clean up unecessary request codes in main activity
* Add tests for new request code
* Add a new string

### This will allow splitscreen in the standalone version as well, as we have to support it anyways