### PR TITLE
PAINTROID-135: Rate us button in standalone only

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/MoreOptionsIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/MoreOptionsIntegrationTest.java
@@ -75,11 +75,11 @@ public class MoreOptionsIntegrationTest {
 				.checkItemExists(R.string.menu_hide_menu)
 				.checkItemExists(R.string.help_title)
 				.checkItemExists(R.string.pocketpaint_menu_about)
-				.checkItemExists(R.string.menu_rate_us)
 
 				.checkItemDoesNotExist(R.string.menu_save_image)
 				.checkItemDoesNotExist(R.string.menu_save_copy)
 				.checkItemDoesNotExist(R.string.menu_new_image)
+				.checkItemDoesNotExist(R.string.menu_rate_us)
 
 				.checkItemExists(R.string.menu_discard_image)
 				.checkItemExists(R.string.menu_export);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/viewholder/TopBarViewHolder.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/viewholder/TopBarViewHolder.java
@@ -82,6 +82,7 @@ public class TopBarViewHolder implements MainActivityContracts.TopBarViewHolder 
 		menu.removeItem(R.id.pocketpaint_options_save_duplicate);
 		menu.removeItem(R.id.pocketpaint_options_new_image);
 		menu.removeItem(R.id.pocketpaint_options_try_pocket_code);
+		menu.removeItem(R.id.pocketpaint_options_rate_us);
 	}
 
 	@Override


### PR DESCRIPTION
Added "Rate Us!" button to the removed buttons when opened from catroid.

https://jira.catrob.at/browse/PAINTROID-135

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
