### PR TITLE
PAINTROID-116 ColorChooser not fullscreen

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -43,6 +43,8 @@ public interface MainActivityContracts {
 	interface Navigator {
 		void showColorPickerDialog();
 
+		void showColorPickerDialogFullscreen();
+
 		void startLoadImageActivity(@ActivityRequestCode int requestCode);
 
 		void startImportImageActivity(@ActivityRequestCode int requestCode);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -382,7 +382,11 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void showColorPickerClicked() {
-		navigator.showColorPickerDialog();
+		if (model.isOpenedFromCatroid()) {
+			navigator.showColorPickerDialogFullscreen();
+		} else {
+			navigator.showColorPickerDialog();
+		}
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -73,6 +73,15 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 		if (findFragmentByTag(Constants.COLOR_PICKER_DIALOG_TAG) == null) {
 			ColorPickerDialog dialog = ColorPickerDialog.newInstance(toolReference.get().getDrawPaint().getColor(), true);
 			setupColorPickerDialogListeners(dialog);
+			showDialogFragmentSafely(dialog, Constants.COLOR_PICKER_DIALOG_TAG);
+		}
+	}
+
+	@Override
+	public void showColorPickerDialogFullscreen() {
+		if (findFragmentByTag(Constants.COLOR_PICKER_DIALOG_TAG) == null) {
+			ColorPickerDialog dialog = ColorPickerDialog.newInstance(toolReference.get().getDrawPaint().getColor(), true);
+			setupColorPickerDialogListeners(dialog);
 			showFragment(dialog, Constants.COLOR_PICKER_DIALOG_TAG);
 		}
 	}


### PR DESCRIPTION
- ColorChooser is no longer fullscreen in Standalone

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
