### PR TITLE
PAINTROID-134 ShapeTool with width 1 had width 2

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ShapeToolOptionsViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ShapeToolOptionsViewInteraction.java
@@ -19,6 +19,8 @@
 
 package org.catrobat.paintroid.test.espresso.util.wrappers;
 
+import android.support.test.espresso.ViewAction;
+
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.tools.drawable.DrawableShape;
 import org.catrobat.paintroid.tools.drawable.DrawableStyle;
@@ -70,5 +72,10 @@ public final class ShapeToolOptionsViewInteraction extends CustomViewInteraction
 		onView(withId(getButtonIdFromShapeDrawType(shapeDrawType)))
 				.perform(click());
 		return this;
+	}
+
+	public void performSetOutlineWidth(ViewAction setWidth) {
+		onView(withId(R.id.pocketpaint_shape_stroke_width_seek_bar))
+				.perform(setWidth);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
@@ -162,6 +162,8 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 				paint.setStrokeWidth(shapeOutlineWidth);
 				paint.setStrokeCap(Paint.Cap.BUTT);
 				paint.setStrokeJoin(Paint.Join.MITER);
+				boolean antiAlias = (shapeOutlineWidth > 1);
+				paint.setAntiAlias(antiAlias);
 				break;
 			default:
 				break;
@@ -180,7 +182,7 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 				&& toolPosition.x + boxWidth / 2 >= 0
 				&& toolPosition.y + boxHeight / 2 >= 0) {
 
-			Paint paint = new Paint(toolPaint.getPaint());
+			Paint paint = toolPaint.getPaint();
 			RectF shapeRect = new RectF();
 			preparePaint(paint);
 			prepareShapeRectangle(shapeRect, boxWidth, boxHeight);


### PR DESCRIPTION
- Fixed error that ShapeTool with outlineWidth one had width 2 and anti aliasing was turned on

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
