### PR TITLE
PAINTROID-118 More options menu should use a light background theme

### DIFF
--- a/Paintroid/src/main/res/values/style.xml
+++ b/Paintroid/src/main/res/values/style.xml
@@ -49,6 +49,8 @@
         <item name="colorPrimaryDark">@color/pocketpaint_colorPrimaryDark</item>
         <item name="colorAccent">@color/pocketpaint_colorAccent</item>
         <item name="actionBarStyle">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+        <item name="android:itemBackground">@android:color/white</item>
+        <item name="android:textColor">@android:color/black</item>
     </style>
 
     <style name="PocketPaintHighlightColorTheme" parent="PocketPaintTheme">


### PR DESCRIPTION
-changed MoreOptionsMenu to black text on white background