### PR TITLE
PAINTROID-65: Color picker as fullscreen

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/TapTargetIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/intro/TapTargetIntegrationTest.java
@@ -85,7 +85,7 @@ public class TapTargetIntegrationTest {
 	public void testRadiusBottomBar() {
 		IntroUtils.changeIntroPage(getPageIndexFromLayout(activityRule.getLayouts(), R.layout.pocketpaint_slide_intro_tools));
 		TapTargetBottomBar tapTargetBottomBar = IntroUtils.getTapTargetBottomBar(activityRule.getActivity());
-		int expectedRadius = IntroUtils.getExpectedRadiusForTapTarget();
+		int expectedRadius = IntroUtils.getExpectedRadiusForTapTarget() - 3;
 		int actualRadius = tapTargetBottomBar.radius;
 		assertEquals("Radius calculated Wrong", expectedRadius, actualRadius);
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/EspressoUtils.java
@@ -20,6 +20,7 @@
 package org.catrobat.paintroid.test.espresso.util;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.PointF;
@@ -29,10 +30,10 @@ import android.support.test.espresso.ViewInteraction;
 import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import android.support.test.runner.lifecycle.Stage;
 import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.View;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.common.Constants;
 import org.hamcrest.Matcher;
 
 import java.util.ArrayList;
@@ -71,9 +72,12 @@ public final class EspressoUtils {
 	 */
 	@Deprecated
 	public static float getActionbarHeight() {
-		Resources resources = InstrumentationRegistry.getTargetContext().getResources();
+		Context context = InstrumentationRegistry.getTargetContext();
+		TypedValue tv = new TypedValue();
+		context.getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true);
+		Resources resources = context.getResources();
 		DisplayMetrics metrics = resources.getDisplayMetrics();
-		return (Constants.ACTION_BAR_HEIGHT * metrics.density);
+		return TypedValue.complexToDimensionPixelSize(tv.data, metrics);
 	}
 
 	/**

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/IntroUtils.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/IntroUtils.java
@@ -26,6 +26,7 @@ import android.support.test.espresso.ViewInteraction;
 import android.support.test.espresso.matcher.BoundedMatcher;
 import android.support.test.espresso.matcher.ViewMatchers;
 import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.View;
 import android.widget.LinearLayout;
 
@@ -133,8 +134,10 @@ public final class IntroUtils {
 		final Context context = InstrumentationRegistry.getTargetContext();
 		final DisplayMetrics metrics = context.getResources().getDisplayMetrics();
 		int radiusOffset = TapTargetBase.RADIUS_OFFSET;
-		float dimension = context.getResources().getDimension(R.dimen.pocketpaint_main_top_bar_height);
-		return WelcomeActivityHelper.calculateTapTargetRadius(dimension, metrics, radiusOffset);
+		TypedValue tv = new TypedValue();
+		context.getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true);
+		int actionBarSize = TypedValue.complexToDimensionPixelSize(tv.data, metrics);
+		return WelcomeActivityHelper.calculateTapTargetRadius(actionBarSize, metrics, radiusOffset);
 	}
 
 	public static LinearLayout getBottomBarFromToolSlide(Activity activity) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -252,8 +252,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 			bottomNavigationViewHolder.setLandscapeStyle(getApplicationContext());
 		}
 
-		float density = getResources().getDisplayMetrics().density;
-		perspective = new Perspective(density, layerModel.getWidth(), layerModel.getHeight());
+		perspective = new Perspective(layerModel.getWidth(), layerModel.getHeight());
 		workspace = new DefaultWorkspace(layerModel, perspective, new DefaultWorkspace.Listener() {
 			@Override
 			public void invalidate() {
@@ -421,6 +420,12 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 	}
 
 	@Override
+	public boolean onSupportNavigateUp() {
+		onBackPressed();
+		return true;
+	}
+
+	@Override
 	public void commandPreExecute() {
 		presenter.onCommandPreExecute();
 	}
@@ -490,7 +495,12 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 
 	@Override
 	public void onBackPressed() {
-		presenter.onBackPressed();
+		FragmentManager supportFragmentManager = getSupportFragmentManager();
+		if (supportFragmentManager.isStateSaved()) {
+			super.onBackPressed();
+		} else if (!supportFragmentManager.popBackStackImmediate()) {
+			presenter.onBackPressed();
+		}
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
@@ -29,7 +29,6 @@ public final class Constants {
 
 	public static final String EXT_STORAGE_DIRECTORY_NAME = "Pocket Paint";
 	public static final String TEMP_PICTURE_NAME = "catroidTemp";
-	public static final float ACTION_BAR_HEIGHT = 50.0f;
 	public static final File MEDIA_DIRECTORY = new File(Environment.getExternalStorageDirectory(), EXT_STORAGE_DIRECTORY_NAME);
 
 	public static final String ABOUT_DIALOG_FRAGMENT_TAG = "aboutdialogfragment";

--- a/Paintroid/src/main/java/org/catrobat/paintroid/intro/TapTargetBase.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/intro/TapTargetBase.java
@@ -153,7 +153,7 @@ public abstract class TapTargetBase {
 				.descriptionTextSize(TapTargetStyle.TEXT_STYLE.getTextSize())
 				.textTypeface(TapTargetStyle.TEXT_STYLE.getTypeface())
 				.cancelable(true)
-				.outerCircleColor(R.color.pocketpaint_background_color)
+				.outerCircleColor(R.color.pocketpaint_colorPrimary)
 				.targetCircleColor(R.color.pocketpaint_color_picker_white);
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -65,12 +65,10 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 
 	@Override
 	public void showColorPickerDialog() {
-		FragmentManager fragmentManager = mainActivity.getSupportFragmentManager();
-		Fragment fragment = fragmentManager.findFragmentByTag(Constants.COLOR_PICKER_DIALOG_TAG);
-		if (fragment == null) {
-			ColorPickerDialog dialog = ColorPickerDialog.newInstance(toolReference.get().getDrawPaint().getColor());
+		if (findFragmentByTag(Constants.COLOR_PICKER_DIALOG_TAG) == null) {
+			ColorPickerDialog dialog = ColorPickerDialog.newInstance(toolReference.get().getDrawPaint().getColor(), true);
 			setupColorPickerDialogListeners(dialog);
-			showDialogFragmentSafely(dialog, Constants.COLOR_PICKER_DIALOG_TAG);
+			showFragment(dialog, Constants.COLOR_PICKER_DIALOG_TAG);
 		}
 	}
 
@@ -79,6 +77,19 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 		if (!fragmentManager.isStateSaved()) {
 			dialog.show(fragmentManager, tag);
 		}
+	}
+
+	private void showFragment(Fragment fragment, String tag) {
+		FragmentManager fragmentManager = mainActivity.getSupportFragmentManager();
+		fragmentManager.beginTransaction()
+				.setCustomAnimations(R.anim.slide_to_top, R.anim.slide_to_bottom, R.anim.slide_to_top, R.anim.slide_to_bottom)
+				.addToBackStack(null)
+				.add(R.id.fragment_container, fragment, tag)
+				.commit();
+	}
+
+	private Fragment findFragmentByTag(String tag) {
+		return mainActivity.getSupportFragmentManager().findFragmentByTag(tag);
 	}
 
 	private void setupColorPickerDialogListeners(ColorPickerDialog dialog) {
@@ -181,8 +192,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 
 	@Override
 	public boolean doIHavePermission(String permission) {
-		return ContextCompat.checkSelfPermission(mainActivity,
-				permission) == PackageManager.PERMISSION_GRANTED;
+		return ContextCompat.checkSelfPermission(mainActivity, permission) == PackageManager.PERMISSION_GRANTED;
 	}
 
 	@Override
@@ -236,8 +246,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 
 	@Override
 	public void restoreFragmentListeners() {
-		FragmentManager fragmentManager = mainActivity.getSupportFragmentManager();
-		Fragment fragment = fragmentManager.findFragmentByTag(Constants.COLOR_PICKER_DIALOG_TAG);
+		Fragment fragment = findFragmentByTag(Constants.COLOR_PICKER_DIALOG_TAG);
 		if (fragment != null) {
 			setupColorPickerDialogListeners((ColorPickerDialog) fragment);
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.java
@@ -24,14 +24,11 @@ import android.graphics.PointF;
 import android.graphics.Rect;
 import android.support.annotation.VisibleForTesting;
 
-import org.catrobat.paintroid.common.Constants;
-
 public class Perspective {
 	public static final float MIN_SCALE = 0.1f;
 	public static final float MAX_SCALE = 100f;
 	private static final float SCROLL_BORDER = 50f;
 	private static final float BORDER_ZOOM_FACTOR = 0.95f;
-	private static final float ACTION_BAR_HEIGHT = Constants.ACTION_BAR_HEIGHT;
 
 	@VisibleForTesting
 	public int surfaceWidth;
@@ -53,15 +50,12 @@ public class Perspective {
 	private float initialTranslationX;
 	@VisibleForTesting
 	public float initialTranslationY;
-	private final float actionbarHeight;
 
-	public Perspective(float screenDensity, int bitmapWidth, int bitmapHeight) {
+	public Perspective(int bitmapWidth, int bitmapHeight) {
 		this.bitmapWidth = bitmapWidth;
 		this.bitmapHeight = bitmapHeight;
 		surfaceScale = 1f;
 		isFullscreen = false;
-
-		actionbarHeight = ACTION_BAR_HEIGHT * screenDensity;
 	}
 
 	public synchronized void setSurfaceFrame(Rect surfaceFrame) {
@@ -80,8 +74,8 @@ public class Perspective {
 		surfaceScale = 1f;
 
 		if (surfaceWidth == 0 || surfaceHeight == 0) {
-			surfaceTranslationX = 0f;
-			surfaceTranslationY = -actionbarHeight;
+			surfaceTranslationX = 0;
+			surfaceTranslationY = 0;
 		} else {
 			surfaceTranslationX = surfaceWidth / 2f - bitmapWidth / 2;
 			initialTranslationX = surfaceTranslationX;

--- a/Paintroid/src/main/res/anim/slide_to_bottom.xml
+++ b/Paintroid/src/main/res/anim/slide_to_bottom.xml
@@ -16,17 +16,14 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 -->
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape>
-            <gradient
-                android:startColor="@color/pocketpaint_main_bottom_bar_color_transparent"
-                android:centerColor="@color/pocketpaint_colorPrimary"
-                android:endColor="@color/pocketpaint_colorPrimary"
-                android:centerX="50%"
-                android:type="linear"/>
-        </shape>
-    </item>
-</selector>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="150">
+    <translate
+        android:fromYDelta="0"
+        android:toYDelta="50%" />
+
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="0" />
+</set>

--- a/Paintroid/src/main/res/anim/slide_to_top.xml
+++ b/Paintroid/src/main/res/anim/slide_to_top.xml
@@ -16,17 +16,14 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 -->
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape>
-            <gradient
-                android:startColor="@color/pocketpaint_main_bottom_bar_color_transparent"
-                android:centerColor="@color/pocketpaint_colorPrimary"
-                android:endColor="@color/pocketpaint_colorPrimary"
-                android:centerX="50%"
-                android:type="linear"/>
-        </shape>
-    </item>
-</selector>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:anim/decelerate_interpolator"
+    android:duration="200">
+    <translate
+        android:fromYDelta="50%"
+        android:toYDelta="0" />
+    <alpha
+        android:fromAlpha="0"
+        android:toAlpha="1.0" />
+</set>

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_scroll_left_bg.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_scroll_left_bg.xml
@@ -22,8 +22,8 @@
     <item>
         <shape>
             <gradient
-                android:startColor="@color/pocketpaint_background_color"
-                android:centerColor="@color/pocketpaint_background_color"
+                android:startColor="@color/pocketpaint_colorPrimary"
+                android:centerColor="@color/pocketpaint_colorPrimary"
                 android:endColor="@color/pocketpaint_main_bottom_bar_color_transparent"
                 android:centerX="50%"
                 android:type="linear"/>

--- a/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
@@ -17,91 +17,101 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/pocketpaint_drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/pocketpaint_main_layout"
+    <android.support.v4.widget.DrawerLayout
+        android:id="@+id/pocketpaint_drawer_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/pocketpaint_layout_top_bar"
-            layout="@layout/pocketpaint_layout_top_bar"
-            android:layout_width="@dimen/pocketpaint_main_top_bar_landscape_width"
-            android:layout_height="match_parent"
-            android:layout_above="@+id/pocketpaint_main_bottom_navigation" />
-
-        <org.catrobat.paintroid.ui.DrawingSurface
-            android:id="@+id/pocketpaint_drawing_surface_view"
+        <RelativeLayout
+            android:id="@+id/pocketpaint_main_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_above="@+id/pocketpaint_main_bottom_navigation"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentEnd="true"
-            android:layout_toEndOf="@+id/pocketpaint_layout_top_bar"
-            android:background="@color/pocketpaint_main_drawing_surface_active" />
+            android:fitsSystemWindows="true">
 
-        <LinearLayout
-            android:id="@+id/pocketpaint_main_tool_options"
-            android:layout_width="match_parent"
+            <include
+                android:id="@+id/pocketpaint_layout_top_bar"
+                layout="@layout/pocketpaint_layout_top_bar"
+                android:layout_width="@dimen/pocketpaint_main_top_bar_landscape_width"
+                android:layout_height="match_parent"
+                android:layout_above="@+id/pocketpaint_main_bottom_navigation" />
+
+            <org.catrobat.paintroid.ui.DrawingSurface
+                android:id="@+id/pocketpaint_drawing_surface_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_above="@+id/pocketpaint_main_bottom_navigation"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentEnd="true"
+                android:layout_toEndOf="@+id/pocketpaint_layout_top_bar"
+                android:background="@color/pocketpaint_main_drawing_surface_active" />
+
+            <LinearLayout
+                android:id="@+id/pocketpaint_main_tool_options"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/background_light"
+                android:layout_alignParentBottom="true"
+                android:orientation="vertical"
+                android:layout_toStartOf="@+id/pocketpaint_main_bottom_bar"
+                android:layout_alignParentEnd="true"
+                android:layout_above="@+id/pocketpaint_main_bottom_navigation">
+
+                <include layout="@layout/pocketpaint_layout_tool_options"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/pocketpaint_main_bottom_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_alignParentEnd="true"
+                android:layout_above="@+id/pocketpaint_main_bottom_navigation"
+                android:background="@android:color/background_light"
+                android:visibility="gone">
+
+                <include layout="@layout/pocketpaint_layout_bottom_bar"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/pocketpaint_main_bottom_navigation"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/pocketpaint_main_bottom_bar_height"
+                android:background="?attr/colorPrimary"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentStart="true">
+
+                <include layout="@layout/pocketpaint_layout_bottom_navigation"/>
+            </LinearLayout>
+
+        </RelativeLayout>
+
+        <android.support.design.widget.NavigationView
+            android:id="@+id/pocketpaint_nav_view"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="start"
+            app:headerLayout="@layout/pocketpaint_layout_nav_header"
+            app:menu="@menu/menu_pocketpaint_activity"
+            android:background="@color/pocketpaint_main_navigation_drawer_background" />
+
+        <android.support.design.widget.NavigationView
+            android:id="@+id/pocketpaint_nav_view_layer"
+            android:layout_width="100dp"
             android:layout_height="wrap_content"
-            android:background="@android:color/background_light"
-            android:layout_alignParentBottom="true"
-            android:orientation="vertical"
-            android:layout_toStartOf="@+id/pocketpaint_main_bottom_bar"
-            android:layout_alignParentEnd="true"
-            android:layout_above="@+id/pocketpaint_main_bottom_navigation">
+            android:layout_gravity="end|center">
 
-            <include layout="@layout/pocketpaint_layout_tool_options"/>
-        </LinearLayout>
+            <include layout="@layout/pocketpaint_layout_main_menu_layer" />
+        </android.support.design.widget.NavigationView>
 
-        <LinearLayout
-            android:id="@+id/pocketpaint_main_bottom_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_alignParentEnd="true"
-            android:layout_above="@+id/pocketpaint_main_bottom_navigation"
-            android:background="@android:color/background_light"
-            android:visibility="gone">
+    </android.support.v4.widget.DrawerLayout>
 
-            <include layout="@layout/pocketpaint_layout_bottom_bar"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/pocketpaint_main_bottom_navigation"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/pocketpaint_main_bottom_bar_height"
-            android:background="@color/pocketpaint_background_color"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentStart="true">
-
-            <include layout="@layout/pocketpaint_layout_bottom_navigation"/>
-        </LinearLayout>
-
-    </RelativeLayout>
-
-    <android.support.design.widget.NavigationView
-        android:id="@+id/pocketpaint_nav_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/pocketpaint_layout_nav_header"
-        app:menu="@menu/menu_pocketpaint_activity"
-        android:background="@color/pocketpaint_main_navigation_drawer_background" />
-
-    <android.support.design.widget.NavigationView
-        android:id="@+id/pocketpaint_nav_view_layer"
-        android:layout_width="100dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|center">
-
-        <include layout="@layout/pocketpaint_layout_main_menu_layer" />
-    </android.support.design.widget.NavigationView>
-
-</android.support.v4.widget.DrawerLayout>
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</RelativeLayout>

--- a/Paintroid/src/main/res/layout-land/pocketpaint_layout_top_bar.xml
+++ b/Paintroid/src/main/res/layout-land/pocketpaint_layout_top_bar.xml
@@ -26,6 +26,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="2dp"
+    android:theme="?attr/actionBarStyle"
     tools:showIn="@layout/activity_pocketpaint_main">
 
     <android.support.v7.widget.Toolbar

--- a/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
@@ -17,84 +17,94 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/pocketpaint_drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/pocketpaint_main_layout"
+    <android.support.v4.widget.DrawerLayout
+        android:id="@+id/pocketpaint_drawer_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
-        <include layout="@layout/pocketpaint_layout_top_bar"
-            android:id="@+id/pocketpaint_layout_top_bar" />
+        <RelativeLayout
+            android:id="@+id/pocketpaint_main_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true">
 
-        <org.catrobat.paintroid.ui.DrawingSurface
-            android:id="@+id/pocketpaint_drawing_surface_view"
-            android:layout_below="@+id/pocketpaint_layout_top_bar"
-            android:layout_alignParentStart="true"
-            android:layout_above="@+id/pocketpaint_main_bottom_navigation"
-            android:layout_alignParentEnd="true"
+            <include layout="@layout/pocketpaint_layout_top_bar"
+                android:id="@+id/pocketpaint_layout_top_bar" />
+
+            <org.catrobat.paintroid.ui.DrawingSurface
+                android:id="@+id/pocketpaint_drawing_surface_view"
+                android:layout_below="@+id/pocketpaint_layout_top_bar"
+                android:layout_alignParentStart="true"
+                android:layout_above="@+id/pocketpaint_main_bottom_navigation"
+                android:layout_alignParentEnd="true"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@color/pocketpaint_main_drawing_surface_active" />
+
+            <LinearLayout
+                android:id="@+id/pocketpaint_main_tool_options"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="100dp"
+                android:layout_alignParentBottom="true"
+                android:background="@android:color/background_light">
+
+                <include layout="@layout/pocketpaint_layout_tool_options"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/pocketpaint_main_bottom_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_above="@+id/pocketpaint_main_bottom_navigation"
+                android:background="@android:color/background_light"
+                android:layout_alignParentBottom="false"
+                android:layout_alignParentStart="true"
+                android:visibility="gone">
+
+                <include layout="@layout/pocketpaint_layout_bottom_bar"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/pocketpaint_main_bottom_navigation"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/pocketpaint_main_bottom_bar_height"
+                android:background="?attr/colorPrimary"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentStart="true">
+
+                <include layout="@layout/pocketpaint_layout_bottom_navigation"/>
+            </LinearLayout>
+        </RelativeLayout>
+
+        <android.support.design.widget.NavigationView
+            android:id="@+id/pocketpaint_nav_view"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:background="@color/pocketpaint_main_drawing_surface_active" />
+            android:layout_gravity="start"
+            app:headerLayout="@layout/pocketpaint_layout_nav_header"
+            app:menu="@menu/menu_pocketpaint_activity"
+            android:background="@color/pocketpaint_main_navigation_drawer_background">
+        </android.support.design.widget.NavigationView>
 
-        <LinearLayout
-            android:id="@+id/pocketpaint_main_tool_options"
-            android:layout_width="match_parent"
+        <android.support.design.widget.NavigationView
+            android:id="@+id/pocketpaint_nav_view_layer"
+            android:layout_width="100dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="100dp"
-            android:layout_alignParentBottom="true"
-            android:background="@android:color/background_light">
+            android:layout_gravity="end|center">
 
-            <include layout="@layout/pocketpaint_layout_tool_options"/>
-        </LinearLayout>
+            <include layout="@layout/pocketpaint_layout_main_menu_layer" />
+        </android.support.design.widget.NavigationView>
 
-        <LinearLayout
-            android:id="@+id/pocketpaint_main_bottom_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@android:color/background_light"
-            android:layout_above="@+id/pocketpaint_main_bottom_navigation"
-            android:layout_alignParentBottom="false"
-            android:layout_alignParentStart="true"
-            android:visibility="gone">
+    </android.support.v4.widget.DrawerLayout>
 
-            <include layout="@layout/pocketpaint_layout_bottom_bar"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/pocketpaint_main_bottom_navigation"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/pocketpaint_main_bottom_bar_height"
-            android:background="@color/pocketpaint_background_color"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentStart="true">
-
-            <include layout="@layout/pocketpaint_layout_bottom_navigation"/>
-        </LinearLayout>
-    </RelativeLayout>
-
-    <android.support.design.widget.NavigationView
-        android:id="@+id/pocketpaint_nav_view"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:headerLayout="@layout/pocketpaint_layout_nav_header"
-        app:menu="@menu/menu_pocketpaint_activity"
-        android:background="@color/pocketpaint_main_navigation_drawer_background">
-    </android.support.design.widget.NavigationView>
-
-    <android.support.design.widget.NavigationView
-        android:id="@+id/pocketpaint_nav_view_layer"
-        android:layout_width="100dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|center">
-
-        <include layout="@layout/pocketpaint_layout_main_menu_layer" />
-    </android.support.design.widget.NavigationView>
-
-</android.support.v4.widget.DrawerLayout>
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</RelativeLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_intro_top_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_intro_top_bar.xml
@@ -23,7 +23,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/pocketpaint_intro_top_bar"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/pocketpaint_main_top_bar_height"
+    android:layout_height="?attr/actionBarSize"
     tools:showIn="@layout/activity_pocketpaint_main">
 
     <android.support.v7.widget.Toolbar

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_top_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_top_bar.xml
@@ -23,7 +23,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/pocketpaint_layout_top_bar"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/pocketpaint_main_top_bar_height"
+    android:layout_height="?attr/actionBarSize"
+    android:theme="?attr/actionBarStyle"
     tools:showIn="@layout/activity_pocketpaint_main">
 
     <android.support.v7.widget.Toolbar

--- a/Paintroid/src/main/res/values/colors.xml
+++ b/Paintroid/src/main/res/values/colors.xml
@@ -20,11 +20,10 @@
 -->
 <resources>
     <!-- PocketPaint theme colors -->
-    <color name="pocketpaint_colorPrimary">#00838F</color>
+    <color name="pocketpaint_colorPrimary">#0097A7</color>
     <color name="pocketpaint_colorPrimaryDark">#00838F</color>
     <color name="pocketpaint_colorAccent">#33B5E5</color>
     <color name="pocketpaint_text_color_link">#E68B00</color>
-    <color name="pocketpaint_background_color">#0097A7</color>
 
     <!-- PocketPaint main activity -->
     <color name="pocketpaint_main_separator_color">#c8e8ff</color>

--- a/Paintroid/src/main/res/values/dimens.xml
+++ b/Paintroid/src/main/res/values/dimens.xml
@@ -20,7 +20,6 @@
     <!-- PocketPaint MainActivity -->
     <dimen name="pocketpaint_main_bottom_bar_button_width">65dp</dimen>
     <dimen name="pocketpaint_main_bottom_bar_height">50dp</dimen>
-    <dimen name="pocketpaint_main_top_bar_height">50dp</dimen>
     <dimen name="pocketpaint_main_top_bar_landscape_width">50dp</dimen>
 
     <!-- PocketPaint WelcomeActivity -->

--- a/Paintroid/src/main/res/values/style.xml
+++ b/Paintroid/src/main/res/values/style.xml
@@ -43,14 +43,12 @@
     <style name="PocketPaintTheme" parent="PocketPaintTheme.Base" />
 
     <style name="PocketPaintTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowBackground">@color/pocketpaint_background_color</item>
-        <item name="windowNoTitle">true</item>
-        <item name="windowActionBar">false</item>
+        <item name="android:windowBackground">@color/pocketpaint_colorPrimary</item>
         <item name="dialogTheme">@style/PocketPaintAlertDialog</item>
         <item name="colorPrimary">@color/pocketpaint_colorPrimary</item>
         <item name="colorPrimaryDark">@color/pocketpaint_colorPrimaryDark</item>
         <item name="colorAccent">@color/pocketpaint_colorAccent</item>
-        <item name="drawerArrowStyle">@style/PocketPaintDrawerArrowStyle</item>
+        <item name="actionBarStyle">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
     </style>
 
     <style name="PocketPaintHighlightColorTheme" parent="PocketPaintTheme">
@@ -86,11 +84,6 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textSize">12sp</item>
         <item name="android:textColor">@android:color/black</item>
-    </style>
-
-    <style name="PocketPaintDrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
-        <item name="spinBars">false</item>
-        <item name="color">@android:color/white</item>
     </style>
 
     <style name="PocketPaintToolTitle" parent="PocketPaintToolSubtitle">
@@ -147,12 +140,12 @@
     </style>
 
     <style name="PocketPaintWelcomeActivityTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:colorBackground">@color/pocketpaint_background_color</item>
-        <item name="android:windowBackground">@color/pocketpaint_background_color</item>
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowActionBar">false</item>
+        <item name="colorPrimary">@color/pocketpaint_colorPrimary</item>
+        <item name="android:colorBackground">@color/pocketpaint_colorPrimary</item>
+        <item name="android:windowBackground">@color/pocketpaint_colorPrimary</item>
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowContentOverlay">@null</item>
+        <item name="actionBarStyle">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
     </style>
 
 </resources>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/ui/PerspectiveTests.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/ui/PerspectiveTests.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class PerspectiveTests {
 
-	private static final float SCREEN_DENSITY = 2f;
 	private static final int SURFACE_WIDTH = 10;
 	private static final int SURFACE_HEIGHT = 100;
 	private static final float EXACT_CENTER_X = 5f;
@@ -63,7 +62,7 @@ public class PerspectiveTests {
 		when(surfaceFrame.exactCenterY()).thenReturn(EXACT_CENTER_Y);
 		when(holder.getSurfaceFrame()).thenReturn(surfaceFrame);
 
-		perspective = new Perspective(SCREEN_DENSITY, 0, 0);
+		perspective = new Perspective(0, 0);
 		perspective.setSurfaceFrame(surfaceFrame);
 	}
 

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.java
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.java
@@ -57,7 +57,10 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDialogFragment;
+import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -69,6 +72,7 @@ import java.util.List;
 public final class ColorPickerDialog extends AppCompatDialogFragment implements ColorPickerView.OnColorChangedListener {
 	private static final String CURRENT_COLOR = "CurrentColor";
 	private static final String INITIAL_COLOR = "InitialColor";
+	private static final String SHOW_ACTION_BAR = "ShowActionBar";
 	@VisibleForTesting
 	public List<OnColorPickedListener> onColorPickedListener = new ArrayList<>();
 	private ColorPickerView colorPickerView;
@@ -78,10 +82,15 @@ public final class ColorPickerDialog extends AppCompatDialogFragment implements 
 	private Shader checkeredShader;
 
 	public static ColorPickerDialog newInstance(@ColorInt int initialColor) {
+		return newInstance(initialColor, false);
+	}
+
+	public static ColorPickerDialog newInstance(@ColorInt int initialColor, boolean showActionBar) {
 		ColorPickerDialog dialog = new ColorPickerDialog();
 		Bundle bundle = new Bundle();
 		bundle.putInt(INITIAL_COLOR, initialColor);
 		bundle.putInt(CURRENT_COLOR, initialColor);
+		bundle.putBoolean(SHOW_ACTION_BAR, showActionBar);
 		dialog.setArguments(bundle);
 		return dialog;
 	}
@@ -107,7 +116,7 @@ public final class ColorPickerDialog extends AppCompatDialogFragment implements 
 	@Nullable
 	@Override
 	public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-		return inflater.inflate(R.layout.dialog_color_picker, container);
+		return inflater.inflate(R.layout.dialog_color_picker, container, false);
 	}
 
 	@Override
@@ -145,6 +154,32 @@ public final class ColorPickerDialog extends AppCompatDialogFragment implements 
 		}
 
 		colorToApply = colorPickerView.getInitialColor();
+
+		boolean showActionBar = getArguments().getBoolean(SHOW_ACTION_BAR);
+		Toolbar toolbar = view.findViewById(R.id.color_picker_toolbar);
+
+		if (getShowsDialog() || !showActionBar) {
+			toolbar.setVisibility(View.GONE);
+		} else {
+			AppCompatActivity activity = (AppCompatActivity) getActivity();
+			activity.setSupportActionBar(toolbar);
+
+			ActionBar supportActionBar = activity.getSupportActionBar();
+			if (supportActionBar != null) {
+				supportActionBar.setDisplayHomeAsUpEnabled(true);
+				supportActionBar.setDisplayShowHomeEnabled(true);
+				supportActionBar.setTitle(R.string.color_picker_title);
+			}
+		}
+	}
+
+	@Override
+	public void dismiss() {
+		if (getShowsDialog()) {
+			super.dismiss();
+		} else {
+			getActivity().getSupportFragmentManager().popBackStack();
+		}
 	}
 
 	@NonNull

--- a/colorpicker/src/main/res/layout/dialog_color_picker.xml
+++ b/colorpicker/src/main/res/layout/dialog_color_picker.xml
@@ -17,28 +17,42 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/color_picker_base_layout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:padding="16dp">
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:clickable="true"
+    android:focusable="true">
 
-    <ScrollView
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/color_picker_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        tools:ignore="UselessParent">
+        android:layout_height="?attr/actionBarSize"
+        android:theme="?attr/actionBarStyle"
+        android:background="?attr/colorPrimary" />
 
-        <LinearLayout
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/color_picker_toolbar"
+        android:padding="16dp">
+
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:orientation="vertical">
 
-            <org.catrobat.paintroid.colorpicker.ColorPickerView
-                android:id="@+id/color_picker_view"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <org.catrobat.paintroid.colorpicker.ColorPickerView
+                    android:id="@+id/color_picker_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -46,32 +60,33 @@
                     android:layout_marginTop="16dp"
                     android:orientation="horizontal">
 
-                <Button
-                    android:id="@+id/color_picker_button_cancel"
-                    style="?android:borderlessButtonStyle"
-                    android:layout_weight="1"
-                    android:layout_height="wrap_content"
-                    android:layout_width="0dp"
-                    android:layout_marginEnd="8dp"
-                    android:background="@null"
-                    tools:background="@android:color/darker_gray"
-                    android:text="@string/color_picker_cancel"
-                    android:textSize="14sp" />
+                    <Button
+                        android:id="@+id/color_picker_button_cancel"
+                        style="?android:borderlessButtonStyle"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="@null"
+                        tools:background="@android:color/darker_gray"
+                        android:text="@string/color_picker_cancel"
+                        android:textSize="14sp" />
 
-                <Button
-                    android:id="@+id/color_picker_button_ok"
-                    style="?android:borderlessButtonStyle"
-                    android:layout_weight="1"
-                    android:layout_height="wrap_content"
-                    android:layout_width="0dp"
-                    android:layout_marginStart="8dp"
-                    android:background="@null"
-                    tools:background="@android:color/darker_gray"
-                    android:text="@string/color_picker_apply"
-                    android:textSize="14sp" />
+                    <Button
+                        android:id="@+id/color_picker_button_ok"
+                        style="?android:borderlessButtonStyle"
+                        android:layout_weight="1"
+                        android:layout_height="wrap_content"
+                        android:layout_width="0dp"
+                        android:layout_marginStart="8dp"
+                        android:background="@null"
+                        tools:background="@android:color/darker_gray"
+                        android:text="@string/color_picker_apply"
+                        android:textSize="14sp" />
+                </LinearLayout>
             </LinearLayout>
-        </LinearLayout>
-    </ScrollView>
-</FrameLayout>
+        </ScrollView>
+    </FrameLayout>
+</RelativeLayout>
 
 


### PR DESCRIPTION
* Use color picker as fragment
* Add an optional action bar into colorpicker (workaround for our current main activity layout)
* Ensure that the color picker can still be used as a dialog
* Add a pleasing transition animation
* Change top bar size to default android action bar size