### PR TITLE
PAINTROID-107: Fix crash on Android API >= 28

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -386,7 +386,7 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 	protected void drawBitmap(Canvas canvas, float boxWidth, float boxHeight) {
 		tempDrawingRectangle.set(-boxWidth / 2, -boxHeight / 2,
 				boxWidth / 2, boxHeight / 2);
-		canvas.clipRect(tempDrawingRectangle, Op.UNION);
+		canvas.clipRect(tempDrawingRectangle);
 		canvas.drawBitmap(drawingBitmap, null, tempDrawingRectangle, null);
 	}
 


### PR DESCRIPTION
* Remove calls to `Canvas.clipRect` with deprecated `Region.Op` values
  See https://developer.android.com/reference/android/graphics/Canvas#clipRect(android.graphics.Rect,%2520android.graphics.Region.Op)