### PR TITLE
PAINTROID-105 ColorPicker Hex Input too long

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -346,6 +346,21 @@ public class ColorDialogIntegrationTest {
 	}
 
 	@Test
+	public void testHEXEditTextMaxInputLength() {
+		onColorPickerView()
+				.performOpenColorPicker();
+
+		onView(allOf(withId(R.id.color_picker_tab_icon), withBackground(R.drawable.ic_color_picker_tab_rgba))).perform(click());
+		onView(withClassName(containsString(TAB_VIEW_RGBA_SELECTOR_CLASS))).check(matches(isDisplayed()));
+
+		onView(withId(R.id.color_picker_color_rgb_hex)).perform(replaceText("#0123456789ABCDEF01234"));
+
+		onView(withId(R.id.color_picker_color_rgb_hex)).check(matches(
+				withText(
+						String.format("#0123456789ABCDEF0"))));
+	}
+
+	@Test
 	public void testHEXUpdatingOnColorChange() {
 		onColorPickerView()
 				.performOpenColorPicker();

--- a/colorpicker/src/main/res/layout/color_picker_layout_rgbview.xml
+++ b/colorpicker/src/main/res/layout/color_picker_layout_rgbview.xml
@@ -205,6 +205,7 @@
                 android:layout_gravity="center_vertical|center_horizontal"
                 android:hint="#"
                 android:inputType="textNoSuggestions"
+                android:maxLength="18"
                 tools:ignore="HardcodedText"/>
         </TableRow>
     </TableLayout>


### PR DESCRIPTION
Took 18 as maxLength because it fits 2 times '#' + HexCode. So it is perfect for copy&paste