### PR TITLE
PAINTROID-22: Refactor text tool

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
@@ -33,8 +33,10 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.options.BrushToolOptions;
+import org.catrobat.paintroid.tools.options.TextToolOptions;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
 import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptions;
+import org.catrobat.paintroid.ui.tools.DefaultTextToolOptions;
 
 public class DefaultToolFactory implements ToolFactory {
 
@@ -87,7 +89,7 @@ public class DefaultToolFactory implements ToolFactory {
 				tool = new LineTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case TEXT:
-				tool = new TextTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new TextTool(createTextToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			default:
 				tool = new BrushTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
@@ -96,6 +98,10 @@ public class DefaultToolFactory implements ToolFactory {
 		tool.setupToolOptions();
 		toolOptionsController.resetToOrigin();
 		return tool;
+	}
+
+	private TextToolOptions createTextToolOptions(ViewGroup toolSpecificOptionsLayout) {
+		return new DefaultTextToolOptions(toolSpecificOptionsLayout);
 	}
 
 	private BrushToolOptions createBrushToolOptions(ViewGroup toolSpecificOptionsLayout) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptions.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptions.java
@@ -1,0 +1,40 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.tools.options;
+
+public interface TextToolOptions {
+	void setState(boolean bold, boolean italic, boolean underlined, String text, int textSize, String font);
+
+	void setCallback(Callback listener);
+
+	interface Callback {
+		void setText(String text);
+
+		void setFont(String font);
+
+		void setUnderlined(boolean underlined);
+
+		void setItalic(boolean italic);
+
+		void setBold(boolean bold);
+
+		void setTextSize(int size);
+	}
+}


### PR DESCRIPTION
## Link to ticket
https://jira.catrob.at/browse/PAINTROID-22 ![](https://img.shields.io/jira/issue/https/jira.catrob.at/PAINTROID-22.svg)

## Description
* Move `TextToolOptions` interface to its own file
* Rename `TextToolOptionsListener` to `DefaultTextToolOptions`
* Move layout inflation into `DefaultTextToolOptions` and hand it to `TextTool` in the constructor
* Adapt creation in `DefaultToolFactory`
* No junit tests were harmed in this PR :angel: (There are none for the text tool)

----------
* [x] Depends on #640 (PAINTROID-20/PAINTROID-18)