### PR TITLE
 PAINTROID-17: Refactor shape tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.java
@@ -34,7 +34,7 @@ import org.catrobat.paintroid.colorpicker.PresetSelectorView;
 import org.catrobat.paintroid.colorpicker.RgbSelectorView;
 import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,8 +83,8 @@ public class LandscapeIntegrationTest {
 		return getMainActivity().toolReference.get();
 	}
 
-	private ToolOptionsController getToolOptionsController() {
-		return getMainActivity().toolOptionsController;
+	private ToolOptionsViewController getToolOptionsViewController() {
+		return getMainActivity().toolOptionsViewController;
 	}
 
 	@Test
@@ -140,7 +140,7 @@ public class LandscapeIntegrationTest {
 
 			assertEquals(toolType, getCurrentTool().getToolType());
 
-			if (!getToolOptionsController().isVisible()) {
+			if (!getToolOptionsViewController().isVisible()) {
 				onToolBarView()
 						.performClickSelectedToolButton();
 			}
@@ -305,8 +305,8 @@ public class LandscapeIntegrationTest {
 		onView(withText(R.string.menu_show_menu)).perform(click());
 
 		onToolBarView()
-				.performOpenToolOptions()
-				.performCloseToolOptions();
+				.performOpenToolOptionsView()
+				.performCloseToolOptionsView();
 	}
 
 	@Test
@@ -326,8 +326,8 @@ public class LandscapeIntegrationTest {
 		onView(withText(R.string.menu_show_menu)).perform(click());
 
 		onToolBarView()
-				.performOpenToolOptions()
-				.performCloseToolOptions();
+				.performOpenToolOptionsView()
+				.performCloseToolOptionsView();
 	}
 
 	@Test
@@ -350,8 +350,8 @@ public class LandscapeIntegrationTest {
 		onView(withText(R.string.menu_show_menu)).perform(click());
 
 		onToolBarView()
-				.performOpenToolOptions()
-				.performCloseToolOptions();
+				.performOpenToolOptionsView()
+				.performCloseToolOptionsView();
 	}
 
 	@Test
@@ -374,8 +374,8 @@ public class LandscapeIntegrationTest {
 		onView(withText(R.string.menu_show_menu)).perform(click());
 
 		onToolBarView()
-				.performOpenToolOptions()
-				.performCloseToolOptions();
+				.performOpenToolOptionsView()
+				.performCloseToolOptionsView();
 	}
 
 	private void setOrientation(int orientation) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
@@ -419,7 +419,7 @@ public class LayerIntegrationTest {
 				.performClose();
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -622,7 +622,7 @@ public class LayerIntegrationTest {
 				.checkLayerDimensions(bitmapHeight, bitmapWidth);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 		onTopBarView()
 				.performUndo();
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
@@ -175,7 +175,7 @@ public class ToolOnBackPressedIntegrationTest {
 	public void testToolOptionsDisappearWhenBackPressed() {
 		onToolBarView()
 				.performSelectTool(ToolType.CURSOR)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onView(withId(R.id.pocketpaint_layout_tool_options_name))
 				.check(matches(withText(R.string.button_cursor)));
@@ -306,10 +306,10 @@ public class ToolOnBackPressedIntegrationTest {
 	public void testCloseToolOptionOnBackPressed() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM);
-		onToolBarView().onToolOptions()
+		onToolBarView().onToolOptionsView()
 				.check(matches(isDisplayed()));
 		pressBack();
-		onToolBarView().onToolOptions()
+		onToolBarView().onToolOptionsView()
 				.check(matches(not(isDisplayed())));
 	}
 
@@ -319,12 +319,12 @@ public class ToolOnBackPressedIntegrationTest {
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 		onToolBarView()
 				.performSelectTool(ToolType.TEXT);
-		onToolBarView().onToolOptions()
+		onToolBarView().onToolOptionsView()
 				.check(matches(isDisplayed()));
 		onTopBarView().onUndoButton()
 				.check(matches(allOf(isDisplayed(), isEnabled())))
 				.perform(click());
-		onToolBarView().onToolOptions()
+		onToolBarView().onToolOptionsView()
 				.check(matches(not(isDisplayed())));
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOptionsIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOptionsIntegrationTest.java
@@ -66,7 +66,7 @@ public class ToolOptionsIntegrationTest {
 	public boolean toolOptionsShownInitially;
 
 	@Parameter(2)
-	public boolean hasToolOptions;
+	public boolean hasToolOptionsView;
 
 	private File testImageFile;
 
@@ -117,14 +117,14 @@ public class ToolOptionsIntegrationTest {
 
 		if (!toolOptionsShownInitially) {
 			onToolBarView()
-					.performOpenToolOptions();
+					.performOpenToolOptionsView();
 		}
 
-		if (hasToolOptions) {
-			onToolBarView().onToolOptions()
+		if (hasToolOptionsView) {
+			onToolBarView().onToolOptionsView()
 					.check(matches(isDisplayed()));
 		} else {
-			onToolBarView().onToolOptions()
+			onToolBarView().onToolOptionsView()
 					.check(matches(not(isDisplayed())));
 		}
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolSelectionIntegrationTest.java
@@ -118,7 +118,7 @@ public class ToolSelectionIntegrationTest {
 	@Test
 	public void testToolSelectionDrawingSurfaceDeactivatedWhenToolOptionsAreShown() {
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_TOP_MIDDLE));
 		onDrawingSurfaceView()
@@ -128,7 +128,7 @@ public class ToolSelectionIntegrationTest {
 	@Test
 	public void testToolSelectionToolOptionsDisappearWhenClickedOutside() {
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onView(withId(R.id.pocketpaint_layout_tool_options))
 				.check(matches(isDisplayed()))

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/BrushPickerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/BrushPickerIntegrationTest.java
@@ -64,7 +64,7 @@ public class BrushPickerIntegrationTest {
 	public void setUp() {
 		onToolBarView()
 				.performSelectTool(ToolType.BRUSH)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 	}
 
 	private Paint getCurrentToolBitmapPaint() {
@@ -125,7 +125,7 @@ public class BrushPickerIntegrationTest {
 		assertStrokePaint(getCurrentToolCanvasPaint(), MAX_STROKE_WIDTH, Cap.SQUARE);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		assertStrokePaint(getCurrentToolCanvasPaint(), MAX_STROKE_WIDTH, Cap.SQUARE);
 	}
@@ -141,16 +141,16 @@ public class BrushPickerIntegrationTest {
 		assertStrokePaint(getCurrentToolCanvasPaint(), newStrokeWidth, Cap.SQUARE);
 
 		onToolBarView()
-				.performCloseToolOptions()
+				.performCloseToolOptionsView()
 				.performSelectTool(ToolType.CURSOR)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onView(withId(R.id.pocketpaint_stroke_width_seek_bar))
 				.check(matches(withProgress(newStrokeWidth)));
 		assertStrokePaint(getCurrentToolCanvasPaint(), newStrokeWidth, Cap.SQUARE);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 	}
 
 	@Test
@@ -159,7 +159,7 @@ public class BrushPickerIntegrationTest {
 		setStrokeWidth(MIN_STROKE_WIDTH);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 	}
 
 	@Test
@@ -168,7 +168,7 @@ public class BrushPickerIntegrationTest {
 				.perform(touchCenterLeft());
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		Paint bitmapPaint = getCurrentToolBitmapPaint();
 		Paint canvasPaint = getCurrentToolCanvasPaint();
@@ -192,12 +192,12 @@ public class BrushPickerIntegrationTest {
 				.check(matches(not(isSelected())));
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		assertStrokePaint(getCurrentToolCanvasPaint(), DEFAULT_STROKE_WIDTH, Cap.SQUARE);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onView(withId(R.id.pocketpaint_stroke_ibtn_circle))
 				.perform(click())
@@ -209,7 +209,7 @@ public class BrushPickerIntegrationTest {
 		assertStrokePaint(getCurrentToolCanvasPaint(), DEFAULT_STROKE_WIDTH, Cap.ROUND);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		assertStrokePaint(getCurrentToolCanvasPaint(), DEFAULT_STROKE_WIDTH, Cap.ROUND);
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/EraserToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/EraserToolIntegrationTest.java
@@ -136,7 +136,7 @@ public class EraserToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.ERASER)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onBrushPickerView().onStrokeWidthSeekBar()
 				.check(matches(allOf(isDisplayed(), withProgress(DEFAULT_STROKE_WIDTH))));
@@ -149,7 +149,7 @@ public class EraserToolIntegrationTest {
 				.check(matches(withProgress(newStrokeWidth)));
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onToolProperties()
 				.checkStrokeWidth(80);
@@ -171,13 +171,13 @@ public class EraserToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.ERASER)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onBrushPickerView().onStrokeCapSquareView()
 				.perform(click());
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onToolProperties()
 				.checkCap(Cap.SQUARE);
@@ -199,7 +199,7 @@ public class EraserToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.ERASER)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onBrushPickerView().onStrokeWidthTextView()
 				.check(matches(allOf(isDisplayed(), withText(TEXT_DEFAULT_STROKE_WIDTH))));
@@ -219,8 +219,8 @@ public class EraserToolIntegrationTest {
 				.checkCap(Cap.SQUARE);
 
 		onToolBarView()
-				.performCloseToolOptions()
-				.performOpenToolOptions();
+				.performCloseToolOptionsView()
+				.performOpenToolOptionsView();
 
 		onBrushPickerView().onStrokeWidthSeekBar()
 				.check(matches(withProgress(newStrokeWidth)));
@@ -239,7 +239,7 @@ public class EraserToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.BRUSH)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onBrushPickerView().onStrokeWidthSeekBar()
 				.check(matches(withProgress(eraserStrokeWidth)));

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/FillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/FillToolIntegrationTest.java
@@ -228,13 +228,13 @@ public class FillToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.FILL)
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onView(withId(R.id.pocketpaint_fill_tool_dialog_color_tolerance_input))
 				.perform(replaceText(String.valueOf(100)));
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/LineToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/LineToolIntegrationTest.java
@@ -95,7 +95,7 @@ public class LineToolIntegrationTest {
 	@Test
 	public void testChangeLineToolForm() {
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		onView(withId(R.id.pocketpaint_stroke_ibtn_rect))
 				.perform(click());

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
@@ -106,7 +106,7 @@ public class RectangleFillToolIntegrationTest {
 		float rectHeight = ellipseTool.boxHeight;
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION));
@@ -211,7 +211,7 @@ public class RectangleFillToolIntegrationTest {
 				.performSelectShape(ShapeTool.BaseShape.HEART);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onToolProperties()
 				.setColor(Color.TRANSPARENT);
@@ -244,7 +244,7 @@ public class RectangleFillToolIntegrationTest {
 		selectShapeTypeAndDraw(true, Color.BLACK);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onShapeToolOptionsView()
 				.performSelectShape(ShapeTool.BaseShape.HEART);
 		selectShapeTypeAndDraw(true, Color.TRANSPARENT);
@@ -274,7 +274,7 @@ public class RectangleFillToolIntegrationTest {
 		PointF pointUnderTest = new PointF(centerPointTool.x, centerPointTool.y);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		if (changeColor) {
 			onToolProperties()

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
@@ -86,7 +86,7 @@ public class ShapeToolIntegrationTest {
 				.perform(click())
 				.check(matches(isSelected()));
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION));
@@ -102,7 +102,7 @@ public class ShapeToolIntegrationTest {
 				.check(matches(isSelected()));
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION));
@@ -118,7 +118,7 @@ public class ShapeToolIntegrationTest {
 				.perform(click())
 				.check(matches(isSelected()));
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION));
@@ -132,7 +132,7 @@ public class ShapeToolIntegrationTest {
 				.check(matches(isSelected()));
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION));

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
@@ -239,7 +239,7 @@ public class TextToolIntegrationTest {
 		selectFormatting(FormattingOptions.SIZE_40);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		PointF boxPosition = getToolMemberBoxPosition();
 		PointF newBoxPosition = new PointF(boxPosition.x + 20, boxPosition.y + 20);
@@ -248,7 +248,7 @@ public class TextToolIntegrationTest {
 		setToolMemberBoxWidth(50.0f);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 
 		assertEquals(TEST_TEXT, textEditText.getText().toString());
 		assertEquals(FONT_SANS_SERIF, fontSpinner.getSelectedItem());
@@ -446,7 +446,7 @@ public class TextToolIntegrationTest {
 		enterMultilineTestText();
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		Bitmap bitmap = getToolMemberDrawingBitmap();
 		int[] pixelsTool = new int[bitmap.getWidth()];
@@ -486,7 +486,7 @@ public class TextToolIntegrationTest {
 		enterTestText();
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		float newBoxWidth = getToolMemberBoxWidth() * 1.5f;
 		float newBoxHeight = getToolMemberBoxHeight() * 1.5f;
@@ -532,7 +532,7 @@ public class TextToolIntegrationTest {
 		enterMultilineTestText();
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		String[] expectedTextSplitUp = {"testing", "multiline", "text", "", "123"};
 		String[] actualTextSplitUp = getToolMemberMultilineText();

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
@@ -244,7 +244,7 @@ public class TransformToolIntegrationTest {
 	public void testWhenNoPixelIsOnBitmap() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION));
@@ -259,7 +259,7 @@ public class TransformToolIntegrationTest {
 	public void testWhenNoPixelIsOnBitmapToasts() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		waitForToast(withText(R.string.transform_info_text), 1000);
 
@@ -273,7 +273,7 @@ public class TransformToolIntegrationTest {
 	public void testChangeCroppingHeightAndCheckWidth() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		float boundingBoxWidth = getToolSelectionBoxWidth();
 		float boundingBoxHeight = getToolSelectionBoxHeight();
@@ -290,7 +290,7 @@ public class TransformToolIntegrationTest {
 	public void testMoveCroppingBordersOnEmptyBitmapAndDoCrop() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		int width = initialWidth / 2;
 		int height = initialHeight / 2;
@@ -386,7 +386,7 @@ public class TransformToolIntegrationTest {
 		}
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -401,7 +401,7 @@ public class TransformToolIntegrationTest {
 		}
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -415,7 +415,7 @@ public class TransformToolIntegrationTest {
 		}
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -669,7 +669,7 @@ public class TransformToolIntegrationTest {
 				0, cropSize, 0, 0, cropSize, height);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -683,7 +683,7 @@ public class TransformToolIntegrationTest {
 				0, width, 0, 0, width, cropSize);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -697,7 +697,7 @@ public class TransformToolIntegrationTest {
 				0, cropSize, width, 0, cropSize, height);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -711,7 +711,7 @@ public class TransformToolIntegrationTest {
 				0, width, 0, height, width, cropSize);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 		onDrawingSurfaceView()
@@ -724,7 +724,7 @@ public class TransformToolIntegrationTest {
 	public void testResizeBordersMatchBitmapBordersAfterCrop() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		drawPlus(layerModel.getCurrentLayer().getBitmap(), initialWidth / 2);
 
@@ -750,7 +750,7 @@ public class TransformToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		perspective.multiplyScale(.25f);
 
@@ -773,7 +773,7 @@ public class TransformToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		final float zoomFactor = perspective.getScaleForCenterBitmap() * .25f;
 		perspective.setScale(zoomFactor);
@@ -796,7 +796,7 @@ public class TransformToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		PointF toolPosition = newPointF(getToolPosition());
 		int[] pixels;
@@ -859,7 +859,7 @@ public class TransformToolIntegrationTest {
 
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		setToolPosition(initialWidth, initialHeight);
 
@@ -870,7 +870,7 @@ public class TransformToolIntegrationTest {
 				.checkBitmapDimension(initialWidth, initialHeight);
 
 		onToolBarView()
-				.performOpenToolOptions();
+				.performOpenToolOptionsView();
 		onTransformToolOptionsView()
 				.performAutoCrop();
 
@@ -882,7 +882,7 @@ public class TransformToolIntegrationTest {
 	public void testResizeBoxCompletelyOutsideBitmap() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		perspective.multiplyScale(.25f);
 
@@ -902,7 +902,7 @@ public class TransformToolIntegrationTest {
 	public void testResizeBoxCompletelyOutsideBitmapToast() {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM)
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 
 		perspective.multiplyScale(.25f);
 
@@ -952,7 +952,7 @@ public class TransformToolIntegrationTest {
 				.checkBitmapDimension(initialHeight, initialWidth);
 
 		onToolBarView()
-				.performCloseToolOptions();
+				.performCloseToolOptionsView();
 		onTopBarView()
 				.performUndo();
 		onDrawingSurfaceView()

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.java
@@ -48,7 +48,7 @@ public final class ToolBarViewInteraction extends CustomViewInteraction {
 		return onView(withId(getCurrentToolType().getToolButtonID()));
 	}
 
-	public ViewInteraction onToolOptions() {
+	public ViewInteraction onToolOptionsView() {
 		return onView(withId(R.id.pocketpaint_layout_tool_options));
 	}
 
@@ -72,14 +72,14 @@ public final class ToolBarViewInteraction extends CustomViewInteraction {
 		return getMainActivity().toolReference.get().getToolType();
 	}
 
-	public ToolBarViewInteraction performOpenToolOptions() {
-		onToolOptions()
+	public ToolBarViewInteraction performOpenToolOptionsView() {
+		onToolOptionsView()
 				.check(matches(not(isDisplayed())));
 		return performClickSelectedToolButton();
 	}
 
-	public ToolBarViewInteraction performCloseToolOptions() {
-		onToolOptions()
+	public ToolBarViewInteraction performCloseToolOptionsView() {
+		onToolOptionsView()
 				.check(matches(isDisplayed()));
 		return performClickSelectedToolButton();
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -30,7 +30,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,7 +67,7 @@ public class BaseToolWithRectangleShapeToolTest {
 	@Mock
 	private CommandManager commandManager;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock
@@ -99,7 +99,7 @@ public class BaseToolWithRectangleShapeToolTest {
 			}
 		});
 
-		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH, toolPaint, workspace, commandManager);
+		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.BRUSH, toolPaint, workspace, commandManager);
 
 		toolPosition = toolToTest.toolPosition;
 		rectWidth = toolToTest.boxWidth;
@@ -162,7 +162,7 @@ public class BaseToolWithRectangleShapeToolTest {
 
 		when(workspace.getScale()).thenReturn(0.8f, 0.15f, 0.1f);
 
-		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.SHAPE,
+		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.SHAPE,
 				toolPaint, workspace, commandManager);
 
 		float width = toolToTest.boxWidth;
@@ -170,7 +170,7 @@ public class BaseToolWithRectangleShapeToolTest {
 
 		assertEquals("Width and Height should be the same with activating Rectangletool on low zoom out", width, height, Double.MIN_VALUE);
 
-		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.SHAPE,
+		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.SHAPE,
 				toolPaint, workspace, commandManager);
 
 		width = toolToTest.boxWidth;
@@ -180,7 +180,7 @@ public class BaseToolWithRectangleShapeToolTest {
 				"With zooming out a lot, height and width should not be the same anymore and adjust the ratio to the drawinSurface",
 				width, height);
 
-		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.SHAPE,
+		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.SHAPE,
 				toolPaint, workspace, commandManager);
 
 		float newWidth = toolToTest.boxWidth;
@@ -198,9 +198,9 @@ public class BaseToolWithRectangleShapeToolTest {
 	@Test
 	public void testRectangleSizeChangeWhenZoomedLevel1ToLevel2() {
 		when(workspace.getScale()).thenReturn(1f, 2f);
-		BaseToolWithRectangleShape rectTool1 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
+		BaseToolWithRectangleShape rectTool1 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
-		BaseToolWithRectangleShape rectTool2 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
+		BaseToolWithRectangleShape rectTool2 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
 
 		assertTrue("rectangle should be smaller with scale 2",
@@ -212,9 +212,9 @@ public class BaseToolWithRectangleShapeToolTest {
 	public void testRectangleSizeChangeWhenZoomedLevel1ToLevel05() {
 		when(workspace.getScale()).thenReturn(1f, 0.5f);
 
-		BaseToolWithRectangleShape rectTool1 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
+		BaseToolWithRectangleShape rectTool1 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
-		BaseToolWithRectangleShape rectTool05 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
+		BaseToolWithRectangleShape rectTool05 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsViewController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
 		assertThat(rectTool1.boxWidth, is(lessThan(rectTool05.boxWidth)));
 		assertThat(rectTool1.boxHeight, is(lessThan(rectTool05.boxHeight)));
@@ -373,9 +373,9 @@ public class BaseToolWithRectangleShapeToolTest {
 	private class BaseToolWithRectangleShapeImpl extends BaseToolWithRectangleShape {
 		private final ToolType toolType;
 
-		BaseToolWithRectangleShapeImpl(ContextCallback contextCallback, ToolOptionsController toolOptionsController, ToolType toolType, ToolPaint toolPaint,
+		BaseToolWithRectangleShapeImpl(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController, ToolType toolType, ToolPaint toolPaint,
 				Workspace layerModelWrapper, CommandManager commandManager) {
-			super(contextCallback, toolOptionsController, toolPaint, layerModelWrapper, commandManager);
+			super(contextCallback, toolOptionsViewController, toolPaint, layerModelWrapper, commandManager);
 			this.toolType = toolType;
 		}
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -22,31 +22,25 @@ package org.catrobat.paintroid.test.junit.tools;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
 import android.graphics.PointF;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.annotation.UiThreadTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
 import android.util.DisplayMetrics;
 
-import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
-import org.catrobat.paintroid.tools.implementation.DefaultContextCallback;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
-import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
@@ -55,50 +49,58 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(MockitoJUnitRunner.class)
 public class BaseToolWithRectangleShapeToolTest {
 	private static final int RESIZE_MOVE_DISTANCE = 50;
-
-	@Rule
-	public ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class);
-
-	@Rule
-	public MockitoRule mockito = MockitoJUnit.rule();
-
-	@Mock
-	private CommandManager commandManager;
-
-	private BaseToolWithRectangleShape toolToTest;
-	private float screenWidth = 1;
-	private float screenHeight = 1;
-	private PointF toolPosition;
+	private int screenWidth;
+	private int screenHeight;
 	private float rectWidth;
 	private float rectHeight;
 	private float rotation;
 	private float symbolDistance;
 
-	private Workspace workspace;
-	private Perspective perspective;
-	private ToolPaint toolPaint;
-	private ToolOptionsController toolOptionsController;
-	private ContextCallback contextCallback;
+	private PointF toolPosition;
 
-	@UiThreadTest
+	@Mock
+	private CommandManager commandManager;
+	@Mock
+	private ToolOptionsController toolOptionsController;
+	@Mock
+	private ContextCallback contextCallback;
+	@Mock
+	private Workspace workspace;
+	@Mock
+	private ToolPaint toolPaint;
+	@Mock
+	private DisplayMetrics metrics;
+
+	private BaseToolWithRectangleShape toolToTest;
+
 	@Before
 	public void setUp() {
-		MainActivity activity = activityTestRule.getActivity();
-		workspace = activity.workspace;
-		perspective = activity.perspective;
-		toolPaint = activity.toolPaint;
-		toolOptionsController = activity.toolOptionsController;
-		contextCallback = new DefaultContextCallback(InstrumentationRegistry.getTargetContext());
-		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH, toolPaint, workspace, commandManager);
-
-		DisplayMetrics metrics = InstrumentationRegistry.getTargetContext()
-				.getResources().getDisplayMetrics();
+		metrics.heightPixels = 1920;
+		metrics.widthPixels = 1080;
+		metrics.density = 1;
 		screenWidth = metrics.widthPixels;
 		screenHeight = metrics.heightPixels;
+		when(contextCallback.getOrientation()).thenReturn(ContextCallback.ScreenOrientation.PORTRAIT);
+		when(contextCallback.getDisplayMetrics()).thenReturn(metrics);
+		when(workspace.getScale()).thenReturn(1f);
+		when(workspace.getWidth()).thenReturn(screenWidth);
+		when(workspace.getHeight()).thenReturn(screenHeight);
+		when(workspace.contains(any(PointF.class))).thenAnswer(new Answer<Boolean>() {
+			@Override
+			public Boolean answer(InvocationOnMock invocation) {
+				PointF point = invocation.getArgument(0);
+				return point.x >= 0 && point.y >= 0 && point.x < screenWidth && point.y < screenHeight;
+			}
+		});
+
+		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH, toolPaint, workspace, commandManager);
+
 		toolPosition = toolToTest.toolPosition;
 		rectWidth = toolToTest.boxWidth;
 		rectHeight = toolToTest.boxHeight;
@@ -106,124 +108,10 @@ public class BaseToolWithRectangleShapeToolTest {
 		symbolDistance = toolToTest.rotationSymbolDistance;
 	}
 
-	@UiThreadTest
-	@Test
-	public void testResizeRectangle() {
-
-		float rectWidth = toolToTest.boxWidth;
-		float rectHeight = toolToTest.boxHeight;
-		PointF rectPosition = toolToTest.toolPosition;
-
-		// resize bigger top left only on Y-coordinate
-		float dragFromX = rectPosition.x - rectWidth / 2;
-		float dragToX = dragFromX;
-		float dragFromY = rectPosition.y - rectHeight / 2;
-		float dragToY = dragFromY - RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, true, true);
-
-		// resize smaller top left only on Y-coordinate
-		dragToX = dragFromX;
-		dragToY = dragFromY + RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, false, true);
-
-		// resize bigger top left only on X-coordinate
-		dragToX = dragFromX - RESIZE_MOVE_DISTANCE;
-		dragToY = dragFromY;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, true, true);
-
-		// resize smaller top left only on X-coordinate
-		dragToX = dragFromX + RESIZE_MOVE_DISTANCE;
-		dragToY = dragFromY;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, false, true);
-
-		// resize bigger top center
-		dragFromX = rectPosition.x;
-		dragToX = dragFromX;
-		dragToY = dragFromY - RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, false, true, true, false);
-
-		// resize smaller top center;
-		dragToY = dragFromY + RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, false, true, false, false);
-
-		// resize bigger top right
-		dragFromX = rectPosition.x + rectWidth / 2;
-		dragToX = dragFromX + RESIZE_MOVE_DISTANCE;
-		dragToY = dragFromY - RESIZE_MOVE_DISTANCE / 2;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, true, true);
-
-		// resize smaller top right
-		dragToX = dragFromX - RESIZE_MOVE_DISTANCE / 2;
-		dragToY = dragFromY + RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, false, true);
-
-		// resize bigger center right
-		dragToX = dragFromX + RESIZE_MOVE_DISTANCE;
-		dragFromY = rectPosition.y;
-		dragToY = dragFromY;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, false, true, false);
-
-		// resize smaller center right
-		dragToX = dragFromX - RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, false, false, false);
-
-		// resize bigger bottom right
-		dragToX = dragFromX + RESIZE_MOVE_DISTANCE;
-		dragFromY = rectPosition.y + rectHeight / 2;
-		dragToY = dragFromY + RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, true, true);
-
-		// resize smaller bottom right
-		dragToX = dragFromX - RESIZE_MOVE_DISTANCE;
-		dragToY = dragFromY - RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, false, true);
-
-		// resize bigger bottom center
-		dragFromX = rectPosition.x;
-		dragToX = dragFromX;
-		dragToY = dragFromY + RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, false, true, true, false);
-
-		// resize smaller bottom center
-		dragToY = dragFromY - RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, false, true, false, false);
-
-		// resize bigger bottom left only on Y-coordinate
-		dragFromX = rectPosition.x - rectWidth / 2;
-		dragFromY = rectPosition.y + rectHeight / 2;
-		dragToX = dragFromX;
-		dragToY = dragFromY + RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, true, true);
-
-		// resize smaller bottom left only on Y-coordinate
-		dragToX = dragFromX;
-		dragToY = dragFromY - RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, false, true);
-
-		// resize bigger bottom left only on X-coordinate
-		dragToX = dragFromX - RESIZE_MOVE_DISTANCE;
-		dragToY = dragFromY;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, true, true);
-
-		// resize smaller bottom left only on X-coordinate
-		dragToX = dragFromX + RESIZE_MOVE_DISTANCE;
-		dragToY = dragFromY;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, true, false, true);
-
-		// resize bigger center left
-		dragToX = dragFromX - RESIZE_MOVE_DISTANCE;
-		dragFromY = rectPosition.y;
-		dragToY = dragFromY;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, false, true, false);
-
-		// resize smaller center left
-		dragToX = dragFromX + RESIZE_MOVE_DISTANCE;
-		doResize(dragFromX, dragToX, dragFromY, dragToY, true, false, false, false);
-	}
-
-	@UiThreadTest
 	@Test
 	public void testResizeRectangleMinimumSizeBiggerThanMargin() {
+		when(workspace.contains(any(PointF.class))).thenReturn(true);
+
 		float rectWidth = toolToTest.boxWidth;
 		float rectHeight = toolToTest.boxHeight;
 		PointF rectPosition = toolToTest.toolPosition;
@@ -241,11 +129,10 @@ public class BaseToolWithRectangleShapeToolTest {
 		float newHeight = toolToTest.boxHeight;
 		float boxResizeMargin = BaseToolWithRectangleShape.DEFAULT_BOX_RESIZE_MARGIN;
 
-		assertTrue("new width should be bigger or equal to the resize margin", newWidth >= boxResizeMargin);
-		assertTrue("new height should be bigger or equal to the resize margin", newHeight >= boxResizeMargin);
+		assertThat(newHeight, is(greaterThanOrEqualTo(boxResizeMargin)));
+		assertThat(newWidth, is(greaterThanOrEqualTo(boxResizeMargin)));
 	}
 
-	@UiThreadTest
 	@Test
 	public void testMoveRectangle() {
 		float rectWidth = toolToTest.boxWidth;
@@ -270,12 +157,10 @@ public class BaseToolWithRectangleShapeToolTest {
 		assertTrue("position should have moved", (newPosition.x == dragToX) && (newPosition.y == dragToY));
 	}
 
-	@UiThreadTest
 	@Test
 	public void testRectangleSizeMaximumWhenZoomed() {
 
-		float scale = 0.8f;
-		perspective.setScale(scale);
+		when(workspace.getScale()).thenReturn(0.8f, 0.15f, 0.1f);
 
 		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.SHAPE,
 				toolPaint, workspace, commandManager);
@@ -284,9 +169,6 @@ public class BaseToolWithRectangleShapeToolTest {
 		float height = toolToTest.boxHeight;
 
 		assertEquals("Width and Height should be the same with activating Rectangletool on low zoom out", width, height, Double.MIN_VALUE);
-
-		scale = 0.15f;
-		perspective.setScale(scale);
 
 		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.SHAPE,
 				toolPaint, workspace, commandManager);
@@ -297,9 +179,6 @@ public class BaseToolWithRectangleShapeToolTest {
 		assertNotSame(
 				"With zooming out a lot, height and width should not be the same anymore and adjust the ratio to the drawinSurface",
 				width, height);
-
-		scale = 0.1f;
-		perspective.setScale(scale);
 
 		toolToTest = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.SHAPE,
 				toolPaint, workspace, commandManager);
@@ -316,40 +195,31 @@ public class BaseToolWithRectangleShapeToolTest {
 				newHeight, height, Double.MIN_VALUE);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testRectangleSizeChangeWhenZoomedLevel1ToLevel2() {
-		float scale = 1f;
-		perspective.setScale(scale);
+		when(workspace.getScale()).thenReturn(1f, 2f);
 		BaseToolWithRectangleShape rectTool1 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
-		scale = 2f;
-		perspective.setScale(scale);
-
 		BaseToolWithRectangleShape rectTool2 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
+
 		assertTrue("rectangle should be smaller with scale 2",
 				(rectTool1.boxWidth > rectTool2.boxWidth)
 						&& (rectTool1.boxHeight > rectTool2.boxHeight));
 	}
 
-	@UiThreadTest
 	@Test
 	public void testRectangleSizeChangeWhenZoomedLevel1ToLevel05() {
-		float scale = 1f;
-		perspective.setScale(scale);
+		when(workspace.getScale()).thenReturn(1f, 0.5f);
 
 		BaseToolWithRectangleShape rectTool1 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
-		scale = 0.5f;
-		perspective.setScale(scale);
 		BaseToolWithRectangleShape rectTool05 = new BaseToolWithRectangleShapeImpl(contextCallback, toolOptionsController, ToolType.BRUSH,
 				toolPaint, workspace, commandManager);
 		assertThat(rectTool1.boxWidth, is(lessThan(rectTool05.boxWidth)));
 		assertThat(rectTool1.boxHeight, is(lessThan(rectTool05.boxHeight)));
 	}
 
-	@UiThreadTest
 	@Test
 	public void testRotateRectangleRight() {
 
@@ -368,10 +238,8 @@ public class BaseToolWithRectangleShapeToolTest {
 		assertThat(newRotation, is(greaterThan(rotation)));
 	}
 
-	@UiThreadTest
 	@Test
 	public void testRotateRectangleLeft() {
-
 		toolToTest.rotationEnabled = true;
 		toolToTest.handleDown(toolPosition);
 		toolToTest.handleUp(toolPosition);
@@ -381,13 +249,12 @@ public class BaseToolWithRectangleShapeToolTest {
 
 		// try rotate left
 		toolToTest.handleDown(topLeftRotationPoint);
-		toolToTest.handleMove(new PointF(topLeftRotationPoint.x, screenHeight / 2));
-		toolToTest.handleUp(new PointF(topLeftRotationPoint.x, screenHeight / 2));
+		toolToTest.handleMove(new PointF(topLeftRotationPoint.x, screenHeight / 2f));
+		toolToTest.handleUp(new PointF(topLeftRotationPoint.x, screenHeight / 2f));
 		float newRotation = toolToTest.boxRotation;
 		assertThat(newRotation, is(lessThan(rotation)));
 	}
 
-	@UiThreadTest
 	@Test
 	public void testRotateRectangle() {
 
@@ -437,7 +304,6 @@ public class BaseToolWithRectangleShapeToolTest {
 		assertEquals("Rotation value should be 0 degree.", newRotation, 0, Float.MIN_VALUE);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testRotateOnlyNearCorner() {
 
@@ -464,7 +330,6 @@ public class BaseToolWithRectangleShapeToolTest {
 		assertNotEquals("Rectangle should rotate.", newRotation, 0);
 	}
 
-	@UiThreadTest
 	@Test
 	public void testIsClickInsideBoxCalculatedCorrect() {
 		PointF topLeftCorner = new PointF(toolPosition.x - rectWidth / 2 + 20,
@@ -505,65 +370,11 @@ public class BaseToolWithRectangleShapeToolTest {
 		assertEquals(toolToTest.toolPosition.y, initialToolPositionY, 0);
 	}
 
-	private void doResize(float dragFromX, float dragToX, float dragFromY, float dragToY, boolean resizeWidth,
-			boolean resizeHeight, boolean resizeBigger, boolean isCorner) {
-
-		float rectWidth = toolToTest.boxWidth;
-		float rectHeight = toolToTest.boxHeight;
-		PointF rectPosition = toolToTest.toolPosition;
-
-		PointF pointDown = new PointF(dragFromX, dragFromY);
-		PointF pointMoveTo = new PointF(dragToX, dragToY);
-
-		toolToTest.handleDown(pointDown);
-		toolToTest.handleMove(pointMoveTo);
-		toolToTest.handleUp(pointMoveTo);
-
-		float newWidth = toolToTest.boxWidth;
-		float newHeight = toolToTest.boxHeight;
-		PointF newPosition = toolToTest.toolPosition;
-
-		if (resizeBigger) {
-			if (resizeWidth) {
-				assertTrue("new width should be bigger", newWidth > rectWidth);
-			} else {
-				assertEquals("height should not have changed", newWidth, rectWidth, Float.MIN_VALUE);
-			}
-			if (resizeHeight) {
-				assertTrue("new width should be bigger", newHeight > rectHeight);
-			} else {
-				assertEquals("height should not have changed", newHeight, rectHeight, Float.MIN_VALUE);
-			}
-			if (isCorner) {
-				assertEquals("resizing should be in aspect ratio", newHeight, newWidth, Float.MIN_VALUE);
-			}
-		} else {
-			if (resizeWidth) {
-				assertTrue("new height should be smaller", newWidth < rectWidth);
-			} else {
-				assertEquals("height should not have changed", newWidth, rectWidth, Float.MIN_VALUE);
-			}
-			if (resizeHeight) {
-				assertTrue("new width should be smaller", newHeight < rectHeight);
-			} else {
-				assertEquals("height should not have changed", newHeight, rectHeight, Float.MIN_VALUE);
-			}
-			if (isCorner) {
-				assertEquals("resizing should be in aspect ratio", newHeight, newWidth, Float.MIN_VALUE);
-			}
-		}
-
-		assertEquals("position should be the same", newPosition.x, rectPosition.x, Float.MIN_VALUE);
-		assertEquals("position should be the same", newPosition.y, rectPosition.y, Float.MIN_VALUE);
-		toolToTest.boxWidth = rectWidth;
-		toolToTest.boxHeight = rectHeight;
-	}
-
 	private class BaseToolWithRectangleShapeImpl extends BaseToolWithRectangleShape {
 		private final ToolType toolType;
 
-		BaseToolWithRectangleShapeImpl(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
-				ToolType toolType, ToolPaint toolPaint, Workspace layerModelWrapper, CommandManager commandManager) {
+		BaseToolWithRectangleShapeImpl(ContextCallback contextCallback, ToolOptionsController toolOptionsController, ToolType toolType, ToolPaint toolPaint,
+				Workspace layerModelWrapper, CommandManager commandManager) {
 			super(contextCallback, toolOptionsController, toolPaint, layerModelWrapper, commandManager);
 			this.toolType = toolType;
 		}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BrushToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BrushToolTest.java
@@ -37,8 +37,8 @@ import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.common.Constants;
 import org.catrobat.paintroid.tools.implementation.BrushTool;
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,9 +66,9 @@ public class BrushToolTest {
 	@Mock
 	private ToolPaint toolPaint;
 	@Mock
-	private BrushToolOptions brushToolOptions;
+	private BrushToolOptionsView brushToolOptionsView;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private Workspace workspace;
 	@Mock
@@ -79,7 +79,7 @@ public class BrushToolTest {
 
 	@Before
 	public void setUp() {
-		toolToTest = new BrushTool(brushToolOptions, contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		toolToTest = new BrushTool(brushToolOptionsView, contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
 		paint = new Paint();
 		paint.setColor(Color.BLACK);
@@ -317,10 +317,10 @@ public class BrushToolTest {
 
 	@Test
 	public void testShouldChangePaintFromBrushPicker() {
-		ArgumentCaptor<BrushToolOptions.OnBrushChangedListener> argumentCaptor =
-				ArgumentCaptor.forClass(BrushToolOptions.OnBrushChangedListener.class);
-		verify(brushToolOptions).setBrushChangedListener(argumentCaptor.capture());
-		BrushToolOptions.OnBrushChangedListener onBrushChangedListener = argumentCaptor.getValue();
+		ArgumentCaptor<BrushToolOptionsView.OnBrushChangedListener> argumentCaptor =
+				ArgumentCaptor.forClass(BrushToolOptionsView.OnBrushChangedListener.class);
+		verify(brushToolOptionsView).setBrushChangedListener(argumentCaptor.capture());
+		BrushToolOptionsView.OnBrushChangedListener onBrushChangedListener = argumentCaptor.getValue();
 
 		onBrushChangedListener.setCap(Paint.Cap.ROUND);
 		onBrushChangedListener.setStrokeWidth(15);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/CursorToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/CursorToolTest.java
@@ -34,8 +34,8 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.common.Constants;
 import org.catrobat.paintroid.tools.implementation.CursorTool;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,9 +65,9 @@ public class CursorToolTest {
 	@Mock
 	private Workspace workspace;
 	@Mock
-	private BrushToolOptions brushToolOptions;
+	private BrushToolOptionsView brushToolOptionsView;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 
@@ -80,7 +80,7 @@ public class CursorToolTest {
 		when(workspace.getHeight()).thenReturn(1920);
 		when(workspace.getWidth()).thenReturn(1080);
 
-		toolToTest = new CursorTool(brushToolOptions, contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		toolToTest = new CursorTool(brushToolOptionsView, contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTest.java
@@ -27,8 +27,8 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.FillTool;
-import org.catrobat.paintroid.tools.options.FillToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.FillToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -40,11 +40,11 @@ import static org.junit.Assert.assertEquals;
 @RunWith(MockitoJUnitRunner.class)
 public class FillToolTest {
 	@Mock
-	public FillToolOptions fillToolOptions;
+	public FillToolOptionsView fillToolOptions;
 	@Mock
 	public ContextCallback contextCallback;
 	@Mock
-	public ToolOptionsController toolOptionsController;
+	public ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	public Workspace workspace;
 	@Mock

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
@@ -28,7 +28,7 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.ImportTool;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +47,7 @@ public class ImportToolTest {
 	@Mock
 	private ToolPaint toolPaint;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock
@@ -73,7 +73,7 @@ public class ImportToolTest {
 		when(workspace.getHeight()).thenReturn(30);
 		when(workspace.getScale()).thenReturn(1f);
 
-		tool = new ImportTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		tool = new ImportTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.java
@@ -26,8 +26,8 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.LineTool;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,9 +45,9 @@ public class LineToolTest {
 	@Mock
 	private ToolPaint toolPaint;
 	@Mock
-	private BrushToolOptions brushToolOptions;
+	private BrushToolOptionsView brushToolOptions;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsController;
 	@Mock
 	private Workspace workspace;
 	@Mock

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
@@ -30,7 +30,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.PipetteTool;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,7 +64,7 @@ public class PipetteToolTest {
 	@Mock
 	private Workspace workspace;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 
@@ -87,7 +87,7 @@ public class PipetteToolTest {
 			}
 		});
 
-		toolToTest = new PipetteTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager, listener);
+		toolToTest = new PipetteTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager, listener);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
@@ -27,8 +27,8 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.ShapeTool;
-import org.catrobat.paintroid.tools.options.ShapeToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ShapeToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,9 +54,9 @@ public class ShapeToolTest {
 	@Mock
 	private CommandManager commandManager;
 	@Mock
-	private ShapeToolOptions shapeToolOptions;
+	private ShapeToolOptionsView shapeToolOptions;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock
@@ -87,7 +87,7 @@ public class ShapeToolTest {
 		displayMetrics.widthPixels = 100;
 		displayMetrics.heightPixels = 100;
 
-		shapeTool = new ShapeTool(shapeToolOptions, contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		shapeTool = new ShapeTool(shapeToolOptions, contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 		shapeTool.baseShape = shape;
 	}
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
@@ -19,103 +19,87 @@
 
 package org.catrobat.paintroid.test.junit.tools;
 
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.annotation.UiThreadTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import android.util.DisplayMetrics;
 
-import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.tools.ContextCallback;
-import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.implementation.DefaultContextCallback;
 import org.catrobat.paintroid.tools.implementation.ShapeTool;
+import org.catrobat.paintroid.tools.options.ShapeToolOptions;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 public class ShapeToolTest {
-
-	@Rule
-	public ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class);
-
 	@Rule
 	public MockitoRule mockito = MockitoJUnit.rule();
-
+	@Parameter
+	public ShapeTool.BaseShape shape;
 	@Mock
 	private CommandManager commandManager;
+	@Mock
+	private ShapeToolOptions shapeToolOptions;
+	@Mock
+	private ToolOptionsController toolOptionsController;
+	@Mock
+	private ContextCallback contextCallback;
+	@Mock
+	private Workspace workspace;
+	@Mock
+	private ToolPaint toolPaint;
+	@Mock
+	private DisplayMetrics displayMetrics;
+	private ShapeTool shapeTool;
 
-	private ShapeTool rectangleShapeTool;
-	private ShapeTool ovalShapeTool;
-	private ShapeTool heartShapeTool;
-	private ShapeTool starShapeTool;
+	@Parameters(name = "{0}")
+	public static Iterable<ShapeTool.BaseShape> data() {
+		return Arrays.asList(
+				ShapeTool.BaseShape.RECTANGLE,
+				ShapeTool.BaseShape.OVAL,
+				ShapeTool.BaseShape.HEART,
+				ShapeTool.BaseShape.STAR
+		);
+	}
 
-	@UiThreadTest
 	@Before
 	public void setUp() {
-		MainActivity activity = activityTestRule.getActivity();
-		Workspace workspace = activity.workspace;
-		ToolPaint toolPaint = activity.toolPaint;
-		ToolOptionsController toolOptionsController = activity.toolOptionsController;
-		ContextCallback contextCallback = new DefaultContextCallback(InstrumentationRegistry.getTargetContext());
+		when(workspace.getWidth()).thenReturn(100);
+		when(workspace.getHeight()).thenReturn(100);
+		when(workspace.getScale()).thenReturn(1f);
 
-		rectangleShapeTool = new ShapeTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-		rectangleShapeTool.baseShape = ShapeTool.BaseShape.RECTANGLE;
+		when(contextCallback.getDisplayMetrics()).thenReturn(displayMetrics);
+		displayMetrics.widthPixels = 100;
+		displayMetrics.heightPixels = 100;
 
-		ovalShapeTool = new ShapeTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-		ovalShapeTool.baseShape = ShapeTool.BaseShape.OVAL;
-
-		heartShapeTool = new ShapeTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-		heartShapeTool.baseShape = ShapeTool.BaseShape.HEART;
-
-		starShapeTool = new ShapeTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-		starShapeTool.baseShape = ShapeTool.BaseShape.STAR;
+		shapeTool = new ShapeTool(shapeToolOptions, contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		shapeTool.baseShape = shape;
 	}
 
-	@UiThreadTest
 	@Test
 	public void testShouldReturnCorrectToolType() {
-		ToolType toolTypeRect = rectangleShapeTool.getToolType();
-		assertEquals(ToolType.SHAPE, toolTypeRect);
-		toolTypeRect = ovalShapeTool.getToolType();
-		assertEquals(ToolType.SHAPE, toolTypeRect);
-		toolTypeRect = heartShapeTool.getToolType();
-		assertEquals(ToolType.SHAPE, toolTypeRect);
-		toolTypeRect = starShapeTool.getToolType();
-		assertEquals(ToolType.SHAPE, toolTypeRect);
-
-		ShapeTool.BaseShape rectangleShape = rectangleShapeTool.getBaseShape();
-		assertEquals(ShapeTool.BaseShape.RECTANGLE, rectangleShape);
-		ShapeTool.BaseShape ovalShape = ovalShapeTool.getBaseShape();
-		assertEquals(ShapeTool.BaseShape.OVAL, ovalShape);
-		ShapeTool.BaseShape heartShape = heartShapeTool.getBaseShape();
-		assertEquals(ShapeTool.BaseShape.HEART, heartShape);
-		ShapeTool.BaseShape starShape = starShapeTool.getBaseShape();
-		assertEquals(ShapeTool.BaseShape.STAR, starShape);
+		ToolType toolType = shapeTool.getToolType();
+		assertEquals(ToolType.SHAPE, toolType);
 	}
 
-	@UiThreadTest
 	@Test
-	public void testColorChangeWorks() {
-		Paint red = new Paint();
-		red.setColor(Color.RED);
-		rectangleShapeTool.setDrawPaint(red);
-		MainActivity activity = activityTestRule.getActivity();
-		Tool currentTool = activity.toolReference.get();
-		int color = currentTool.getDrawPaint().getColor();
-		assertEquals("Red colour expected", Color.RED, color);
+	public void testShouldReturnCorrectBaseShape() {
+		ShapeTool.BaseShape baseShape = shapeTool.getBaseShape();
+		assertEquals(shape, baseShape);
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
@@ -33,7 +33,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.StampTool;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +55,7 @@ public class StampToolTest {
 	@Mock
 	private Workspace workspace;
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock
@@ -78,7 +78,7 @@ public class StampToolTest {
 			}
 		});
 
-		tool = new StampTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		tool = new StampTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 	}
 
 	@Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -72,7 +72,7 @@ import org.catrobat.paintroid.tools.implementation.DefaultToolFactory;
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint;
 import org.catrobat.paintroid.tools.implementation.DefaultToolReference;
 import org.catrobat.paintroid.tools.implementation.DefaultWorkspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.BottomBarHorizontalScrollView;
 import org.catrobat.paintroid.ui.DrawingSurface;
 import org.catrobat.paintroid.ui.KeyboardListener;
@@ -82,7 +82,7 @@ import org.catrobat.paintroid.ui.MainActivityInteractor;
 import org.catrobat.paintroid.ui.MainActivityNavigator;
 import org.catrobat.paintroid.ui.Perspective;
 import org.catrobat.paintroid.ui.dragndrop.DragAndDropListView;
-import org.catrobat.paintroid.ui.tools.DefaultToolOptionsController;
+import org.catrobat.paintroid.ui.tools.DefaultToolOptionsViewController;
 import org.catrobat.paintroid.ui.viewholder.BottomBarViewHolder;
 import org.catrobat.paintroid.ui.viewholder.DrawerLayoutViewHolder;
 import org.catrobat.paintroid.ui.viewholder.LayerMenuViewHolder;
@@ -122,7 +122,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 	@VisibleForTesting
 	public ToolReference toolReference;
 	@VisibleForTesting
-	public ToolOptionsController toolOptionsController;
+	public ToolOptionsViewController toolOptionsViewController;
 
 	private LayerPresenter layerPresenter;
 	private DrawingSurface drawingSurface;
@@ -240,7 +240,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 		View bottomBarLayout = findViewById(R.id.pocketpaint_main_bottom_bar);
 		NavigationView navigationView = findViewById(R.id.pocketpaint_nav_view);
 
-		toolOptionsController = new DefaultToolOptionsController(this);
+		toolOptionsViewController = new DefaultToolOptionsViewController(this);
 		drawerLayoutViewHolder = new DrawerLayoutViewHolder(drawerLayout);
 		TopBarViewHolder topBarViewHolder = new TopBarViewHolder(topBarLayout);
 		BottomBarViewHolder bottomBarViewHolder = new BottomBarViewHolder(bottomBarLayout);
@@ -258,7 +258,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 		MainActivityContracts.Interactor interactor = new MainActivityInteractor();
 		model = new MainActivityModel();
 		ContextCallback contextCallback = new DefaultContextCallback(getApplicationContext());
-		ToolController toolController = new DefaultToolController(toolReference, toolOptionsController,
+		ToolController toolController = new DefaultToolController(toolReference, toolOptionsViewController,
 				new DefaultToolFactory(), commandManager, workspace, toolPaint, contextCallback);
 		presenter = new MainActivityPresenter(this, model, workspace,
 				navigator, interactor, topBarViewHolder, bottomBarViewHolder, drawerLayoutViewHolder,
@@ -291,7 +291,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 
 	private void onCreateDrawingSurface() {
 		drawingSurface = findViewById(R.id.pocketpaint_drawing_surface_view);
-		drawingSurface.setArguments(layerModel, perspective, toolReference, toolOptionsController);
+		drawingSurface.setArguments(layerModel, perspective, toolReference, toolOptionsViewController);
 
 		appFragment.setPerspective(perspective);
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -54,15 +54,21 @@ import org.catrobat.paintroid.command.implementation.DefaultCommandManager;
 import org.catrobat.paintroid.common.CommonFactory;
 import org.catrobat.paintroid.contract.LayerContracts;
 import org.catrobat.paintroid.contract.MainActivityContracts;
+import org.catrobat.paintroid.controller.DefaultToolController;
+import org.catrobat.paintroid.controller.ToolController;
 import org.catrobat.paintroid.listener.BottomBarScrollListener;
+import org.catrobat.paintroid.listener.PresenterColorPickedListener;
 import org.catrobat.paintroid.model.LayerModel;
 import org.catrobat.paintroid.model.MainActivityModel;
 import org.catrobat.paintroid.presenter.LayerPresenter;
 import org.catrobat.paintroid.presenter.MainActivityPresenter;
+import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.tools.implementation.DefaultContextCallback;
+import org.catrobat.paintroid.tools.implementation.DefaultToolFactory;
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint;
 import org.catrobat.paintroid.tools.implementation.DefaultToolReference;
 import org.catrobat.paintroid.tools.implementation.DefaultWorkspace;
@@ -251,9 +257,13 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 		MainActivityContracts.Navigator navigator = new MainActivityNavigator(this, toolReference);
 		MainActivityContracts.Interactor interactor = new MainActivityInteractor();
 		model = new MainActivityModel();
-		presenter = new MainActivityPresenter(this, model, workspace, toolReference, toolOptionsController,
+		ContextCallback contextCallback = new DefaultContextCallback(getApplicationContext());
+		ToolController toolController = new DefaultToolController(toolReference, toolOptionsController,
+				new DefaultToolFactory(), commandManager, workspace, toolPaint, contextCallback);
+		presenter = new MainActivityPresenter(this, model, workspace,
 				navigator, interactor, topBarViewHolder, bottomBarViewHolder, drawerLayoutViewHolder,
-				navigationDrawerViewHolder, commandManager, toolPaint, perspective);
+				navigationDrawerViewHolder, new DefaultCommandFactory(), commandManager, perspective, toolController);
+		toolController.setOnColorPickedListener(new PresenterColorPickedListener(presenter));
 
 		keyboardListener = new KeyboardListener(drawerLayout);
 		setTopBarListeners(topBarViewHolder);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.java
@@ -1,0 +1,176 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.controller;
+
+import android.graphics.Bitmap;
+import android.graphics.Paint;
+import android.os.Bundle;
+
+import org.catrobat.paintroid.colorpicker.ColorPickerDialog;
+import org.catrobat.paintroid.command.CommandManager;
+import org.catrobat.paintroid.tools.ContextCallback;
+import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.tools.ToolFactory;
+import org.catrobat.paintroid.tools.ToolPaint;
+import org.catrobat.paintroid.tools.ToolReference;
+import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.tools.implementation.ImportTool;
+import org.catrobat.paintroid.tools.options.ToolOptionsController;
+
+import static org.catrobat.paintroid.tools.Tool.StateChange.NEW_IMAGE_LOADED;
+import static org.catrobat.paintroid.tools.Tool.StateChange.RESET_INTERNAL_STATE;
+
+public class DefaultToolController implements ToolController {
+	private ToolReference toolReference;
+	private ToolOptionsController toolOptionsController;
+	private ToolFactory toolFactory;
+	private CommandManager commandManager;
+	private Workspace workspace;
+	private ToolPaint toolPaint;
+	private ContextCallback contextCallback;
+	private ColorPickerDialog.OnColorPickedListener onColorPickedListener;
+
+	public DefaultToolController(ToolReference toolReference, ToolOptionsController toolOptionsController,
+			ToolFactory toolFactory, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint,
+			ContextCallback contextCallback) {
+		this.toolReference = toolReference;
+		this.toolOptionsController = toolOptionsController;
+		this.toolFactory = toolFactory;
+		this.commandManager = commandManager;
+		this.workspace = workspace;
+		this.toolPaint = toolPaint;
+		this.contextCallback = contextCallback;
+	}
+
+	@Override
+	public void setOnColorPickedListener(ColorPickerDialog.OnColorPickedListener onColorPickedListener) {
+		this.onColorPickedListener = onColorPickedListener;
+	}
+
+	@Override
+	public void switchTool(ToolType toolType) {
+		Tool tool = toolFactory.createTool(toolType, toolOptionsController, commandManager, workspace, toolPaint, contextCallback, onColorPickedListener);
+		switchTool(tool);
+	}
+
+	@Override
+	public boolean isDefaultTool() {
+		return toolReference.get().getToolType() == ToolType.BRUSH;
+	}
+
+	@Override
+	public void hideToolOptions() {
+		toolOptionsController.hideAnimated();
+	}
+
+	@Override
+	public boolean toolOptionsVisible() {
+		return toolOptionsController.isVisible();
+	}
+
+	@Override
+	public void resetToolInternalState() {
+		toolReference.get().resetInternalState(RESET_INTERNAL_STATE);
+	}
+
+	@Override
+	public void resetToolInternalStateOnImageLoaded() {
+		toolReference.get().resetInternalState(NEW_IMAGE_LOADED);
+	}
+
+	@Override
+	public int getToolColor() {
+		return toolReference.get().getDrawPaint().getColor();
+	}
+
+	private void switchTool(Tool tool) {
+		Bundle toolBundle = new Bundle();
+		Tool currentTool = toolReference.get();
+		Paint tempPaint = currentTool.getDrawPaint();
+
+		currentTool.leaveTool();
+		if (currentTool.getToolType() == tool.getToolType()) {
+			currentTool.onSaveInstanceState(toolBundle);
+			toolReference.set(tool);
+			tool.onRestoreInstanceState(toolBundle);
+		} else {
+			toolBundle.clear();
+			toolReference.set(tool);
+		}
+		tool.startTool();
+		tool.setDrawPaint(tempPaint);
+	}
+
+	@Override
+	public ToolType getToolType() {
+		return toolReference.get().getToolType();
+	}
+
+	@Override
+	public void disableToolOptions() {
+		toolOptionsController.disable();
+	}
+
+	@Override
+	public void enableToolOptions() {
+		toolOptionsController.enable();
+	}
+
+	@Override
+	public void createTool() {
+		Bundle bundle = new Bundle();
+
+		if (toolReference.get() == null) {
+			toolReference.set(toolFactory.createTool(ToolType.BRUSH,
+					toolOptionsController, commandManager, workspace, toolPaint, contextCallback, onColorPickedListener));
+			toolReference.get().startTool();
+		} else {
+			Paint paint = toolReference.get().getDrawPaint();
+			toolReference.get().leaveTool();
+			toolReference.get().onSaveInstanceState(bundle);
+			toolReference.set(toolFactory.createTool(toolReference.get().getToolType(),
+					toolOptionsController, commandManager, workspace, toolPaint, contextCallback, onColorPickedListener));
+			toolReference.get().onRestoreInstanceState(bundle);
+			toolReference.get().startTool();
+			toolReference.get().setDrawPaint(paint);
+		}
+	}
+
+	@Override
+	public void toggleToolOptions() {
+		if (toolOptionsController.isVisible()) {
+			toolOptionsController.hideAnimated();
+		} else {
+			toolOptionsController.showAnimated();
+		}
+	}
+
+	@Override
+	public boolean hasToolOptions() {
+		return getToolType().hasOptions();
+	}
+
+	@Override
+	public void setBitmapFromFile(Bitmap bitmap) {
+		ImportTool importTool = (ImportTool) toolReference.get();
+		importTool.setBitmapFromFile(bitmap);
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
@@ -17,12 +17,41 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.tools;
+package org.catrobat.paintroid.controller;
+
+import android.graphics.Bitmap;
 
 import org.catrobat.paintroid.colorpicker.ColorPickerDialog;
-import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.ToolType;
 
-public interface ToolFactory {
-	Tool createTool(ToolType toolType, ToolOptionsController toolOptionsController, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint, ContextCallback contextCallback, ColorPickerDialog.OnColorPickedListener onColorPickedListener);
+public interface ToolController {
+	void setOnColorPickedListener(ColorPickerDialog.OnColorPickedListener onColorPickedListener);
+
+	void switchTool(ToolType toolType);
+
+	boolean isDefaultTool();
+
+	void hideToolOptions();
+
+	boolean toolOptionsVisible();
+
+	void resetToolInternalState();
+
+	void resetToolInternalStateOnImageLoaded();
+
+	int getToolColor();
+
+	ToolType getToolType();
+
+	void disableToolOptions();
+
+	void enableToolOptions();
+
+	void createTool();
+
+	void toggleToolOptions();
+
+	boolean hasToolOptions();
+
+	void setBitmapFromFile(Bitmap bitmap);
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
@@ -31,9 +31,9 @@ public interface ToolController {
 
 	boolean isDefaultTool();
 
-	void hideToolOptions();
+	void hideToolOptionsView();
 
-	boolean toolOptionsVisible();
+	boolean toolOptionsViewVisible();
 
 	void resetToolInternalState();
 
@@ -43,15 +43,15 @@ public interface ToolController {
 
 	ToolType getToolType();
 
-	void disableToolOptions();
+	void disableToolOptionsView();
 
-	void enableToolOptions();
+	void enableToolOptionsView();
 
 	void createTool();
 
-	void toggleToolOptions();
+	void toggleToolOptionsView();
 
-	boolean hasToolOptions();
+	boolean hasToolOptionsView();
 
 	void setBitmapFromFile(Bitmap bitmap);
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.java
@@ -29,7 +29,7 @@ import android.view.View.OnTouchListener;
 import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.Tool.StateChange;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.DrawingSurface;
 
 import java.util.EnumSet;
@@ -96,10 +96,10 @@ public class DrawingSurfaceListener implements OnTouchListener {
 
 	@Override
 	public boolean onTouch(View view, MotionEvent event) {
-		ToolOptionsController toolOptionsController = callback.getToolOptionsController();
+		ToolOptionsViewController toolOptionsViewController = callback.getToolOptionsViewController();
 
-		if (toolOptionsController.isVisible()) {
-			toolOptionsController.hideAnimated();
+		if (toolOptionsViewController.isVisible()) {
+			toolOptionsViewController.hideAnimated();
 			return false;
 		}
 
@@ -311,6 +311,6 @@ public class DrawingSurfaceListener implements OnTouchListener {
 
 		void convertToCanvasFromSurface(PointF surfacePoint);
 
-		ToolOptionsController getToolOptionsController();
+		ToolOptionsViewController getToolOptionsViewController();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/PresenterColorPickedListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/PresenterColorPickedListener.java
@@ -1,0 +1,17 @@
+package org.catrobat.paintroid.listener;
+
+import org.catrobat.paintroid.colorpicker.ColorPickerDialog;
+import org.catrobat.paintroid.contract.MainActivityContracts;
+
+public class PresenterColorPickedListener implements ColorPickerDialog.OnColorPickedListener {
+	private final MainActivityContracts.Presenter presenter;
+
+	public PresenterColorPickedListener(MainActivityContracts.Presenter presenter) {
+		this.presenter = presenter;
+	}
+
+	@Override
+	public void colorChanged(int color) {
+		presenter.setTopBarColor(color);
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -315,8 +315,8 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 			drawerLayoutViewHolder.closeDrawer(Gravity.END, true);
 		} else if (model.isFullscreen()) {
 			exitFullscreenClicked();
-		} else if (toolController.toolOptionsVisible()) {
-			toolController.hideToolOptions();
+		} else if (toolController.toolOptionsViewVisible()) {
+			toolController.hideToolOptionsView();
 		} else if (!toolController.isDefaultTool()) {
 			setTool(ToolType.BRUSH);
 			toolController.switchTool(ToolType.BRUSH);
@@ -335,8 +335,8 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	public void undoClicked() {
 		if (view.isKeyboardShown()) {
 			view.hideKeyboard();
-		} else if (toolController.toolOptionsVisible()) {
-			toolController.hideToolOptions();
+		} else if (toolController.toolOptionsViewVisible()) {
+			toolController.hideToolOptionsView();
 		} else {
 			commandManager.undo();
 		}
@@ -346,8 +346,8 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	public void redoClicked() {
 		if (view.isKeyboardShown()) {
 			view.hideKeyboard();
-		} else if (toolController.toolOptionsVisible()) {
-			toolController.hideToolOptions();
+		} else if (toolController.toolOptionsViewVisible()) {
+			toolController.hideToolOptionsView();
 		} else {
 			commandManager.redo();
 		}
@@ -442,7 +442,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		bottomBarViewHolder.show();
 		navigationDrawerViewHolder.hideExitFullscreen();
 		navigationDrawerViewHolder.showEnterFullscreen();
-		toolController.enableToolOptions();
+		toolController.enableToolOptionsView();
 		perspective.exitFullscreen();
 	}
 
@@ -453,7 +453,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		bottomBarViewHolder.hide();
 		navigationDrawerViewHolder.showExitFullscreen();
 		navigationDrawerViewHolder.hideEnterFullscreen();
-		toolController.disableToolOptions();
+		toolController.disableToolOptionsView();
 		perspective.enterFullscreen();
 	}
 
@@ -494,8 +494,8 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	public void toolClicked(ToolType type) {
 		bottomBarViewHolder.cancelAnimation();
 
-		if (toolController.getToolType() == type && toolController.hasToolOptions()) {
-			toolController.toggleToolOptions();
+		if (toolController.getToolType() == type && toolController.hasToolOptionsView()) {
+			toolController.toggleToolOptionsView();
 		} else if (view.isKeyboardShown()) {
 			view.hideKeyboard();
 		} else {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolFactory.java
@@ -21,8 +21,10 @@ package org.catrobat.paintroid.tools;
 
 import org.catrobat.paintroid.colorpicker.ColorPickerDialog;
 import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public interface ToolFactory {
-	Tool createTool(ToolType toolType, ToolOptionsController toolOptionsController, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint, ContextCallback contextCallback, ColorPickerDialog.OnColorPickedListener onColorPickedListener);
+	Tool createTool(ToolType toolType, ToolOptionsViewController toolOptionsViewController, CommandManager commandManager,
+			Workspace workspace, ToolPaint toolPaint, ContextCallback contextCallback,
+			ColorPickerDialog.OnColorPickedListener onColorPickedListener);
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushChangedListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushChangedListener.java
@@ -22,9 +22,9 @@ package org.catrobat.paintroid.tools.common;
 import android.graphics.Paint;
 
 import org.catrobat.paintroid.tools.Tool;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
 
-public class CommonBrushChangedListener implements BrushToolOptions.OnBrushChangedListener {
+public class CommonBrushChangedListener implements BrushToolOptionsView.OnBrushChangedListener {
 	private Tool tool;
 
 	public CommonBrushChangedListener(Tool tool) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushPreviewListener.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/CommonBrushPreviewListener.java
@@ -23,9 +23,9 @@ import android.graphics.Paint;
 
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
 
-public class CommonBrushPreviewListener implements BrushToolOptions.OnBrushPreviewListener {
+public class CommonBrushPreviewListener implements BrushToolOptionsView.OnBrushPreviewListener {
 	private ToolType toolType;
 	private ToolPaint toolPaint;
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.java
@@ -38,7 +38,7 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public abstract class BaseTool implements Tool {
 	protected final int scrollTolerance;
@@ -49,14 +49,14 @@ public abstract class BaseTool implements Tool {
 	protected CommandManager commandManager;
 	protected Workspace workspace;
 	protected ContextCallback contextCallback;
-	protected ToolOptionsController toolOptionsController;
+	protected ToolOptionsViewController toolOptionsViewController;
 	protected ToolPaint toolPaint;
 	protected Shader checkeredShader;
 
-	public BaseTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public BaseTool(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
 		this.contextCallback = contextCallback;
-		this.toolOptionsController = toolOptionsController;
+		this.toolOptionsViewController = toolOptionsViewController;
 		this.toolPaint = toolPaint;
 		this.workspace = workspace;
 		this.commandManager = commandManager;
@@ -67,7 +67,7 @@ public abstract class BaseTool implements Tool {
 		movedDistance = new PointF(0f, 0f);
 		previousEventCoordinate = new PointF(0f, 0f);
 
-		toolSpecificOptionsLayout = toolOptionsController.getToolSpecificOptionsLayout();
+		toolSpecificOptionsLayout = toolOptionsViewController.getToolSpecificOptionsLayout();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -43,7 +43,7 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ContextCallback.ScreenOrientation;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 import static org.catrobat.paintroid.common.Constants.INVALID_RESOURCE_ID;
 
@@ -119,9 +119,9 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 	protected float touchDownPositionX;
 	protected float touchDownPositionY;
 
-	public BaseToolWithRectangleShape(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public BaseToolWithRectangleShape(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
 		ScreenOrientation orientation = contextCallback.getOrientation();
 		float boxSize = orientation == ScreenOrientation.PORTRAIT

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
@@ -33,7 +33,7 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolWithShape;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public abstract class BaseToolWithShape extends BaseTool implements ToolWithShape {
 
@@ -49,9 +49,9 @@ public abstract class BaseToolWithShape extends BaseTool implements ToolWithShap
 	final Paint linePaint;
 	final DisplayMetrics metrics;
 
-	public BaseToolWithShape(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public BaseToolWithShape(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
 		metrics = contextCallback.getDisplayMetrics();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.java
@@ -34,8 +34,8 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.common.CommonBrushChangedListener;
 import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 import static org.catrobat.paintroid.tools.common.Constants.MOVE_TOLERANCE;
 
@@ -46,21 +46,21 @@ public class BrushTool extends BaseTool {
 	protected final PointF drawToolMovedDistance;
 	protected PointF initialEventCoordinate;
 	protected boolean pathInsideBitmap;
-	protected BrushToolOptions brushToolOptions;
+	protected BrushToolOptionsView brushToolOptionsView;
 
-	public BrushTool(BrushToolOptions brushToolOptions, ContextCallback contextCallback,
-			ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace,
+	public BrushTool(BrushToolOptionsView brushToolOptionsView, ContextCallback contextCallback,
+			ToolOptionsViewController toolOptionsViewController, ToolPaint toolPaint, Workspace workspace,
 			CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-		this.brushToolOptions = brushToolOptions;
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
+		this.brushToolOptionsView = brushToolOptionsView;
 
 		pathToDraw = new Path();
 		pathToDraw.incReserve(1);
 		drawToolMovedDistance = new PointF(0f, 0f);
 		pathInsideBitmap = false;
 
-		brushToolOptions.setBrushChangedListener(new CommonBrushChangedListener(this));
-		brushToolOptions.setBrushPreviewListener(new CommonBrushPreviewListener(toolPaint, getToolType()));
+		brushToolOptionsView.setBrushChangedListener(new CommonBrushChangedListener(this));
+		brushToolOptionsView.setBrushPreviewListener(new CommonBrushPreviewListener(toolPaint, getToolType()));
 	}
 
 	@Override
@@ -91,7 +91,7 @@ public class BrushTool extends BaseTool {
 
 	@Override
 	public void setupToolOptions() {
-		brushToolOptions.setCurrentPaint(toolPaint.getPaint());
+		brushToolOptionsView.setCurrentPaint(toolPaint.getPaint());
 	}
 
 	@Override
@@ -181,6 +181,6 @@ public class BrushTool extends BaseTool {
 	@Override
 	public void changePaintColor(int color) {
 		super.changePaintColor(color);
-		brushToolOptions.invalidate();
+		brushToolOptionsView.invalidate();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.java
@@ -38,8 +38,8 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.common.CommonBrushChangedListener;
 import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 import static org.catrobat.paintroid.tools.common.Constants.MOVE_TOLERANCE;
 
@@ -58,12 +58,12 @@ public class CursorTool extends BaseToolWithShape {
 	public int cursorToolSecondaryShapeColor;
 	@VisibleForTesting
 	public boolean toolInDrawMode = false;
-	private BrushToolOptions brushToolOptions;
+	private BrushToolOptionsView brushToolOptionsView;
 
-	public CursorTool(BrushToolOptions brushToolOptions, ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public CursorTool(BrushToolOptionsView brushToolOptionsView, ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-		this.brushToolOptions = brushToolOptions;
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
+		this.brushToolOptionsView = brushToolOptionsView;
 
 		pathToDraw = new Path();
 		pathToDraw.incReserve(1);
@@ -71,8 +71,8 @@ public class CursorTool extends BaseToolWithShape {
 		cursorToolSecondaryShapeColor = Color.LTGRAY;
 		pointInsideBitmap = false;
 
-		brushToolOptions.setBrushChangedListener(new CommonBrushChangedListener(this));
-		brushToolOptions.setBrushPreviewListener(new CommonBrushPreviewListener(toolPaint, getToolType()));
+		brushToolOptionsView.setBrushChangedListener(new CommonBrushChangedListener(this));
+		brushToolOptionsView.setBrushPreviewListener(new CommonBrushPreviewListener(toolPaint, getToolType()));
 	}
 
 	@Override
@@ -81,8 +81,8 @@ public class CursorTool extends BaseToolWithShape {
 		if (toolInDrawMode) {
 			cursorToolSecondaryShapeColor = toolPaint.getColor();
 		}
-		if (brushToolOptions != null) {
-			brushToolOptions.invalidate();
+		if (brushToolOptionsView != null) {
+			brushToolOptionsView.invalidate();
 		}
 	}
 
@@ -346,6 +346,6 @@ public class CursorTool extends BaseToolWithShape {
 
 	@Override
 	public void setupToolOptions() {
-		brushToolOptions.setCurrentPaint(toolPaint.getPaint());
+		brushToolOptionsView.setCurrentPaint(toolPaint.getPaint());
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
@@ -19,13 +19,10 @@
 
 package org.catrobat.paintroid.tools.implementation;
 
-import android.app.Activity;
 import android.view.ViewGroup;
 
-import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.colorpicker.ColorPickerDialog;
 import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.contract.MainActivityContracts;
 import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolFactory;
@@ -34,31 +31,32 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.options.BrushToolOptions;
 import org.catrobat.paintroid.tools.options.FillToolOptions;
+import org.catrobat.paintroid.tools.options.ShapeToolOptions;
 import org.catrobat.paintroid.tools.options.TextToolOptions;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
 import org.catrobat.paintroid.tools.options.TransformToolOptions;
 import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptions;
 import org.catrobat.paintroid.ui.tools.DefaultFillToolOptions;
+import org.catrobat.paintroid.ui.tools.DefaultShapeToolOptions;
 import org.catrobat.paintroid.ui.tools.DefaultTextToolOptions;
 import org.catrobat.paintroid.ui.tools.DefaultTransformToolOptions;
 
 public class DefaultToolFactory implements ToolFactory {
 
 	@Override
-	public Tool createTool(ToolType toolType, ToolOptionsController toolOptionsController, Activity activity, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint) {
+	public Tool createTool(ToolType toolType, ToolOptionsController toolOptionsController, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint, ContextCallback contextCallback, ColorPickerDialog.OnColorPickedListener onColorPickedListener) {
 		Tool tool;
 
-		ContextCallback contextCallback = new DefaultContextCallback(activity.getApplicationContext());
 		toolOptionsController.removeToolViews();
 		toolOptionsController.setToolName(toolType.getNameResource());
-		ViewGroup toolSpecificOptionsLayout = toolOptionsController.getToolSpecificOptionsLayout();
+		ViewGroup toolLayout = toolOptionsController.getToolSpecificOptionsLayout();
 
 		switch (toolType) {
 			case BRUSH:
-				tool = new BrushTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new BrushTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case CURSOR:
-				tool = new CursorTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new CursorTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case STAMP:
 				tool = new StampTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
@@ -67,39 +65,31 @@ public class DefaultToolFactory implements ToolFactory {
 				tool = new ImportTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case PIPETTE:
-				final MainActivity mainActivity = (MainActivity) activity;
-				final MainActivityContracts.Presenter presenter = mainActivity.getPresenter();
-				ColorPickerDialog.OnColorPickedListener listener = new ColorPickerDialog.OnColorPickedListener() {
-					@Override
-					public void colorChanged(int color) {
-						presenter.setTopBarColor(color);
-					}
-				};
-				tool = new PipetteTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager, listener);
+				tool = new PipetteTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager, onColorPickedListener);
 				break;
 			case FILL:
-				tool = new FillTool(createFillToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new FillTool(createFillToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case TRANSFORM:
-				tool = new TransformTool(createTransformToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new TransformTool(createTransformToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case SHAPE:
-				tool = new ShapeTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new ShapeTool(createShapeToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case ERASER:
-				tool = new EraserTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new EraserTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case LINE:
-				tool = new LineTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new LineTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case TEXT:
-				tool = new TextTool(createTextToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new TextTool(createTextToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			case HAND:
 				tool = new HandTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 			default:
-				tool = new BrushTool(createBrushToolOptions(toolSpecificOptionsLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+				tool = new BrushTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 				break;
 		}
 		tool.setupToolOptions();
@@ -107,16 +97,20 @@ public class DefaultToolFactory implements ToolFactory {
 		return tool;
 	}
 
+	private BrushToolOptions createBrushToolOptions(ViewGroup toolSpecificOptionsLayout) {
+		return new DefaultBrushToolOptions(toolSpecificOptionsLayout);
+	}
+
 	private FillToolOptions createFillToolOptions(ViewGroup toolSpecificOptionsLayout) {
 		return new DefaultFillToolOptions(toolSpecificOptionsLayout);
 	}
 
-	private TextToolOptions createTextToolOptions(ViewGroup toolSpecificOptionsLayout) {
-		return new DefaultTextToolOptions(toolSpecificOptionsLayout);
+	private ShapeToolOptions createShapeToolOptions(ViewGroup toolSpecificOptionsLayout) {
+		return new DefaultShapeToolOptions(toolSpecificOptionsLayout);
 	}
 
-	private BrushToolOptions createBrushToolOptions(ViewGroup toolSpecificOptionsLayout) {
-		return new DefaultBrushToolOptions(toolSpecificOptionsLayout);
+	private TextToolOptions createTextToolOptions(ViewGroup toolSpecificOptionsLayout) {
+		return new DefaultTextToolOptions(toolSpecificOptionsLayout);
 	}
 
 	private TransformToolOptions createTransformToolOptions(ViewGroup toolSpecificOptionsLayout) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.java
@@ -29,91 +29,71 @@ import org.catrobat.paintroid.tools.ToolFactory;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.FillToolOptions;
-import org.catrobat.paintroid.tools.options.ShapeToolOptions;
-import org.catrobat.paintroid.tools.options.TextToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
-import org.catrobat.paintroid.tools.options.TransformToolOptions;
-import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptions;
-import org.catrobat.paintroid.ui.tools.DefaultFillToolOptions;
-import org.catrobat.paintroid.ui.tools.DefaultShapeToolOptions;
-import org.catrobat.paintroid.ui.tools.DefaultTextToolOptions;
-import org.catrobat.paintroid.ui.tools.DefaultTransformToolOptions;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.FillToolOptionsView;
+import org.catrobat.paintroid.tools.options.ShapeToolOptionsView;
+import org.catrobat.paintroid.tools.options.TextToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
+import org.catrobat.paintroid.tools.options.TransformToolOptionsView;
+import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptionsView;
+import org.catrobat.paintroid.ui.tools.DefaultFillToolOptionsView;
+import org.catrobat.paintroid.ui.tools.DefaultShapeToolOptionsView;
+import org.catrobat.paintroid.ui.tools.DefaultTextToolOptionsView;
+import org.catrobat.paintroid.ui.tools.DefaultTransformToolOptionsView;
 
 public class DefaultToolFactory implements ToolFactory {
 
 	@Override
-	public Tool createTool(ToolType toolType, ToolOptionsController toolOptionsController, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint, ContextCallback contextCallback, ColorPickerDialog.OnColorPickedListener onColorPickedListener) {
-		Tool tool;
-
-		toolOptionsController.removeToolViews();
-		toolOptionsController.setToolName(toolType.getNameResource());
-		ViewGroup toolLayout = toolOptionsController.getToolSpecificOptionsLayout();
+	public Tool createTool(ToolType toolType, ToolOptionsViewController toolOptionsViewController, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint, ContextCallback contextCallback, ColorPickerDialog.OnColorPickedListener onColorPickedListener) {
+		ViewGroup toolLayout = toolOptionsViewController.getToolSpecificOptionsLayout();
 
 		switch (toolType) {
 			case BRUSH:
-				tool = new BrushTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new BrushTool(createBrushToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case CURSOR:
-				tool = new CursorTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new CursorTool(createBrushToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case STAMP:
-				tool = new StampTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new StampTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case IMPORTPNG:
-				tool = new ImportTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new ImportTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case PIPETTE:
-				tool = new PipetteTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager, onColorPickedListener);
-				break;
+				return new PipetteTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager, onColorPickedListener);
 			case FILL:
-				tool = new FillTool(createFillToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new FillTool(createFillToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case TRANSFORM:
-				tool = new TransformTool(createTransformToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new TransformTool(createTransformToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case SHAPE:
-				tool = new ShapeTool(createShapeToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new ShapeTool(createShapeToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case ERASER:
-				tool = new EraserTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new EraserTool(createBrushToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case LINE:
-				tool = new LineTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new LineTool(createBrushToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case TEXT:
-				tool = new TextTool(createTextToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new TextTool(createTextToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			case HAND:
-				tool = new HandTool(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new HandTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 			default:
-				tool = new BrushTool(createBrushToolOptions(toolLayout), contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-				break;
+				return new BrushTool(createBrushToolOptionsView(toolLayout), contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 		}
-		tool.setupToolOptions();
-		toolOptionsController.resetToOrigin();
-		return tool;
 	}
 
-	private BrushToolOptions createBrushToolOptions(ViewGroup toolSpecificOptionsLayout) {
-		return new DefaultBrushToolOptions(toolSpecificOptionsLayout);
+	private BrushToolOptionsView createBrushToolOptionsView(ViewGroup toolLayout) {
+		return new DefaultBrushToolOptionsView(toolLayout);
 	}
 
-	private FillToolOptions createFillToolOptions(ViewGroup toolSpecificOptionsLayout) {
-		return new DefaultFillToolOptions(toolSpecificOptionsLayout);
+	private FillToolOptionsView createFillToolOptionsView(ViewGroup toolLayout) {
+		return new DefaultFillToolOptionsView(toolLayout);
 	}
 
-	private ShapeToolOptions createShapeToolOptions(ViewGroup toolSpecificOptionsLayout) {
-		return new DefaultShapeToolOptions(toolSpecificOptionsLayout);
+	private ShapeToolOptionsView createShapeToolOptionsView(ViewGroup toolLayout) {
+		return new DefaultShapeToolOptionsView(toolLayout);
 	}
 
-	private TextToolOptions createTextToolOptions(ViewGroup toolSpecificOptionsLayout) {
-		return new DefaultTextToolOptions(toolSpecificOptionsLayout);
+	private TextToolOptionsView createTextToolOptionsView(ViewGroup toolLayout) {
+		return new DefaultTextToolOptionsView(toolLayout);
 	}
 
-	private TransformToolOptions createTransformToolOptions(ViewGroup toolSpecificOptionsLayout) {
-		return new DefaultTransformToolOptions(toolSpecificOptionsLayout);
+	private TransformToolOptionsView createTransformToolOptionsView(ViewGroup toolLayout) {
+		return new DefaultTransformToolOptionsView(toolLayout);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.java
@@ -28,18 +28,18 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class EraserTool extends BrushTool {
 
 	@ColorInt
 	private int previousColor = Color.BLACK;
 
-	public EraserTool(BrushToolOptions brushToolOptions, ContextCallback contextCallback,
-			ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace,
+	public EraserTool(BrushToolOptionsView brushToolOptionsView, ContextCallback contextCallback,
+			ToolOptionsViewController toolOptionsViewController, ToolPaint toolPaint, Workspace workspace,
 			CommandManager commandManager) {
-		super(brushToolOptions, contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(brushToolOptionsView, contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.java
@@ -29,8 +29,8 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.FillToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.FillToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class FillTool extends BaseTool {
 
@@ -40,12 +40,12 @@ public class FillTool extends BaseTool {
 	@VisibleForTesting
 	public float colorTolerance = MAX_ABSOLUTE_TOLERANCE * DEFAULT_TOLERANCE_IN_PERCENT / 100.0f;
 
-	public FillTool(FillToolOptions fillToolOptions, ContextCallback contextCallback,
-			ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace,
+	public FillTool(FillToolOptionsView fillToolOptionsView, ContextCallback contextCallback,
+			ToolOptionsViewController toolOptionsViewController, ToolPaint toolPaint, Workspace workspace,
 			CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
-		fillToolOptions.setCallback(new FillToolOptions.Callback() {
+		fillToolOptionsView.setCallback(new FillToolOptionsView.Callback() {
 			@Override
 			public void onColorToleranceChanged(int colorTolerance) {
 				updateColorTolerance(colorTolerance);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/HandTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/HandTool.java
@@ -8,12 +8,12 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class HandTool extends BaseTool {
-	public HandTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public HandTool(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 					ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.java
@@ -26,13 +26,13 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class ImportTool extends StampTool {
 
-	public ImportTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public ImportTool(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 		readyForPaste = true;
 		longClickAllowed = false;
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.java
@@ -35,21 +35,22 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.common.CommonBrushChangedListener;
 import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class LineTool extends BaseTool {
 
 	private PointF initialEventCoordinate;
 	private PointF currentCoordinate;
-	private BrushToolOptions brushToolOptions;
+	private BrushToolOptionsView brushToolOptionsView;
 
-	public LineTool(BrushToolOptions brushToolOptions, ContextCallback contextCallback, ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
-		this.brushToolOptions = brushToolOptions;
+	public LineTool(BrushToolOptionsView brushToolOptionsView, ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
+			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
+		this.brushToolOptionsView = brushToolOptionsView;
 
-		brushToolOptions.setBrushChangedListener(new CommonBrushChangedListener(this));
-		brushToolOptions.setBrushPreviewListener(new CommonBrushPreviewListener(toolPaint, getToolType()));
+		brushToolOptionsView.setBrushChangedListener(new CommonBrushChangedListener(this));
+		brushToolOptionsView.setBrushPreviewListener(new CommonBrushPreviewListener(toolPaint, getToolType()));
 	}
 
 	@Override
@@ -129,12 +130,12 @@ public class LineTool extends BaseTool {
 	@Override
 	public void changePaintColor(int color) {
 		super.changePaintColor(color);
-		brushToolOptions.invalidate();
+		brushToolOptionsView.invalidate();
 	}
 
 	@Override
 	public void setupToolOptions() {
-		brushToolOptions.setCurrentPaint(toolPaint.getPaint());
+		brushToolOptionsView.setCurrentPaint(toolPaint.getPaint());
 	}
 
 	@VisibleForTesting (otherwise = VisibleForTesting.NONE)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.java
@@ -29,16 +29,16 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class PipetteTool extends BaseTool {
 
 	private Bitmap surfaceBitmap;
 	private ColorPickerDialog.OnColorPickedListener listener;
 
-	public PipetteTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public PipetteTool(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager, ColorPickerDialog.OnColorPickedListener listener) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 		this.listener = listener;
 
 		updateSurfaceBitmap();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
@@ -30,18 +30,15 @@ import android.graphics.PorterDuffXfermode;
 import android.graphics.RectF;
 import android.os.Bundle;
 import android.support.annotation.VisibleForTesting;
-import android.view.LayoutInflater;
-import android.view.View;
 
-import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.Command;
 import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.listener.ShapeToolOptionsListener;
 import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.helper.Conversion;
+import org.catrobat.paintroid.tools.options.ShapeToolOptions;
 import org.catrobat.paintroid.tools.options.ToolOptionsController;
 
 public class ShapeTool extends BaseToolWithRectangleShape {
@@ -57,12 +54,12 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 	public BaseShape baseShape;
 	private int shapeOutlineWidth = 25;
 	private ShapeDrawType shapeDrawType;
-	private ShapeToolOptionsListener shapeToolOptionsListener;
+	private ShapeToolOptions shapeToolOptions;
 	private Paint geometricFillCommandPaint;
 	private float previousBoxWidth;
 	private float previousBoxHeight;
 
-	public ShapeTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public ShapeTool(ShapeToolOptions shapeToolOptions, ContextCallback contextCallback, ToolOptionsController toolOptionsController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
 		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
 
@@ -73,6 +70,28 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 		}
 
 		shapeDrawType = ShapeDrawType.FILL;
+
+		this.shapeToolOptions = shapeToolOptions;
+		this.shapeToolOptions.setCallback(
+				new ShapeToolOptions.Callback() {
+					@Override
+					public void setToolType(BaseShape shape) {
+						baseShape = shape;
+						createAndSetBitmap();
+					}
+
+					@Override
+					public void setDrawType(ShapeDrawType drawType) {
+						shapeDrawType = drawType;
+						createAndSetBitmap();
+					}
+
+					@Override
+					public void setOutlineWidth(int outlineWidth) {
+						shapeOutlineWidth = outlineWidth;
+						createAndSetBitmap();
+					}
+				});
 
 		createAndSetBitmap();
 	}
@@ -94,30 +113,8 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 		createAndSetBitmap();
 	}
 
-	private void setupOnShapeToolDialogChangedListener() {
-		shapeToolOptionsListener.setOnShapeToolOptionsChangedListener(
-				new ShapeToolOptionsListener.OnShapeToolOptionsChangedListener() {
-					@Override
-					public void setToolType(BaseShape shape) {
-						baseShape = shape;
-						createAndSetBitmap();
-					}
-					@Override
-					public void setDrawType(ShapeDrawType drawType) {
-						shapeDrawType = drawType;
-						createAndSetBitmap();
-					}
-					@Override
-					public void setOutlineWidth(int outlineWidth) {
-						shapeOutlineWidth = outlineWidth;
-						createAndSetBitmap();
-					}
-				});
-	}
-
 	private void createAndSetBitmap() {
-		Bitmap bitmap = Bitmap.createBitmap((int) boxWidth, (int) boxHeight,
-				Bitmap.Config.ARGB_8888);
+		Bitmap bitmap = Bitmap.createBitmap((int) boxWidth, (int) boxHeight, Bitmap.Config.ARGB_8888);
 		Canvas drawCanvas = new Canvas(bitmap);
 
 		RectF shapeRect;
@@ -201,9 +198,9 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 			this.shapeDrawType = shapeDrawType;
 			this.shapeOutlineWidth = shapeOutlineWidth;
 
-			shapeToolOptionsListener.setShapeActivated(baseShape);
-			shapeToolOptionsListener.setDrawTypeActivated(shapeDrawType);
-			shapeToolOptionsListener.setShapeOutlineWidth(shapeOutlineWidth);
+			shapeToolOptions.setShapeActivated(baseShape);
+			shapeToolOptions.setDrawTypeActivated(shapeDrawType);
+			shapeToolOptions.setShapeOutlineWidth(shapeOutlineWidth);
 			createAndSetBitmap();
 		}
 	}
@@ -236,7 +233,7 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 
 		Path path = new Path();
 
-		switch (type){
+		switch (type) {
 			case STAR:
 				path.moveTo(midWidth, zeroHeight);
 				path.lineTo(midWidth + width / 8, midHeight - height / 8);
@@ -308,11 +305,6 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 
 	@Override
 	public void setupToolOptions() {
-		LayoutInflater inflater = LayoutInflater.from(toolSpecificOptionsLayout.getContext());
-		View shapeToolOptionView = inflater.inflate(R.layout.dialog_pocketpaint_shapes, toolSpecificOptionsLayout);
-
-		shapeToolOptionsListener = new ShapeToolOptionsListener(shapeToolOptionView);
-		setupOnShapeToolDialogChangedListener();
 		toolSpecificOptionsLayout.post(new Runnable() {
 			@Override
 			public void run() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
@@ -38,8 +38,8 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.helper.Conversion;
-import org.catrobat.paintroid.tools.options.ShapeToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ShapeToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class ShapeTool extends BaseToolWithRectangleShape {
 
@@ -54,14 +54,14 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 	public BaseShape baseShape;
 	private int shapeOutlineWidth = 25;
 	private ShapeDrawType shapeDrawType;
-	private ShapeToolOptions shapeToolOptions;
+	private ShapeToolOptionsView shapeToolOptionsView;
 	private Paint geometricFillCommandPaint;
 	private float previousBoxWidth;
 	private float previousBoxHeight;
 
-	public ShapeTool(ShapeToolOptions shapeToolOptions, ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public ShapeTool(ShapeToolOptionsView shapeToolOptionsView, ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
 		setRotationEnabled(ROTATION_ENABLED);
 
@@ -71,9 +71,9 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 
 		shapeDrawType = ShapeDrawType.FILL;
 
-		this.shapeToolOptions = shapeToolOptions;
-		this.shapeToolOptions.setCallback(
-				new ShapeToolOptions.Callback() {
+		this.shapeToolOptionsView = shapeToolOptionsView;
+		this.shapeToolOptionsView.setCallback(
+				new ShapeToolOptionsView.Callback() {
 					@Override
 					public void setToolType(BaseShape shape) {
 						baseShape = shape;
@@ -198,9 +198,9 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 			this.shapeDrawType = shapeDrawType;
 			this.shapeOutlineWidth = shapeOutlineWidth;
 
-			shapeToolOptions.setShapeActivated(baseShape);
-			shapeToolOptions.setDrawTypeActivated(shapeDrawType);
-			shapeToolOptions.setShapeOutlineWidth(shapeOutlineWidth);
+			shapeToolOptionsView.setShapeActivated(baseShape);
+			shapeToolOptionsView.setDrawTypeActivated(shapeDrawType);
+			shapeToolOptionsView.setShapeOutlineWidth(shapeOutlineWidth);
 			createAndSetBitmap();
 		}
 	}
@@ -308,7 +308,7 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 		toolSpecificOptionsLayout.post(new Runnable() {
 			@Override
 			public void run() {
-				toolOptionsController.showAnimated();
+				toolOptionsViewController.showAnimated();
 			}
 		});
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
@@ -35,7 +35,7 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class StampTool extends BaseToolWithRectangleShape {
 
@@ -49,9 +49,9 @@ public class StampTool extends BaseToolWithRectangleShape {
 	private CountDownTimer downTimer;
 	private boolean longClickPerformed;
 
-	public StampTool(ContextCallback contextCallback, ToolOptionsController toolOptionsController,
+	public StampTool(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
 			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 		readyForPaste = false;
 		longPressTimeout = ViewConfiguration.getLongPressTimeout();
 		setRotationEnabled(ROTATION_ENABLED);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
@@ -36,8 +36,8 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.TextToolOptions;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.TextToolOptionsView;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 public class TextTool extends BaseToolWithRectangleShape {
 
@@ -75,12 +75,13 @@ public class TextTool extends BaseToolWithRectangleShape {
 	public boolean bold = false;
 	@VisibleForTesting
 	public int textSize = 20;
-	private TextToolOptions textToolOptions;
+	private TextToolOptionsView textToolOptionsView;
 
-	public TextTool(TextToolOptions textToolOptions, ContextCallback contextCallback, final ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+	public TextTool(TextToolOptionsView textToolOptionsView, ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController,
+			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
-		this.textToolOptions = textToolOptions;
+		this.textToolOptionsView = textToolOptionsView;
 
 		setRotationEnabled(ROTATION_ENABLED);
 		setResizePointsVisible(RESIZE_POINTS_VISIBLE);
@@ -94,7 +95,7 @@ public class TextTool extends BaseToolWithRectangleShape {
 		createAndSetBitmap();
 		resetBoxPosition();
 
-		toolOptionsController.setCallback(new ToolOptionsController.Callback() {
+		toolOptionsViewController.setCallback(new ToolOptionsViewController.Callback() {
 			@Override
 			public void onHide() {
 				createAndSetBitmap();
@@ -106,8 +107,8 @@ public class TextTool extends BaseToolWithRectangleShape {
 			}
 		});
 
-		TextToolOptions.Callback callback =
-				new TextToolOptions.Callback() {
+		TextToolOptionsView.Callback callback =
+				new TextToolOptionsView.Callback() {
 					@Override
 					public void setText(String text) {
 						TextTool.this.text = text;
@@ -151,11 +152,11 @@ public class TextTool extends BaseToolWithRectangleShape {
 
 					@Override
 					public void hideToolOptions() {
-						toolOptionsController.hideAnimated();
+						TextTool.this.toolOptionsViewController.hideAnimated();
 					}
 				};
 
-		textToolOptions.setCallback(callback);
+		textToolOptionsView.setCallback(callback);
 	}
 
 	private void initializePaint() {
@@ -216,7 +217,7 @@ public class TextTool extends BaseToolWithRectangleShape {
 		textSize = bundle.getInt(BUNDLE_TOOL_TEXT_SIZE, textSize);
 		font = bundle.getString(BUNDLE_TOOL_FONT, font);
 
-		textToolOptions.setState(bold, italic, underlined, text, textSize, font);
+		textToolOptionsView.setState(bold, italic, underlined, text, textSize, font);
 		textPaint.setUnderlineText(underlined);
 		textPaint.setFakeBoldText(bold);
 		updateTypeface();
@@ -303,7 +304,7 @@ public class TextTool extends BaseToolWithRectangleShape {
 		toolSpecificOptionsLayout.post(new Runnable() {
 			@Override
 			public void run() {
-				toolOptionsController.showAnimated();
+				toolOptionsViewController.showAnimated();
 			}
 		});
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
@@ -38,8 +38,8 @@ import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.helper.CropAlgorithm;
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter;
 import org.catrobat.paintroid.tools.helper.JavaCropAlgorithm;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
-import org.catrobat.paintroid.tools.options.TransformToolOptions;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
+import org.catrobat.paintroid.tools.options.TransformToolOptionsView;
 import org.catrobat.paintroid.ui.tools.NumberRangeFilter;
 
 public class TransformTool extends BaseToolWithRectangleShape {
@@ -64,15 +64,16 @@ public class TransformTool extends BaseToolWithRectangleShape {
 	private boolean cropRunFinished = false;
 	private boolean maxImageResolutionInformationAlreadyShown = false;
 
-	private TransformToolOptions transformToolOptions;
+	private TransformToolOptionsView transformToolOptionsView;
 	private NumberRangeFilter rangeFilterHeight;
 	private NumberRangeFilter rangeFilterWidth;
 	private final CropAlgorithm cropAlgorithm;
 
-	public TransformTool(TransformToolOptions transformToolOptions, final ContextCallback contextCallback, ToolOptionsController toolOptionsController, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
-		super(contextCallback, toolOptionsController, toolPaint, workspace, commandManager);
+	public TransformTool(TransformToolOptionsView transformToolOptionsView, final ContextCallback contextCallback,
+			ToolOptionsViewController toolOptionsViewController, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
+		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
-		this.transformToolOptions = transformToolOptions;
+		this.transformToolOptionsView = transformToolOptionsView;
 
 		setRotationEnabled(ROTATION_ENABLED);
 		setResizePointsVisible(RESIZE_POINTS_VISIBLE);
@@ -93,7 +94,7 @@ public class TransformTool extends BaseToolWithRectangleShape {
 		setRespectMaximumBoxResolution(RESPECT_MAXIMUM_BOX_RESOLUTION);
 		initResizeBounds();
 
-		toolOptionsController.setCallback(new ToolOptionsController.Callback() {
+		toolOptionsViewController.setCallback(new ToolOptionsViewController.Callback() {
 			@Override
 			public void onHide() {
 				contextCallback.showNotification(R.string.transform_info_text, ContextCallback.NotificationDuration.LONG);
@@ -105,7 +106,7 @@ public class TransformTool extends BaseToolWithRectangleShape {
 			}
 		});
 
-		transformToolOptions.setCallback(new TransformToolOptions.Callback() {
+		transformToolOptionsView.setCallback(new TransformToolOptionsView.Callback() {
 			@Override
 			public void autoCropClicked() {
 				autoCrop();
@@ -150,8 +151,8 @@ public class TransformTool extends BaseToolWithRectangleShape {
 		rangeFilterHeight = new DefaultNumberRangeFilter(1, (int) (maximumBoxResolution / boxWidth));
 		rangeFilterWidth = new DefaultNumberRangeFilter(1, (int) (maximumBoxResolution / boxHeight));
 
-		transformToolOptions.setHeightFilter(rangeFilterHeight);
-		transformToolOptions.setWidthFilter(rangeFilterWidth);
+		transformToolOptionsView.setHeightFilter(rangeFilterHeight);
+		transformToolOptionsView.setWidthFilter(rangeFilterWidth);
 
 		updateToolOptions();
 	}
@@ -298,7 +299,7 @@ public class TransformTool extends BaseToolWithRectangleShape {
 			@Override
 			protected void onPostExecute(Void result) {
 				workspace.invalidate();
-				toolOptionsController.hideAnimated();
+				toolOptionsViewController.hideAnimated();
 			}
 		}.execute();
 	}
@@ -365,7 +366,7 @@ public class TransformTool extends BaseToolWithRectangleShape {
 		toolSpecificOptionsLayout.post(new Runnable() {
 			@Override
 			public void run() {
-				toolOptionsController.showAnimated();
+				toolOptionsViewController.showAnimated();
 			}
 		});
 	}
@@ -374,8 +375,8 @@ public class TransformTool extends BaseToolWithRectangleShape {
 		rangeFilterHeight.setMax((int) (maximumBoxResolution / boxWidth));
 		rangeFilterWidth.setMax((int) (maximumBoxResolution / boxHeight));
 
-		transformToolOptions.setWidth((int) boxWidth);
-		transformToolOptions.setHeight((int) boxHeight);
+		transformToolOptionsView.setWidth((int) boxWidth);
+		transformToolOptionsView.setHeight((int) boxHeight);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolOptionsView.java
@@ -19,10 +19,32 @@
 
 package org.catrobat.paintroid.tools.options;
 
-public interface FillToolOptions {
-	void setCallback(Callback callback);
+import android.graphics.Paint;
 
-	interface Callback {
-		void onColorToleranceChanged(int colorTolerance);
+import org.catrobat.paintroid.tools.ToolType;
+
+public interface BrushToolOptionsView {
+	void invalidate();
+
+	void setCurrentPaint(Paint paint);
+
+	void setBrushChangedListener(OnBrushChangedListener onBrushChangedListener);
+
+	void setBrushPreviewListener(OnBrushPreviewListener onBrushPreviewListener);
+
+	interface OnBrushChangedListener {
+		void setCap(Paint.Cap strokeCap);
+
+		void setStrokeWidth(int strokeWidth);
+	}
+
+	interface OnBrushPreviewListener {
+		float getStrokeWidth();
+
+		Paint.Cap getStrokeCap();
+
+		int getColor();
+
+		ToolType getToolType();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolPreview.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolPreview.java
@@ -20,7 +20,7 @@
 package org.catrobat.paintroid.tools.options;
 
 public interface BrushToolPreview {
-	void setListener(BrushToolOptions.OnBrushPreviewListener callback);
+	void setListener(BrushToolOptionsView.OnBrushPreviewListener callback);
 
 	void invalidate();
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/FillToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/FillToolOptionsView.java
@@ -19,22 +19,10 @@
 
 package org.catrobat.paintroid.tools.options;
 
-import org.catrobat.paintroid.tools.implementation.ShapeTool;
-
-public interface ShapeToolOptions {
-	void setShapeActivated(ShapeTool.BaseShape shape);
-
-	void setDrawTypeActivated(ShapeTool.ShapeDrawType drawType);
-
-	void setShapeOutlineWidth(int outlineWidth);
-
+public interface FillToolOptionsView {
 	void setCallback(Callback callback);
 
 	interface Callback {
-		void setToolType(ShapeTool.BaseShape shape);
-
-		void setDrawType(ShapeTool.ShapeDrawType drawType);
-
-		void setOutlineWidth(int outlineWidth);
+		void onColorToleranceChanged(int colorTolerance);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ShapeToolOptions.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ShapeToolOptions.java
@@ -17,12 +17,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.tools;
+package org.catrobat.paintroid.tools.options;
 
-import org.catrobat.paintroid.colorpicker.ColorPickerDialog;
-import org.catrobat.paintroid.command.CommandManager;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.implementation.ShapeTool;
 
-public interface ToolFactory {
-	Tool createTool(ToolType toolType, ToolOptionsController toolOptionsController, CommandManager commandManager, Workspace workspace, ToolPaint toolPaint, ContextCallback contextCallback, ColorPickerDialog.OnColorPickedListener onColorPickedListener);
+public interface ShapeToolOptions {
+	void setShapeActivated(ShapeTool.BaseShape shape);
+
+	void setDrawTypeActivated(ShapeTool.ShapeDrawType drawType);
+
+	void setShapeOutlineWidth(int outlineWidth);
+
+	void setCallback(Callback callback);
+
+	interface Callback {
+		void setToolType(ShapeTool.BaseShape shape);
+
+		void setDrawType(ShapeTool.ShapeDrawType drawType);
+
+		void setOutlineWidth(int outlineWidth);
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ShapeToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ShapeToolOptionsView.java
@@ -19,32 +19,22 @@
 
 package org.catrobat.paintroid.tools.options;
 
-import android.graphics.Paint;
+import org.catrobat.paintroid.tools.implementation.ShapeTool;
 
-import org.catrobat.paintroid.tools.ToolType;
+public interface ShapeToolOptionsView {
+	void setShapeActivated(ShapeTool.BaseShape shape);
 
-public interface BrushToolOptions {
-	void invalidate();
+	void setDrawTypeActivated(ShapeTool.ShapeDrawType drawType);
 
-	void setCurrentPaint(Paint paint);
+	void setShapeOutlineWidth(int outlineWidth);
 
-	void setBrushChangedListener(OnBrushChangedListener onBrushChangedListener);
+	void setCallback(Callback callback);
 
-	void setBrushPreviewListener(OnBrushPreviewListener onBrushPreviewListener);
+	interface Callback {
+		void setToolType(ShapeTool.BaseShape shape);
 
-	interface OnBrushChangedListener {
-		void setCap(Paint.Cap strokeCap);
+		void setDrawType(ShapeTool.ShapeDrawType drawType);
 
-		void setStrokeWidth(int strokeWidth);
-	}
-
-	interface OnBrushPreviewListener {
-		float getStrokeWidth();
-
-		Paint.Cap getStrokeCap();
-
-		int getColor();
-
-		ToolType getToolType();
+		void setOutlineWidth(int outlineWidth);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.java
@@ -19,7 +19,7 @@
 
 package org.catrobat.paintroid.tools.options;
 
-public interface TextToolOptions {
+public interface TextToolOptionsView {
 	void setState(boolean bold, boolean italic, boolean underlined, String text, int textSize, String font);
 
 	void setCallback(Callback listener);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ToolOptionsViewController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ToolOptionsViewController.java
@@ -23,7 +23,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.view.ViewGroup;
 
-public interface ToolOptionsController {
+public interface ToolOptionsViewController {
 	void hideAnimated();
 
 	void disable();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TransformToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TransformToolOptionsView.java
@@ -21,7 +21,7 @@ package org.catrobat.paintroid.tools.options;
 
 import org.catrobat.paintroid.ui.tools.NumberRangeFilter;
 
-public interface TransformToolOptions {
+public interface TransformToolOptionsView {
 	void setWidthFilter(NumberRangeFilter numberRangeFilter);
 
 	void setHeightFilter(NumberRangeFilter numberRangeFilter);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -49,7 +49,7 @@ import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTaskCall
 import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
 import java.util.ListIterator;
 
@@ -67,7 +67,7 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 	private Perspective perspective;
 	private DrawingSurfaceListener drawingSurfaceListener;
 	private ToolReference toolReference;
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 
 	public DrawingSurface(Context context, AttributeSet attrSet) {
 		super(context, attrSet);
@@ -117,19 +117,19 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 			}
 
 			@Override
-			public ToolOptionsController getToolOptionsController() {
-				return toolOptionsController;
+			public ToolOptionsViewController getToolOptionsViewController() {
+				return toolOptionsViewController;
 			}
 		};
 		drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask, callback, density);
 		setOnTouchListener(drawingSurfaceListener);
 	}
 
-	public void setArguments(LayerContracts.Model layerModel, Perspective perspective, ToolReference toolReference, ToolOptionsController toolOptionsController) {
+	public void setArguments(LayerContracts.Model layerModel, Perspective perspective, ToolReference toolReference, ToolOptionsViewController toolOptionsViewController) {
 		this.layerModel = layerModel;
 		this.perspective = perspective;
 		this.toolReference = toolReference;
-		this.toolOptionsController = toolOptionsController;
+		this.toolOptionsViewController = toolOptionsViewController;
 	}
 
 	private synchronized void doDraw(Canvas surfaceViewCanvas) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/BrushToolView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/BrushToolView.java
@@ -33,7 +33,7 @@ import android.view.View;
 
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.ToolType;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
 import org.catrobat.paintroid.tools.options.BrushToolPreview;
 
 public class BrushToolView extends View implements BrushToolPreview {
@@ -44,7 +44,7 @@ public class BrushToolView extends View implements BrushToolPreview {
 	private Paint checkeredPattern;
 	private Paint borderPaint;
 	private Path path;
-	private BrushToolOptions.OnBrushPreviewListener callback;
+	private BrushToolOptionsView.OnBrushPreviewListener callback;
 
 	public BrushToolView(Context context) {
 		super(context);
@@ -236,7 +236,7 @@ public class BrushToolView extends View implements BrushToolPreview {
 	}
 
 	@Override
-	public void setListener(BrushToolOptions.OnBrushPreviewListener callback) {
+	public void setListener(BrushToolOptionsView.OnBrushPreviewListener callback) {
 		this.callback = callback;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptionsView.java
@@ -35,14 +35,14 @@ import android.widget.SeekBar;
 
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter;
-import org.catrobat.paintroid.tools.options.BrushToolOptions;
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
 import org.catrobat.paintroid.tools.options.BrushToolPreview;
 
 import java.util.Locale;
 
-public final class DefaultBrushToolOptions implements BrushToolOptions {
+public final class DefaultBrushToolOptionsView implements BrushToolOptionsView {
 	private static final int MIN_BRUSH_SIZE = 1;
-	private static final String TAG = DefaultBrushToolOptions.class.getSimpleName();
+	private static final String TAG = DefaultBrushToolOptionsView.class.getSimpleName();
 
 	private final EditText brushSizeText;
 	private final SeekBar brushWidthSeekBar;
@@ -50,16 +50,16 @@ public final class DefaultBrushToolOptions implements BrushToolOptions {
 	private final ImageButton buttonRect;
 	private final BrushToolPreview brushToolPreview;
 	@VisibleForTesting
-	public BrushToolOptions.OnBrushChangedListener brushChangedListener;
+	public BrushToolOptionsView.OnBrushChangedListener brushChangedListener;
 
-	public DefaultBrushToolOptions(ViewGroup rootView) {
+	public DefaultBrushToolOptionsView(ViewGroup rootView) {
 		LayoutInflater inflater = LayoutInflater.from(rootView.getContext());
 		View brushPickerView = inflater.inflate(R.layout.dialog_pocketpaint_stroke, rootView, true);
 
 		buttonCircle = brushPickerView.findViewById(R.id.pocketpaint_stroke_ibtn_circle);
 		buttonRect = brushPickerView.findViewById(R.id.pocketpaint_stroke_ibtn_rect);
 		brushWidthSeekBar = brushPickerView.findViewById(R.id.pocketpaint_stroke_width_seek_bar);
-		brushWidthSeekBar.setOnSeekBarChangeListener(new DefaultBrushToolOptions.OnBrushChangedWidthSeekBarListener());
+		brushWidthSeekBar.setOnSeekBarChangeListener(new DefaultBrushToolOptionsView.OnBrushChangedWidthSeekBarListener());
 		brushSizeText = brushPickerView.findViewById(R.id.pocketpaint_stroke_width_width_text);
 		brushSizeText.setFilters(new InputFilter[]{new DefaultNumberRangeFilter(1, 100)});
 		brushToolPreview = brushPickerView.findViewById(R.id.pocketpaint_brush_tool_preview);
@@ -128,7 +128,7 @@ public final class DefaultBrushToolOptions implements BrushToolOptions {
 	}
 
 	@Override
-	public void setBrushChangedListener(BrushToolOptions.OnBrushChangedListener brushChangedListener) {
+	public void setBrushChangedListener(BrushToolOptionsView.OnBrushChangedListener brushChangedListener) {
 		this.brushChangedListener = brushChangedListener;
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultFillToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultFillToolOptionsView.java
@@ -32,16 +32,16 @@ import android.widget.SeekBar;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter;
 import org.catrobat.paintroid.tools.implementation.FillTool;
-import org.catrobat.paintroid.tools.options.FillToolOptions;
+import org.catrobat.paintroid.tools.options.FillToolOptionsView;
 
 import java.util.Locale;
 
-public class DefaultFillToolOptions implements FillToolOptions {
+public class DefaultFillToolOptionsView implements FillToolOptionsView {
 	private SeekBar colorToleranceSeekBar;
 	private EditText colorToleranceEditText;
 	private Callback callback;
 
-	public DefaultFillToolOptions(ViewGroup toolSpecificOptionsLayout) {
+	public DefaultFillToolOptionsView(ViewGroup toolSpecificOptionsLayout) {
 		LayoutInflater inflater = LayoutInflater.from(toolSpecificOptionsLayout.getContext());
 		View fillToolOptionsView = inflater.inflate(R.layout.dialog_pocketpaint_fill_tool, toolSpecificOptionsLayout);
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptions.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptions.java
@@ -1,28 +1,30 @@
-/**
+/*
  * Paintroid: An image manipulation application for Android.
  * Copyright (C) 2010-2015 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
- * <p>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * <p>
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.paintroid.listener;
+package org.catrobat.paintroid.ui.tools;
 
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.SeekBar;
@@ -31,13 +33,14 @@ import android.widget.TextView;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter;
 import org.catrobat.paintroid.tools.implementation.ShapeTool;
+import org.catrobat.paintroid.tools.options.ShapeToolOptions;
 
 import java.util.Locale;
 
-public class ShapeToolOptionsListener {
+public class DefaultShapeToolOptions implements ShapeToolOptions {
 	private static final int MIN_STROKE_WIDTH = 1;
 
-	private OnShapeToolOptionsChangedListener onShapeToolOptionsChangedListener;
+	private Callback callback;
 	private ImageButton squareButton;
 	private ImageButton circleButton;
 	private ImageButton heartButton;
@@ -51,26 +54,30 @@ public class ShapeToolOptionsListener {
 	private TextView shapeToolDialogTitle;
 	private TextView shapeToolFillOutline;
 
-	public ShapeToolOptionsListener(View shapeToolOptionsView) {
-		squareButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.pocketpaint_shapes_square_btn);
-		circleButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.pocketpaint_shapes_circle_btn);
-		heartButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.pocketpaint_shapes_heart_btn);
-		starButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.pocketpaint_shapes_star_btn);
-		fillButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.pocketpaint_shape_ibtn_fill);
-		outlineButton = (ImageButton) shapeToolOptionsView.findViewById(R.id.pocketpaint_shape_ibtn_outline);
-		shapeToolDialogTitle = (TextView) shapeToolOptionsView.findViewById(R.id.pocketpaint_shape_tool_dialog_title);
-		shapeToolFillOutline = (TextView) shapeToolOptionsView.findViewById(R.id.pocketpaint_shape_tool_fill_outline);
+	public DefaultShapeToolOptions(ViewGroup rootView) {
+		LayoutInflater inflater = LayoutInflater.from(rootView.getContext());
+		View shapeToolView = inflater.inflate(R.layout.dialog_pocketpaint_shapes, rootView);
 
-		outlineView = shapeToolOptionsView.findViewById(R.id.pocketpaint_outline_view_border);
-		outlineTextView = (TextView) shapeToolOptionsView.findViewById(R.id.pocketpaint_outline_view_text_view);
+		squareButton = shapeToolView.findViewById(R.id.pocketpaint_shapes_square_btn);
+		circleButton = shapeToolView.findViewById(R.id.pocketpaint_shapes_circle_btn);
+		heartButton = shapeToolView.findViewById(R.id.pocketpaint_shapes_heart_btn);
+		starButton = shapeToolView.findViewById(R.id.pocketpaint_shapes_star_btn);
+		fillButton = shapeToolView.findViewById(R.id.pocketpaint_shape_ibtn_fill);
+		outlineButton = shapeToolView.findViewById(R.id.pocketpaint_shape_ibtn_outline);
+		shapeToolDialogTitle = shapeToolView.findViewById(R.id.pocketpaint_shape_tool_dialog_title);
+		shapeToolFillOutline = shapeToolView.findViewById(R.id.pocketpaint_shape_tool_fill_outline);
 
-		outlineWidthSeekBar = (SeekBar) shapeToolOptionsView.findViewById(R.id.pocketpaint_shape_stroke_width_seek_bar);
-		outlineWidthEditText = (EditText) shapeToolOptionsView.findViewById(R.id.pocketpaint_shape_outline_edit);
+		outlineView = shapeToolView.findViewById(R.id.pocketpaint_outline_view_border);
+		outlineTextView = shapeToolView.findViewById(R.id.pocketpaint_outline_view_text_view);
+
+		outlineWidthSeekBar = shapeToolView.findViewById(R.id.pocketpaint_shape_stroke_width_seek_bar);
+		outlineWidthEditText = shapeToolView.findViewById(R.id.pocketpaint_shape_outline_edit);
 		outlineWidthEditText.setFilters(new InputFilter[]{new DefaultNumberRangeFilter(1, 100)});
 
 		int startingOutlineWidth = 25;
-		outlineWidthEditText.setText(String.format(Locale.getDefault(), "%d", (int) startingOutlineWidth));
+		outlineWidthEditText.setText(String.valueOf(startingOutlineWidth));
 		outlineWidthSeekBar.setProgress(startingOutlineWidth);
+
 		initializeListeners();
 		setShapeActivated(ShapeTool.BaseShape.RECTANGLE);
 		setDrawTypeActivated(ShapeTool.ShapeDrawType.FILL);
@@ -127,10 +134,12 @@ public class ShapeToolOptionsListener {
 			}
 
 			@Override
-			public void onStartTrackingTouch(SeekBar seekBar) { }
+			public void onStartTrackingTouch(SeekBar seekBar) {
+			}
 
 			@Override
-			public void onStopTrackingTouch(SeekBar seekBar) { }
+			public void onStopTrackingTouch(SeekBar seekBar) {
+			}
 		});
 		outlineWidthEditText.addTextChangedListener(new TextWatcher() {
 			@Override
@@ -156,17 +165,17 @@ public class ShapeToolOptionsListener {
 	}
 
 	private void onShapeClicked(ShapeTool.BaseShape shape) {
-		onShapeToolOptionsChangedListener.setToolType(shape);
+		callback.setToolType(shape);
 		setShapeActivated(shape);
 	}
 
 	private void onDrawTypeClicked(ShapeTool.ShapeDrawType drawType) {
-		onShapeToolOptionsChangedListener.setDrawType(drawType);
+		callback.setDrawType(drawType);
 		setDrawTypeActivated(drawType);
 	}
 
 	private void onOutlineWidthChanged(int outlineWidth) {
-		onShapeToolOptionsChangedListener.setOutlineWidth(outlineWidth);
+		callback.setOutlineWidth(outlineWidth);
 	}
 
 	private void resetShapeActivated() {
@@ -181,6 +190,7 @@ public class ShapeToolOptionsListener {
 		outlineButton.setSelected(false);
 	}
 
+	@Override
 	public void setShapeActivated(ShapeTool.BaseShape shape) {
 		resetShapeActivated();
 		switch (shape) {
@@ -206,6 +216,7 @@ public class ShapeToolOptionsListener {
 		}
 	}
 
+	@Override
 	public void setDrawTypeActivated(ShapeTool.ShapeDrawType drawType) {
 		resetDrawTypeActivated();
 		switch (drawType) {
@@ -239,18 +250,14 @@ public class ShapeToolOptionsListener {
 		}
 	}
 
+	@Override
 	public void setShapeOutlineWidth(int outlineWidth) {
 		outlineWidthSeekBar.setProgress(outlineWidth);
 		outlineWidthEditText.setText(String.format(Locale.getDefault(), "%d", (int) outlineWidth));
 	}
 
-	public void setOnShapeToolOptionsChangedListener(OnShapeToolOptionsChangedListener listener) {
-		onShapeToolOptionsChangedListener = listener;
-	}
-
-	public interface OnShapeToolOptionsChangedListener {
-		void setToolType(ShapeTool.BaseShape shape);
-		void setDrawType(ShapeTool.ShapeDrawType drawType);
-		void setOutlineWidth(int outlineWidth);
+	@Override
+	public void setCallback(Callback callback) {
+		this.callback = callback;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptionsView.java
@@ -33,11 +33,11 @@ import android.widget.TextView;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter;
 import org.catrobat.paintroid.tools.implementation.ShapeTool;
-import org.catrobat.paintroid.tools.options.ShapeToolOptions;
+import org.catrobat.paintroid.tools.options.ShapeToolOptionsView;
 
 import java.util.Locale;
 
-public class DefaultShapeToolOptions implements ShapeToolOptions {
+public class DefaultShapeToolOptionsView implements ShapeToolOptionsView {
 	private static final int MIN_STROKE_WIDTH = 1;
 
 	private Callback callback;
@@ -54,7 +54,7 @@ public class DefaultShapeToolOptions implements ShapeToolOptions {
 	private TextView shapeToolDialogTitle;
 	private TextView shapeToolFillOutline;
 
-	public DefaultShapeToolOptions(ViewGroup rootView) {
+	public DefaultShapeToolOptionsView(ViewGroup rootView) {
 		LayoutInflater inflater = LayoutInflater.from(rootView.getContext());
 		View shapeToolView = inflater.inflate(R.layout.dialog_pocketpaint_shapes, rootView);
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.java
@@ -37,14 +37,14 @@ import android.widget.Spinner;
 import android.widget.ToggleButton;
 
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.tools.options.TextToolOptions;
+import org.catrobat.paintroid.tools.options.TextToolOptionsView;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-public class DefaultTextToolOptions implements TextToolOptions {
+public class DefaultTextToolOptionsView implements TextToolOptionsView {
 	private final Context context;
 	private Callback callback;
 	private final EditText textEditText;
@@ -56,7 +56,7 @@ public class DefaultTextToolOptions implements TextToolOptions {
 	private final Button doneButton;
 	private final List<String> fonts;
 
-	public DefaultTextToolOptions(ViewGroup rootView) {
+	public DefaultTextToolOptionsView(ViewGroup rootView) {
 		context = rootView.getContext();
 		LayoutInflater inflater = LayoutInflater.from(context);
 		View textToolView = inflater.inflate(R.layout.dialog_pocketpaint_text_tool, rootView);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.java
@@ -33,9 +33,9 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
-public class DefaultToolOptionsController implements ToolOptionsController {
+public class DefaultToolOptionsViewController implements ToolOptionsViewController {
 	private final Activity activity;
 
 	private final TextView toolOptionsTextView;
@@ -51,7 +51,7 @@ public class DefaultToolOptionsController implements ToolOptionsController {
 	private boolean enabled = true;
 	private Callback callback;
 
-	public DefaultToolOptionsController(Activity activity) {
+	public DefaultToolOptionsViewController(Activity activity) {
 		this.activity = activity;
 
 		drawingSurfaceView = activity.findViewById(R.id.pocketpaint_drawing_surface_view);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTransformToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTransformToolOptionsView.java
@@ -31,14 +31,14 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 
 import org.catrobat.paintroid.R;
-import org.catrobat.paintroid.tools.options.TransformToolOptions;
+import org.catrobat.paintroid.tools.options.TransformToolOptionsView;
 
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
 
-public class DefaultTransformToolOptions implements TransformToolOptions {
-	private static final String TAG = DefaultTransformToolOptions.class.getSimpleName();
+public class DefaultTransformToolOptionsView implements TransformToolOptionsView {
+	private static final String TAG = DefaultTransformToolOptionsView.class.getSimpleName();
 	private final TransformToolSizeTextWatcher heightTextWatcher;
 	private final TransformToolSizeTextWatcher widthTextWatcher;
 	private EditText widthEditText;
@@ -48,7 +48,7 @@ public class DefaultTransformToolOptions implements TransformToolOptions {
 
 	private Callback callback;
 
-	public DefaultTransformToolOptions(ViewGroup rootView) {
+	public DefaultTransformToolOptionsView(ViewGroup rootView) {
 		LayoutInflater inflater = LayoutInflater.from(rootView.getContext());
 		View optionsView = inflater.inflate(R.layout.dialog_pocketpaint_transform_tool, rootView);
 

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
@@ -1,0 +1,214 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.controller;
+
+import android.graphics.Color;
+import android.graphics.Paint;
+
+import org.catrobat.paintroid.command.CommandManager;
+import org.catrobat.paintroid.controller.DefaultToolController;
+import org.catrobat.paintroid.tools.ContextCallback;
+import org.catrobat.paintroid.tools.Tool;
+import org.catrobat.paintroid.tools.ToolFactory;
+import org.catrobat.paintroid.tools.ToolPaint;
+import org.catrobat.paintroid.tools.ToolReference;
+import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.catrobat.paintroid.tools.Tool.StateChange.NEW_IMAGE_LOADED;
+import static org.catrobat.paintroid.tools.Tool.StateChange.RESET_INTERNAL_STATE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class ToolControllerTest {
+	@Mock
+	public ToolReference toolReference;
+	@Mock
+	public ToolOptionsController toolOptionsController;
+	@Mock
+	public ToolFactory toolFactory;
+	@Mock
+	public CommandManager commandManager;
+	@Mock
+	public Workspace workspace;
+	@Mock
+	public ToolPaint toolPaint;
+	@Mock
+	public ContextCallback contextCallback;
+
+	@InjectMocks
+	public DefaultToolController toolController;
+
+	@Test
+	public void testSetUp() {
+		verifyZeroInteractions(toolReference, toolOptionsController, toolFactory, commandManager, workspace, toolPaint,
+				contextCallback);
+		assertNotNull(toolController);
+	}
+
+	@Test
+	public void testIsDefaultToolWhenBrushReturnsTrue() {
+		Tool tool = mock(Tool.class);
+		when(tool.getToolType()).thenReturn(ToolType.BRUSH);
+		when(toolReference.get()).thenReturn(tool);
+
+		assertTrue(toolController.isDefaultTool());
+	}
+
+	@Test
+	public void testIsDefaultToolWhenNotBrushReturnsFalse() {
+		Tool tool = mock(Tool.class);
+		when(tool.getToolType()).thenReturn(
+				ToolType.CURSOR,
+				ToolType.ERASER,
+				ToolType.FILL,
+				ToolType.LINE,
+				ToolType.PIPETTE,
+				ToolType.SHAPE,
+				ToolType.STAMP,
+				ToolType.TEXT
+		);
+		when(toolReference.get()).thenReturn(tool);
+
+		assertFalse(toolController.isDefaultTool());
+		assertFalse(toolController.isDefaultTool());
+		assertFalse(toolController.isDefaultTool());
+		assertFalse(toolController.isDefaultTool());
+		assertFalse(toolController.isDefaultTool());
+		assertFalse(toolController.isDefaultTool());
+		assertFalse(toolController.isDefaultTool());
+		assertFalse(toolController.isDefaultTool());
+	}
+
+	@Test
+	public void testHideToolOptionsCallsToolOptionsController() {
+		toolController.hideToolOptions();
+
+		verify(toolOptionsController).hideAnimated();
+		verifyNoMoreInteractions(toolOptionsController);
+	}
+
+	@Test
+	public void testToolOptionsControllerWhenOptionsVisibleReturnsTrue() {
+		when(toolOptionsController.isVisible()).thenReturn(true);
+
+		assertTrue(toolController.toolOptionsVisible());
+	}
+
+	@Test
+	public void testToolOptionsControllerWhenOptionsNotVisibleReturnsFalse() {
+		assertFalse(toolController.toolOptionsVisible());
+	}
+
+	@Test
+	public void testResetToolInternalStateCallsResetInternalState() {
+		Tool tool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
+
+		toolController.resetToolInternalState();
+
+		verify(tool).resetInternalState(RESET_INTERNAL_STATE);
+	}
+
+	@Test
+	public void testResetToolInternalStateOnImageLoadedCallsResetInternalState() {
+		Tool tool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
+
+		toolController.resetToolInternalStateOnImageLoaded();
+
+		verify(tool).resetInternalState(NEW_IMAGE_LOADED);
+	}
+
+	@Test
+	public void testGetToolColorReturnsColor() {
+		Tool tool = mock(Tool.class);
+		Paint paint = mock(Paint.class);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getDrawPaint()).thenReturn(paint);
+		when(paint.getColor()).thenReturn(Color.CYAN);
+
+		assertEquals(Color.CYAN, toolController.getToolColor());
+	}
+
+	@Test
+	public void testGetToolTypeReturnsToolType() {
+		Tool tool = mock(Tool.class);
+		when(toolReference.get()).thenReturn(tool);
+		when(tool.getToolType()).thenReturn(ToolType.BRUSH, ToolType.ERASER);
+
+		assertEquals(ToolType.BRUSH, toolController.getToolType());
+		assertEquals(ToolType.ERASER, toolController.getToolType());
+	}
+
+	@Test
+	public void testDisableToolOptionsCallsOptions() {
+		toolController.disableToolOptions();
+
+		verify(toolOptionsController).disable();
+	}
+
+	@Test
+	public void testEnableToolOptionsCallsOptions() {
+		toolController.enableToolOptions();
+
+		verify(toolOptionsController).enable();
+	}
+
+	@Test
+	public void testToggleToolOptionsWhenNotVisibleThenShowOptions() {
+		toolController.toggleToolOptions();
+
+		verify(toolOptionsController).showAnimated();
+	}
+
+	@Test
+	public void testToggleToolOptionsWhenVisibleThenHideOptions() {
+		when(toolOptionsController.isVisible()).thenReturn(true);
+
+		toolController.toggleToolOptions();
+
+		verify(toolOptionsController).hideAnimated();
+	}
+
+	@Test
+	public void testHasToolOptions() {
+		Tool mock = mock(Tool.class);
+		when(toolReference.get()).thenReturn(mock);
+		when(mock.getToolType()).thenReturn(ToolType.BRUSH, ToolType.IMPORTPNG);
+
+		assertTrue(toolController.hasToolOptions());
+		assertFalse(toolController.hasToolOptions());
+	}
+}

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
@@ -31,7 +31,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -55,7 +55,7 @@ public class ToolControllerTest {
 	@Mock
 	public ToolReference toolReference;
 	@Mock
-	public ToolOptionsController toolOptionsController;
+	public ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	public ToolFactory toolFactory;
 	@Mock
@@ -72,7 +72,7 @@ public class ToolControllerTest {
 
 	@Test
 	public void testSetUp() {
-		verifyZeroInteractions(toolReference, toolOptionsController, toolFactory, commandManager, workspace, toolPaint,
+		verifyZeroInteractions(toolReference, toolOptionsViewController, toolFactory, commandManager, workspace, toolPaint,
 				contextCallback);
 		assertNotNull(toolController);
 	}
@@ -112,23 +112,23 @@ public class ToolControllerTest {
 	}
 
 	@Test
-	public void testHideToolOptionsCallsToolOptionsController() {
-		toolController.hideToolOptions();
+	public void testHideToolOptionsCallsToolOptionsViewController() {
+		toolController.hideToolOptionsView();
 
-		verify(toolOptionsController).hideAnimated();
-		verifyNoMoreInteractions(toolOptionsController);
+		verify(toolOptionsViewController).hideAnimated();
+		verifyNoMoreInteractions(toolOptionsViewController);
 	}
 
 	@Test
-	public void testToolOptionsControllerWhenOptionsVisibleReturnsTrue() {
-		when(toolOptionsController.isVisible()).thenReturn(true);
+	public void testToolOptionsViewControllerWhenOptionsVisibleReturnsTrue() {
+		when(toolOptionsViewController.isVisible()).thenReturn(true);
 
-		assertTrue(toolController.toolOptionsVisible());
+		assertTrue(toolController.toolOptionsViewVisible());
 	}
 
 	@Test
-	public void testToolOptionsControllerWhenOptionsNotVisibleReturnsFalse() {
-		assertFalse(toolController.toolOptionsVisible());
+	public void testToolOptionsViewControllerWhenOptionsNotVisibleReturnsFalse() {
+		assertFalse(toolController.toolOptionsViewVisible());
 	}
 
 	@Test
@@ -174,32 +174,32 @@ public class ToolControllerTest {
 
 	@Test
 	public void testDisableToolOptionsCallsOptions() {
-		toolController.disableToolOptions();
+		toolController.disableToolOptionsView();
 
-		verify(toolOptionsController).disable();
+		verify(toolOptionsViewController).disable();
 	}
 
 	@Test
 	public void testEnableToolOptionsCallsOptions() {
-		toolController.enableToolOptions();
+		toolController.enableToolOptionsView();
 
-		verify(toolOptionsController).enable();
+		verify(toolOptionsViewController).enable();
 	}
 
 	@Test
 	public void testToggleToolOptionsWhenNotVisibleThenShowOptions() {
-		toolController.toggleToolOptions();
+		toolController.toggleToolOptionsView();
 
-		verify(toolOptionsController).showAnimated();
+		verify(toolOptionsViewController).showAnimated();
 	}
 
 	@Test
 	public void testToggleToolOptionsWhenVisibleThenHideOptions() {
-		when(toolOptionsController.isVisible()).thenReturn(true);
+		when(toolOptionsViewController.isVisible()).thenReturn(true);
 
-		toolController.toggleToolOptions();
+		toolController.toggleToolOptionsView();
 
-		verify(toolOptionsController).hideAnimated();
+		verify(toolOptionsViewController).hideAnimated();
 	}
 
 	@Test
@@ -208,7 +208,7 @@ public class ToolControllerTest {
 		when(toolReference.get()).thenReturn(mock);
 		when(mock.getToolType()).thenReturn(ToolType.BRUSH, ToolType.IMPORTPNG);
 
-		assertTrue(toolController.hasToolOptions());
-		assertFalse(toolController.hasToolOptions());
+		assertTrue(toolController.hasToolOptionsView());
+		assertFalse(toolController.hasToolOptionsView());
 	}
 }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
@@ -25,7 +25,7 @@ import android.view.MotionEvent;
 import org.catrobat.paintroid.listener.DrawingSurfaceListener;
 import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTask;
 import org.catrobat.paintroid.tools.Tool;
-import org.catrobat.paintroid.tools.options.ToolOptionsController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.DrawingSurface;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +59,7 @@ public class DrawingSurfaceListenerTest {
 	private Tool currentTool;
 
 	@Mock
-	private ToolOptionsController toolOptionsController;
+	private ToolOptionsViewController toolOptionsViewController;
 
 	@Mock
 	private DrawingSurfaceListener.DrawingSurfaceListenerCallback callback;
@@ -70,8 +70,8 @@ public class DrawingSurfaceListenerTest {
 	public void setUp() {
 		when(callback.getCurrentTool())
 				.thenReturn(currentTool);
-		when(callback.getToolOptionsController())
-				.thenReturn(toolOptionsController);
+		when(callback.getToolOptionsViewController())
+				.thenReturn(toolOptionsViewController);
 
 		drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask, callback, DISPLAY_DENSITY);
 	}
@@ -510,12 +510,12 @@ public class DrawingSurfaceListenerTest {
 		DrawingSurface drawingSurface = mock(DrawingSurface.class);
 		MotionEvent motionEvent = mock(MotionEvent.class);
 
-		when(toolOptionsController.isVisible()).thenReturn(true);
+		when(toolOptionsViewController.isVisible()).thenReturn(true);
 
 		boolean onTouchResult = drawingSurfaceListener.onTouch(drawingSurface, motionEvent);
 
 		assertFalse(onTouchResult);
-		verify(toolOptionsController).hideAnimated();
+		verify(toolOptionsViewController).hideAnimated();
 		verifyZeroInteractions(currentTool);
 	}
 }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -281,7 +281,7 @@ public class MainActivityPresenterTest {
 		verify(view).enterFullscreen();
 		verify(navigationDrawerViewHolder).hideEnterFullscreen();
 		verify(navigationDrawerViewHolder).showExitFullscreen();
-		verify(toolController).disableToolOptions();
+		verify(toolController).disableToolOptionsView();
 		verify(perspective).enterFullscreen();
 	}
 
@@ -294,7 +294,7 @@ public class MainActivityPresenterTest {
 		verify(view).exitFullscreen();
 		verify(navigationDrawerViewHolder).showEnterFullscreen();
 		verify(navigationDrawerViewHolder).hideExitFullscreen();
-		verify(toolController).enableToolOptions();
+		verify(toolController).enableToolOptionsView();
 		verify(perspective).exitFullscreen();
 	}
 
@@ -468,11 +468,11 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnBackPressedWhenToolOptionsShownThenHideToolOptions() {
-		when(toolController.toolOptionsVisible()).thenReturn(true);
+		when(toolController.toolOptionsViewVisible()).thenReturn(true);
 
 		presenter.onBackPressed();
 
-		verify(toolController).hideToolOptions();
+		verify(toolController).hideToolOptionsView();
 	}
 
 	@Test
@@ -781,11 +781,11 @@ public class MainActivityPresenterTest {
 	@Test
 	public void testToolClickedWhenSameToolTypeThenToggleOptions() {
 		when(toolController.getToolType()).thenReturn(ToolType.TEXT);
-		when(toolController.hasToolOptions()).thenReturn(true);
+		when(toolController.hasToolOptionsView()).thenReturn(true);
 
 		presenter.toolClicked(ToolType.TEXT);
 
-		verify(toolController).toggleToolOptions();
+		verify(toolController).toggleToolOptionsView();
 	}
 
 	@Test


### PR DESCRIPTION
* Add a new interface `ToolController` and an implementation `DefaultToolController`, which acts as a facade and simplifies the `MainActivityPresenter`
* Refactor `LayerTest`, `BaseToolWithRectangleShapeToolTest` and `ShapeToolTest` and remove dependency on android activity.
* Refactor `ShapeTool`, move any UI dependency into `ShapeToolOptions`

* Rename ToolOptions to ToolOptionsView