### PR TITLE
PAINTROID-63: hex color input

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
@@ -45,6 +45,7 @@ import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.action.ViewActions.swipeDown;
 import static android.support.test.espresso.assertion.PositionAssertions.isCompletelyLeftOf;
 import static android.support.test.espresso.assertion.PositionAssertions.isCompletelyRightOf;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -240,6 +241,8 @@ public class LandscapeIntegrationTest {
 				.perform(click());
 		onView(withClassName(is(RgbSelectorView.class.getName())))
 				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.color_chooser_rgb_base_layout)).perform(swipeDown());
 
 		onView(allOf(withId(R.id.color_chooser_tab_icon), withBackground(R.drawable.ic_color_chooser_tab_preset)))
 				.perform(click());

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
@@ -42,6 +42,8 @@ public final class Constants {
 
 	public static final String PERMISSION_DIALOG_FRAGMENT_TAG = "permissiondialogfragment";
 
+	public static final int NOT_A_HEX_VALUE = 20000000;
+
 	public static final int INVALID_RESOURCE_ID = 0;
 
 	private Constants() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/RgbSelectorView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/colorpicker/RgbSelectorView.java
@@ -21,8 +21,11 @@ package org.catrobat.paintroid.dialog.colorpicker;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
@@ -30,6 +33,8 @@ import android.widget.TextView;
 import org.catrobat.paintroid.R;
 
 import java.util.Locale;
+
+import static org.catrobat.paintroid.common.Constants.NOT_A_HEX_VALUE;
 
 public class RgbSelectorView extends LinearLayout {
 
@@ -41,6 +46,7 @@ public class RgbSelectorView extends LinearLayout {
 	private TextView textViewGreen;
 	private TextView textViewBlue;
 	private TextView textViewAlpha;
+	private EditText editTextHex;
 	private OnColorChangedListener onColorChangedListener;
 
 	public RgbSelectorView(Context context) {
@@ -67,6 +73,9 @@ public class RgbSelectorView extends LinearLayout {
 		textViewGreen = (TextView) rgbView.findViewById(R.id.color_chooser_rgb_green_value);
 		textViewBlue = (TextView) rgbView.findViewById(R.id.color_chooser_rgb_blue_value);
 		textViewAlpha = (TextView) rgbView.findViewById(R.id.color_chooser_rgb_alpha_value);
+
+		editTextHex = (EditText) rgbView.findViewById(R.id.color_chooser_color_rgb_hex);
+		resetTextColor();
 
 		setSelectedColor(Color.BLACK);
 	}
@@ -98,6 +107,50 @@ public class RgbSelectorView extends LinearLayout {
 		seekBarGreen.setOnSeekBarChangeListener(seekBarListener);
 		seekBarBlue.setOnSeekBarChangeListener(seekBarListener);
 		seekBarAlpha.setOnSeekBarChangeListener(seekBarListener);
+
+		editTextHex.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
+
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) { }
+
+			@Override
+			public void afterTextChanged(Editable newText) {
+				if (editTextHex.getTag() == null) {
+					int color = parseInputToCheckIfHEX(newText.toString());
+					if (color != NOT_A_HEX_VALUE) {
+						setSelectedColor(color);
+						onColorChanged(color);
+						resetTextColor();
+					} else {
+						setTextColorToRed();
+					}
+				} else {
+					resetTextColor();
+				}
+			}
+		});
+	}
+
+	private int parseInputToCheckIfHEX(String newText) {
+		if (newText.length() != 9 || !newText.substring(0, 1).equals("#")) {
+			return NOT_A_HEX_VALUE;
+		}
+
+		try {
+			return Color.parseColor(newText);
+		} catch (IllegalArgumentException e) {
+			return NOT_A_HEX_VALUE;
+		}
+	}
+
+	private void resetTextColor() {
+		editTextHex.setTextColor(getResources().getColor(R.color.pocketpaint_color_chooser_hex_correct_black));
+	}
+
+	private void setTextColorToRed() {
+		editTextHex.setTextColor(getResources().getColor(R.color.pocketpaint_color_chooser_hex_wrong_value_red));
 	}
 
 	@Override
@@ -126,6 +179,10 @@ public class RgbSelectorView extends LinearLayout {
 		seekBarRed.setProgress(colorRed);
 		seekBarGreen.setProgress(colorGreen);
 		seekBarBlue.setProgress(colorBlue);
+
+		editTextHex.setTag("changed programmatically");
+		editTextHex.setText(String.format("#%02X%02X%02X%02X", colorAlpha, colorRed, colorGreen, colorBlue));
+		editTextHex.setTag(null);
 
 		setSelectedColorText(color);
 	}

--- a/Paintroid/src/main/res/layout/color_chooser_layout_rgbview.xml
+++ b/Paintroid/src/main/res/layout/color_chooser_layout_rgbview.xml
@@ -22,8 +22,7 @@
     android:id="@+id/color_chooser_rgb_base_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <View
         android:layout_width="1000dp"
@@ -32,13 +31,13 @@
     <TableLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:stretchColumns="1" >
+        android:stretchColumns="1">
 
         <TableRow
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:paddingBottom="12dp"
-            android:paddingTop="12dp" >
+            android:paddingTop="12dp">
 
             <TextView
                 android:id="@+id/color_chooser_color_rgb_textview_red"
@@ -68,14 +67,13 @@
                 android:text="255"
                 android:textColor="@color/pocketpaint_colorAccent"
                 tools:ignore="HardcodedText" />
-
         </TableRow>
 
         <TableRow
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:paddingBottom="12dp"
-            android:paddingTop="12dp" >
+            android:paddingTop="12dp">
 
             <TextView
                 android:id="@+id/color_chooser_color_rgb_textview_green"
@@ -110,7 +108,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:paddingBottom="12dp"
-            android:paddingTop="12dp" >
+            android:paddingTop="12dp">
 
             <TextView
                 android:id="@+id/color_chooser_color_rgb_textview_blue"
@@ -146,7 +144,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:paddingBottom="12dp"
-            android:paddingTop="12dp" >
+            android:paddingTop="12dp">
 
             <TextView
                 android:id="@+id/color_chooser_color_rgb_textview_alpha"
@@ -184,7 +182,30 @@
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:textColor="@color/pocketpaint_colorAccent"
                 tools:ignore="HardcodedText" />
+        </TableRow>
 
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingBottom="12dp"
+            android:paddingTop="12dp">
+
+            <TextView
+                android:id="@+id/color_chooser_color_rgb_textview_hex"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical"
+                android:text="@string/color_hex"
+                android:textColor="@color/pocketpaint_color_chooser_hex_black" />
+
+            <EditText
+                android:id="@+id/color_chooser_color_rgb_hex"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|center_horizontal"
+                android:hint="#"
+                android:inputType="textNoSuggestions"
+                tools:ignore="HardcodedText"/>
         </TableRow>
     </TableLayout>
 

--- a/Paintroid/src/main/res/values/colors.xml
+++ b/Paintroid/src/main/res/values/colors.xml
@@ -69,4 +69,8 @@
     <color name="pocketpaint_color_chooser_gray">#FFA3A3A3</color>
     <color name="pocketpaint_color_chooser_white">#ffffff</color>
     <color name="pocketpaint_color_chooser_transparent">#00000000</color>
+
+    <color name="pocketpaint_color_chooser_hex_wrong_value_red">#FFFE4A49</color>
+    <color name="pocketpaint_color_chooser_hex_correct_black">#FF000000</color>
+    <color name="pocketpaint_color_chooser_hex_black">#FF000000</color>
 </resources>

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -40,6 +40,7 @@
     <string name="color_green">Green</string>
     <string name="color_blue">Blue</string>
     <string name="color_alpha">Alpha</string>
+    <string name="color_hex">HEX</string>
     <string name="dialog_tools_title">Tools</string>
     <string name="dialog_error_save_title">Error load/save File</string>
     <string name="dialog_error_sdcard_text">Check Image or SD-Card!</string>


### PR DESCRIPTION
## Link to ticket
https://jira.catrob.at/browse/PAINTROID-63 ![](https://img.shields.io/jira/issue/https/jira.catrob.at/PAINTROID-63.svg)

## Description
- TextColor of EditText will turn red if the input is not a valid hex value
- Added a Constant greater than the int value a color can be as a return for not a HEX value