### PR TITLE
PAINTROID-102: Fix crash when tool is null in drawingsurface

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -159,7 +159,10 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 					surfaceViewCanvas.drawBitmap(iterator.previous().getBitmap(), 0, 0, null);
 				}
 
-				toolReference.get().draw(surfaceViewCanvas);
+				Tool tool = toolReference.get();
+				if (tool != null) {
+					tool.draw(surfaceViewCanvas);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
* This might still not completely fix all issues, the locking has
  to be reworked in the future