### PR TITLE
JENKINS-366 quickfix disable fastlane installation to fix Dockerfile

### DIFF
--- a/docker/Dockerfile.jenkins
+++ b/docker/Dockerfile.jenkins
@@ -53,21 +53,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libasound2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Fastlane
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        rubygems \
-        ruby-dev \
-        g++ \
-        make \
-        less \
-    && rm -rf /var/lib/apt/lists/* \
-    && gem update --system \
-    && gem install fastlane -NV \
-    && apt-get purge -y --auto-remove \
-        ruby-dev \
-        g++ \
-        make
-
 # User Management
 # ---------------
 #


### PR DESCRIPTION
Unfortunately the Dockerfile is not working as we have incompatible versions of gem and fastlane at the moment - this is a quick fix to fix this.

However we need to fix the situation to be able to have fastlane for releases again. See Jenkins Ticket https://jira.catrob.at/browse/JENKINS-330 for that (is already in progress)