### PR TITLE
PAINTROID-20/PAINTROID-18: Refactor brush and eraser tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/BrushPickerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/BrushPickerIntegrationTest.java
@@ -95,7 +95,7 @@ public class BrushPickerIntegrationTest {
 
 	@Test
 	public void brushPickerDialogDefaultLayoutAndToolChanges() {
-		onView(withId(R.id.pocketpaint_drawer_preview))
+		onView(withId(R.id.pocketpaint_brush_tool_preview))
 				.check(matches(isDisplayed()));
 		onView(withId(R.id.pocketpaint_stroke_width_seek_bar))
 				.check(matches(isDisplayed()))

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushChangedListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushChangedListener.java
@@ -1,0 +1,43 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.tools.common;
+
+import android.graphics.Paint;
+
+import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.tools.options.BrushToolOptions;
+
+public class CommonBrushChangedListener implements BrushToolOptions.OnBrushChangedListener {
+	private Tool tool;
+
+	public CommonBrushChangedListener(Tool tool) {
+		this.tool = tool;
+	}
+
+	@Override
+	public void setCap(Paint.Cap strokeCap) {
+		tool.changePaintStrokeCap(strokeCap);
+	}
+
+	@Override
+	public void setStrokeWidth(int strokeWidth) {
+		tool.changePaintStrokeWidth(strokeWidth);
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushPreviewListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushPreviewListener.java
@@ -17,52 +17,40 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.tools.implementation;
+package org.catrobat.paintroid.tools.common;
 
-import android.graphics.Color;
 import android.graphics.Paint;
-import android.support.annotation.ColorInt;
 
-import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
 
-public class EraserTool extends BrushTool {
+public class CommonBrushPreviewListener implements BrushToolOptions.OnBrushPreviewListener {
+	private ToolType toolType;
+	private ToolPaint toolPaint;
 
-	@ColorInt
-	private int previousColor = Color.BLACK;
-
-	public EraserTool(BrushToolOptions brushToolOptions, ContextCallback contextCallback,
-			ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace,
-			CommandManager commandManager) {
-		super(brushToolOptions, contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+	public CommonBrushPreviewListener(ToolPaint toolPaint, ToolType toolType) {
+		this.toolType = toolType;
+		this.toolPaint = toolPaint;
 	}
 
 	@Override
-	public Paint getDrawPaint() {
-		Paint paint = super.getDrawPaint();
-		paint.setColor(previousColor);
-		return paint;
+	public float getStrokeWidth() {
+		return toolPaint.getStrokeWidth();
 	}
 
 	@Override
-	public void setDrawPaint(Paint paint) {
-		super.setDrawPaint(paint);
-		previousColor = paint.getColor();
+	public Paint.Cap getStrokeCap() {
+		return toolPaint.getStrokeCap();
 	}
 
 	@Override
-	public void changePaintColor(int color) {
-		super.changePaintColor(color);
-		previousColor = color;
+	public int getColor() {
+		return toolPaint.getColor();
 	}
 
 	@Override
 	public ToolType getToolType() {
-		return ToolType.ERASER;
+		return toolType;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
@@ -32,13 +32,13 @@ import android.support.annotation.VisibleForTesting;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.listener.BrushPickerView;
 import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.tools.options.BrushToolOptions;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
-import org.catrobat.paintroid.ui.tools.DrawerPreview;
+import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptions;
 
 import static org.catrobat.paintroid.tools.common.Constants.MOVE_TOLERANCE;
 
@@ -57,7 +57,7 @@ public class CursorTool extends BaseToolWithShape {
 	public int cursorToolSecondaryShapeColor;
 	@VisibleForTesting
 	public boolean toolInDrawMode = false;
-	private BrushPickerView brushPickerView;
+	private DefaultBrushToolOptions brushPickerView;
 
 	public CursorTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
@@ -335,14 +335,14 @@ public class CursorTool extends BaseToolWithShape {
 
 	@Override
 	public void setupToolOptions() {
-		brushPickerView = new BrushPickerView(toolSpecificOptionsLayout);
+		brushPickerView = new DefaultBrushToolOptions(toolSpecificOptionsLayout);
 		brushPickerView.setCurrentPaint(toolPaint.getPaint());
 	}
 
 	@Override
 	public void startTool() {
 		super.startTool();
-		brushPickerView.setBrushChangedListener(new BrushPickerView.OnBrushChangedListener() {
+		brushPickerView.setBrushChangedListener(new BrushToolOptions.OnBrushChangedListener() {
 			@Override
 			public void setCap(Cap strokeCap) {
 				changePaintStrokeCap(strokeCap);
@@ -353,7 +353,7 @@ public class CursorTool extends BaseToolWithShape {
 				changePaintStrokeWidth(strokeWidth);
 			}
 		});
-		brushPickerView.setDrawerPreviewCallback(new DrawerPreview.Callback() {
+		brushPickerView.setBrushPreviewListener(new BrushToolOptions.OnBrushPreviewListener() {
 			@Override
 			public float getStrokeWidth() {
 				return toolPaint.getStrokeWidth();
@@ -380,6 +380,6 @@ public class CursorTool extends BaseToolWithShape {
 	public void leaveTool() {
 		super.leaveTool();
 		brushPickerView.setBrushChangedListener(null);
-		brushPickerView.setDrawerPreviewCallback(null);
+		brushPickerView.setBrushPreviewListener(null);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
@@ -20,6 +20,7 @@
 package org.catrobat.paintroid.tools.implementation;
 
 import android.app.Activity;
+import android.view.ViewGroup;
 
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.command.CommandManager;
@@ -31,7 +32,9 @@ import org.catrobat.paintroid.tools.ToolFactory;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.tools.options.BrushToolOptions;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptions;
 
 public class DefaultToolFactory implements ToolFactory {
 
@@ -42,10 +45,11 @@ public class DefaultToolFactory implements ToolFactory {
 		ContextCallback contextCallback = new DefaultContextCallback(activity.getApplicationContext());
 		toolOptionsController.removeToolViews();
 		toolOptionsController.setToolName(toolType.getNameResource());
+		ViewGroup toolSpecificOptionsLayout = toolOptionsController.getToolSpecificOptionsLayout();
 
 		switch (toolType) {
 			case BRUSH:
-				tool = new BrushTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new BrushTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case CURSOR:
 				tool = new CursorTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
@@ -77,7 +81,7 @@ public class DefaultToolFactory implements ToolFactory {
 				tool = new ShapeTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case ERASER:
-				tool = new EraserTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new EraserTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case LINE:
 				tool = new LineTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
@@ -86,11 +90,15 @@ public class DefaultToolFactory implements ToolFactory {
 				tool = new TextTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			default:
-				tool = new BrushTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new BrushTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 		}
 		tool.setupToolOptions();
 		toolOptionsController.resetToOrigin();
 		return tool;
+	}
+
+	private BrushToolOptions createBrushToolOptions(ViewGroup toolSpecificOptionsLayout) {
+		return new DefaultBrushToolOptions(toolSpecificOptionsLayout);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
@@ -28,20 +28,20 @@ import android.graphics.PointF;
 
 import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.listener.BrushPickerView;
 import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.tools.options.BrushToolOptions;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
-import org.catrobat.paintroid.ui.tools.DrawerPreview;
+import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptions;
 
 public class LineTool extends BaseTool {
 
 	protected PointF initialEventCoordinate;
 	protected PointF currentCoordinate;
 	protected boolean pathInsideBitmap;
-	private BrushPickerView brushPickerView;
+	private BrushToolOptions brushPickerView;
 
 	public LineTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
 		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
@@ -135,14 +135,14 @@ public class LineTool extends BaseTool {
 
 	@Override
 	public void setupToolOptions() {
-		brushPickerView = new BrushPickerView(toolSpecificOptionsLayout);
+		brushPickerView = new DefaultBrushToolOptions(toolSpecificOptionsLayout);
 		brushPickerView.setCurrentPaint(toolPaint.getPaint());
 	}
 
 	@Override
 	public void startTool() {
 		super.startTool();
-		brushPickerView.setBrushChangedListener(new BrushPickerView.OnBrushChangedListener() {
+		brushPickerView.setBrushChangedListener(new BrushToolOptions.OnBrushChangedListener() {
 			@Override
 			public void setCap(Cap strokeCap) {
 				changePaintStrokeCap(strokeCap);
@@ -154,7 +154,7 @@ public class LineTool extends BaseTool {
 			}
 		});
 
-		brushPickerView.setDrawerPreviewCallback(new DrawerPreview.Callback() {
+		brushPickerView.setBrushPreviewListener(new BrushToolOptions.OnBrushPreviewListener() {
 			@Override
 			public float getStrokeWidth() {
 				return toolPaint.getStrokeWidth();
@@ -181,6 +181,6 @@ public class LineTool extends BaseTool {
 	public void leaveTool() {
 		super.leaveTool();
 		brushPickerView.setBrushChangedListener(null);
-		brushPickerView.setDrawerPreviewCallback(null);
+		brushPickerView.setBrushPreviewListener(null);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolOptions.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolOptions.java
@@ -1,0 +1,50 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.tools.options;
+
+import android.graphics.Paint;
+
+import org.catrobat.paintroid.tools.ToolType;
+
+public interface BrushToolOptions {
+	void invalidate();
+
+	void setCurrentPaint(Paint paint);
+
+	void setBrushChangedListener(OnBrushChangedListener onBrushChangedListener);
+
+	void setBrushPreviewListener(OnBrushPreviewListener onBrushPreviewListener);
+
+	interface OnBrushChangedListener {
+		void setCap(Paint.Cap strokeCap);
+
+		void setStrokeWidth(int strokeWidth);
+	}
+
+	interface OnBrushPreviewListener {
+		float getStrokeWidth();
+
+		Paint.Cap getStrokeCap();
+
+		int getColor();
+
+		ToolType getToolType();
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolPreview.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolPreview.java
@@ -1,0 +1,26 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.tools.options;
+
+public interface BrushToolPreview {
+	void setListener(BrushToolOptions.OnBrushPreviewListener callback);
+
+	void invalidate();
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/BrushToolView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/BrushToolView.java
@@ -33,8 +33,10 @@ import android.view.View;
 
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.tools.options.BrushToolOptions;
+import org.catrobat.paintroid.tools.options.BrushToolPreview;
 
-public class DrawerPreview extends View {
+public class BrushToolView extends View implements BrushToolPreview {
 
 	private static final int BORDER = 2;
 
@@ -42,14 +44,14 @@ public class DrawerPreview extends View {
 	private Paint checkeredPattern;
 	private Paint borderPaint;
 	private Path path;
-	private Callback callback;
+	private BrushToolOptions.OnBrushPreviewListener callback;
 
-	public DrawerPreview(Context context) {
+	public BrushToolView(Context context) {
 		super(context);
 		init();
 	}
 
-	public DrawerPreview(Context context, AttributeSet attrs) {
+	public BrushToolView(Context context, AttributeSet attrs) {
 		super(context, attrs);
 		init();
 	}
@@ -233,17 +235,8 @@ public class DrawerPreview extends View {
 		setMeasuredDimension(widthSize, (int) (widthSize * .25));
 	}
 
-	public void setCallback(Callback callback) {
+	@Override
+	public void setListener(BrushToolOptions.OnBrushPreviewListener callback) {
 		this.callback = callback;
-	}
-
-	public interface Callback {
-		float getStrokeWidth();
-
-		Paint.Cap getStrokeCap();
-
-		int getColor();
-
-		ToolType getToolType();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptions.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptions.java
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.listener;
+package org.catrobat.paintroid.ui.tools;
 
 import android.graphics.Paint;
 import android.graphics.Paint.Cap;
@@ -34,34 +34,34 @@ import android.widget.ImageButton;
 import android.widget.SeekBar;
 
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.ui.tools.DrawerPreview;
-import org.catrobat.paintroid.ui.tools.NumberRangeFilter;
+import org.catrobat.paintroid.tools.options.BrushToolOptions;
+import org.catrobat.paintroid.tools.options.BrushToolPreview;
 
 import java.util.Locale;
 
-public final class BrushPickerView {
+public final class DefaultBrushToolOptions implements BrushToolOptions {
 	private static final int MIN_BRUSH_SIZE = 1;
-	private static final String TAG = BrushPickerView.class.getSimpleName();
+	private static final String TAG = DefaultBrushToolOptions.class.getSimpleName();
 
 	private final EditText brushSizeText;
 	private final SeekBar brushWidthSeekBar;
 	private final ImageButton buttonCircle;
 	private final ImageButton buttonRect;
-	private final DrawerPreview drawerPreview;
+	private final BrushToolPreview brushToolPreview;
 	@VisibleForTesting
-	public OnBrushChangedListener brushChangedListener;
+	public BrushToolOptions.OnBrushChangedListener brushChangedListener;
 
-	public BrushPickerView(ViewGroup rootView) {
+	public DefaultBrushToolOptions(ViewGroup rootView) {
 		LayoutInflater inflater = LayoutInflater.from(rootView.getContext());
 		View brushPickerView = inflater.inflate(R.layout.dialog_pocketpaint_stroke, rootView, true);
 
 		buttonCircle = brushPickerView.findViewById(R.id.pocketpaint_stroke_ibtn_circle);
 		buttonRect = brushPickerView.findViewById(R.id.pocketpaint_stroke_ibtn_rect);
 		brushWidthSeekBar = brushPickerView.findViewById(R.id.pocketpaint_stroke_width_seek_bar);
-		brushWidthSeekBar.setOnSeekBarChangeListener(new BrushPickerView.OnBrushChangedWidthSeekBarListener());
+		brushWidthSeekBar.setOnSeekBarChangeListener(new DefaultBrushToolOptions.OnBrushChangedWidthSeekBarListener());
 		brushSizeText = brushPickerView.findViewById(R.id.pocketpaint_stroke_width_width_text);
 		brushSizeText.setFilters(new InputFilter[]{new NumberRangeFilter(1, 100)});
-		drawerPreview = brushPickerView.findViewById(R.id.pocketpaint_drawer_preview);
+		brushToolPreview = brushPickerView.findViewById(R.id.pocketpaint_brush_tool_preview);
 
 		buttonCircle.setOnClickListener(new View.OnClickListener() {
 			@Override
@@ -126,8 +126,15 @@ public final class BrushPickerView {
 		brushSizeText.setText(String.format(Locale.getDefault(), "%d", (int) currentPaint.getStrokeWidth()));
 	}
 
-	public void setBrushChangedListener(OnBrushChangedListener brushChangedListener) {
+	@Override
+	public void setBrushChangedListener(BrushToolOptions.OnBrushChangedListener brushChangedListener) {
 		this.brushChangedListener = brushChangedListener;
+	}
+
+	@Override
+	public void setBrushPreviewListener(OnBrushPreviewListener onBrushPreviewListener) {
+		brushToolPreview.setListener(onBrushPreviewListener);
+		brushToolPreview.invalidate();
 	}
 
 	private void updateStrokeWidthChange(int strokeWidth) {
@@ -143,22 +150,10 @@ public final class BrushPickerView {
 	}
 
 	public void invalidate() {
-		drawerPreview.invalidate();
+		brushToolPreview.invalidate();
 	}
 
-	public void setDrawerPreviewCallback(DrawerPreview.Callback callback) {
-		drawerPreview.setCallback(callback);
-		drawerPreview.invalidate();
-	}
-
-	public interface OnBrushChangedListener {
-		void setCap(Cap strokeCap);
-
-		void setStrokeWidth(int strokeWidth);
-	}
-
-	public class OnBrushChangedWidthSeekBarListener implements
-			SeekBar.OnSeekBarChangeListener {
+	public class OnBrushChangedWidthSeekBarListener implements SeekBar.OnSeekBarChangeListener {
 
 		@Override
 		public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
@@ -171,7 +166,7 @@ public final class BrushPickerView {
 				brushSizeText.setText(String.format(Locale.getDefault(), "%d", progress));
 			}
 
-			drawerPreview.invalidate();
+			brushToolPreview.invalidate();
 		}
 
 		@Override

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
@@ -27,8 +27,8 @@
         android:orientation="vertical"
         android:focusableInTouchMode="true">
 
-    <org.catrobat.paintroid.ui.tools.DrawerPreview
-        android:id="@+id/pocketpaint_drawer_preview"
+    <org.catrobat.paintroid.ui.tools.BrushToolView
+        android:id="@+id/pocketpaint_brush_tool_preview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 


### PR DESCRIPTION
## Link to ticket
https://jira.catrob.at/browse/PAINTROID-20 ![](https://img.shields.io/jira/issue/https/jira.catrob.at/PAINTROID-20.svg)
https://jira.catrob.at/browse/PAINTROID-18 ![](https://img.shields.io/jira/issue/https/jira.catrob.at/PAINTROID-18.svg)

## Description
* Move all `View` creation out of `BrushTool` and `EraserTool`
* Rename `DrawerPreview` to `BrushToolView` and extract interface
* Rename `BrushPickerView` to `DefaultBrushToolOptions` and extract interface
* Create reusable `CommonBrushChangedListener` and `CommonBrushPreviewListener` classes
* Refactor `BrushToolTest` to work without an activity