### PR TITLE
PAINTROID-23: Refactor import tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
@@ -20,40 +20,38 @@
 package org.catrobat.paintroid.test.junit.tools;
 
 import android.graphics.Bitmap;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.annotation.UiThreadTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import android.util.DisplayMetrics;
 
-import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.implementation.DefaultContextCallback;
 import org.catrobat.paintroid.tools.implementation.ImportTool;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ImportToolTest {
-
-	@Rule
-	public ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-	@Rule
-	public MockitoRule mockito = MockitoJUnit.rule();
-
 	@Mock
 	private CommandManager commandManager;
+	@Mock
+	private Workspace workspace;
+	@Mock
+	private ToolPaint toolPaint;
+	@Mock
+	private ToolOptionsController toolOptionsController;
+	@Mock
+	private ContextCallback contextCallback;
+	@Mock
+	private DisplayMetrics displayMetrics;
 
 	private int drawingSurfaceWidth;
 	private int drawingSurfaceHeight;
@@ -63,15 +61,19 @@ public class ImportToolTest {
 	@UiThreadTest
 	@Before
 	public void setUp() {
-		MainActivity activity = activityTestRule.getActivity();
-		Workspace workspace = activity.workspace;
-		ToolPaint toolPaint = activity.toolPaint;
-		ToolOptionsController toolOptionsController = activity.toolOptionsController;
-		ContextCallback contextCallback = new DefaultContextCallback(InstrumentationRegistry.getTargetContext());
-		tool = new ImportTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		drawingSurfaceWidth = 20;
+		drawingSurfaceHeight = 30;
 
-		drawingSurfaceWidth = workspace.getWidth();
-		drawingSurfaceHeight = workspace.getHeight();
+		displayMetrics.heightPixels = 1920;
+		displayMetrics.widthPixels = 1080;
+		displayMetrics.density = 1;
+
+		when(contextCallback.getDisplayMetrics()).thenReturn(displayMetrics);
+		when(workspace.getWidth()).thenReturn(20);
+		when(workspace.getHeight()).thenReturn(30);
+		when(workspace.getScale()).thenReturn(1f);
+
+		tool = new ImportTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
@@ -22,136 +22,138 @@ package org.catrobat.paintroid.test.junit.tools;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PointF;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.annotation.UiThreadTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
 
-import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.dialog.colorpicker.ColorPickerDialog.OnColorPickedListener;
 import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.implementation.DefaultContextCallback;
 import org.catrobat.paintroid.tools.implementation.PipetteTool;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class PipetteToolTest {
 	private static final int X_COORDINATE_RED = 1;
 	private static final int X_COORDINATE_GREEN = 3;
 	private static final int X_COORDINATE_BLUE = 5;
 	private static final int X_COORDINATE_PART_TRANSPARENT = 7;
 
-	@Rule
-	public ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-	@Rule
-	public MockitoRule mockito = MockitoJUnit.rule();
-
 	@Mock
 	private CommandManager commandManager;
+	@Mock
+	private OnColorPickedListener listener;
+	@Mock
+	private ToolPaint toolPaint;
+	@Mock
+	private Workspace workspace;
+	@Mock
+	private ToolOptionsController toolOptionsController;
+	@Mock
+	private ContextCallback contextCallback;
 
 	private PipetteTool toolToTest;
-	private OnColorPickedListener listener;
-	private ToolPaint toolPaint;
 
-	@UiThreadTest
 	@Before
 	public void setUp() {
-		listener = mock(OnColorPickedListener.class);
-		MainActivity activity = activityTestRule.getActivity();
-		Workspace workspace = activity.workspace;
-		toolPaint = activity.toolPaint;
-		ToolOptionsController toolOptionsController = activity.toolOptionsController;
-		ContextCallback contextCallback = new DefaultContextCallback(InstrumentationRegistry.getTargetContext());
-		toolToTest = new PipetteTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager, listener);
-
-		Bitmap bitmap = activity.layerModel.getCurrentLayer().getBitmap();
+		Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
 		bitmap.setPixel(X_COORDINATE_RED, 0, Color.RED);
 		bitmap.setPixel(X_COORDINATE_GREEN, 0, Color.GREEN);
 		bitmap.setPixel(X_COORDINATE_BLUE, 0, Color.BLUE);
 		bitmap.setPixel(X_COORDINATE_PART_TRANSPARENT, 0, 0xAAAAAAAA);
 
-		toolToTest.updateSurfaceBitmap();
+		when(workspace.getBitmapOfAllLayers()).thenReturn(bitmap);
+		when(workspace.contains(any(PointF.class))).thenAnswer(new Answer<Boolean>() {
+			@Override
+			public Boolean answer(InvocationOnMock invocation) {
+				PointF argument = invocation.getArgument(0);
+				return argument.x >= 0 && argument.y >= 0 && argument.x < 10 && argument.y < 10;
+			}
+		});
+
+		toolToTest = new PipetteTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager, listener);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testHandleDown() {
 		toolToTest.handleDown(new PointF(X_COORDINATE_RED, 0));
-		assertEquals(Color.RED, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleMove(new PointF(X_COORDINATE_PART_TRANSPARENT, 0));
-		assertEquals(0xAAAAAAAA, toolToTest.getDrawPaint().getColor());
 
-		verify(listener).colorChanged(Color.RED);
-		verify(listener).colorChanged(0xAAAAAAAA);
+		InOrder inOrderToolPaint = inOrder(toolPaint);
+		inOrderToolPaint.verify(toolPaint).setColor(Color.RED);
+		inOrderToolPaint.verify(toolPaint).setColor(0xAAAAAAAA);
+
+		InOrder inOrderListener = inOrder(listener);
+		inOrderListener.verify(listener).colorChanged(Color.RED);
+		inOrderListener.verify(listener).colorChanged(0xAAAAAAAA);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testHandleMove() {
 		toolToTest.handleDown(new PointF(X_COORDINATE_RED, 0));
-		assertEquals(Color.RED, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleMove(new PointF(X_COORDINATE_RED + 1, 0));
-		assertEquals(Color.TRANSPARENT, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleMove(new PointF(X_COORDINATE_GREEN, 0));
-		assertEquals(Color.GREEN, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleMove(new PointF(X_COORDINATE_PART_TRANSPARENT, 0));
-		assertEquals(0xAAAAAAAA, toolToTest.getDrawPaint().getColor());
 
-		verify(listener).colorChanged(Color.RED);
-		verify(listener).colorChanged(Color.TRANSPARENT);
-		verify(listener).colorChanged(Color.GREEN);
-		verify(listener).colorChanged(0xAAAAAAAA);
+		InOrder inOrderToolPaint = inOrder(toolPaint);
+		inOrderToolPaint.verify(toolPaint).setColor(Color.RED);
+		inOrderToolPaint.verify(toolPaint).setColor(Color.TRANSPARENT);
+		inOrderToolPaint.verify(toolPaint).setColor(Color.GREEN);
+		inOrderToolPaint.verify(toolPaint).setColor(0xAAAAAAAA);
+
+		InOrder inOrderListener = inOrder(listener);
+		inOrderListener.verify(listener).colorChanged(Color.RED);
+		inOrderListener.verify(listener).colorChanged(Color.TRANSPARENT);
+		inOrderListener.verify(listener).colorChanged(Color.GREEN);
+		inOrderListener.verify(listener).colorChanged(0xAAAAAAAA);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testHandleUp() {
 		toolToTest.handleUp(new PointF(X_COORDINATE_BLUE, 0));
-		assertEquals(Color.BLUE, toolToTest.getDrawPaint().getColor());
 		toolToTest.handleUp(new PointF(X_COORDINATE_PART_TRANSPARENT, 0));
-		assertEquals(0xAAAAAAAA, toolToTest.getDrawPaint().getColor());
 
-		verify(listener).colorChanged(Color.BLUE);
-		verify(listener).colorChanged(0xAAAAAAAA);
+		InOrder inOrderToolPaint = Mockito.inOrder(toolPaint);
+		inOrderToolPaint.verify(toolPaint).setColor(Color.BLUE);
+		inOrderToolPaint.verify(toolPaint).setColor(0xAAAAAAAA);
+
+		InOrder inOrderListener = Mockito.inOrder(listener);
+		inOrderListener.verify(listener).colorChanged(Color.BLUE);
+		inOrderListener.verify(listener).colorChanged(0xAAAAAAAA);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testShouldReturnCorrectToolType() {
 		assertThat(toolToTest.getToolType(), is(ToolType.PIPETTE));
 	}
 
-	@UiThreadTest
 	@Test
 	public void testShouldReturnCorrectColorForForTopButtonIfColorIsTransparent() {
 		toolToTest.handleUp(new PointF(0, 0));
-		int color = toolPaint.getColor();
-		assertEquals(Color.TRANSPARENT, color);
+
+		verify(toolPaint).setColor(Color.TRANSPARENT);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testShouldReturnCorrectColorForForTopButtonIfColorIsRed() {
 		toolToTest.handleUp(new PointF(X_COORDINATE_RED, 0));
-		int color = toolPaint.getColor();
-		assertEquals(Color.RED, color);
+
+		verify(toolPaint).setColor(Color.RED);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
@@ -73,8 +73,7 @@ public class PipetteTool extends BaseTool {
 			return false;
 		}
 
-		if (coordinate.x < 0 || coordinate.y < 0
-				|| coordinate.x >= surfaceBitmap.getWidth() || coordinate.y >= surfaceBitmap.getHeight()) {
+		if (!workspace.contains(coordinate)) {
 			return false;
 		}
 


### PR DESCRIPTION
## Link to ticket
https://jira.catrob.at/browse/PAINTROID-23 ![](https://img.shields.io/jira/issue/https/jira.catrob.at/PAINTROID-23.svg)

## Description
* Rewrite tests for import tool and pipette tool to run without an activity
* As the import tool does not use an UI, this is just refactoring the tests
* Remove code duplication in pipette tool

--------
* [x] Depends on #639 (PAINTROID-15)