### PR TITLE
PAINTROID-136 ShapeTool With Transparent Outline Not Working

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/RectangleFillToolIntegrationTest.java
@@ -153,6 +153,45 @@ public class RectangleFillToolIntegrationTest {
 	}
 
 	@Test
+	public void testShapeWithOutlineAlsoWorksWithTransparentColor() {
+		onToolBarView()
+				.performSelectTool(ToolType.SHAPE);
+		onShapeToolOptionsView()
+				.performSelectShape(ShapeTool.BaseShape.RECTANGLE);
+		onShapeToolOptionsView()
+				.performSelectContour(ShapeTool.ShapeDrawType.FILL);
+		onToolProperties()
+				.setColor(Color.BLACK);
+		drawShape();
+		checkWorkspaceAtCenterPositionHasColor(Color.BLACK);
+
+		onToolBarView()
+				.performClickSelectedToolButton();
+
+		onShapeToolOptionsView()
+				.performSelectShape(ShapeTool.BaseShape.OVAL);
+		onShapeToolOptionsView()
+				.performSelectContour(ShapeTool.ShapeDrawType.OUTLINE);
+		onToolProperties()
+				.setColor(Color.TRANSPARENT);
+		drawShape();
+		checkWorkspaceAtCenterPositionHasColor(Color.BLACK);
+
+		BaseToolWithRectangleShape tool = (BaseToolWithRectangleShape) toolReference.get();
+		Bitmap drawingBitmap = tool.drawingBitmap;
+
+		Bitmap bitmap = workspace.getBitmapOfCurrentLayer();
+
+		int pointX = bitmap.getWidth() / 2 - drawingBitmap.getWidth() / 2;
+		int pointY = bitmap.getHeight() / 2 - drawingBitmap.getHeight() / 2;
+
+		Point topMiddlePointInRectangle = new Point(pointX, pointY);
+
+		int colorInRectangle = bitmap.getPixel(topMiddlePointInRectangle.x, topMiddlePointInRectangle.y);
+		assertThat(colorInRectangle, is(Color.TRANSPARENT));
+	}
+
+	@Test
 	public void testFilledRectChangesColor() {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
@@ -265,6 +304,24 @@ public class RectangleFillToolIntegrationTest {
 
 		pixelColor = bitmap.getPixel(upperRightPixel.x, upperRightPixel.y);
 		assertEquals("Pixel should have been erased", Color.TRANSPARENT, pixelColor);
+	}
+
+	public void drawShape() {
+		onToolBarView()
+				.performCloseToolOptionsView();
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION));
+	}
+
+	public void checkWorkspaceAtCenterPositionHasColor(int color) {
+		Bitmap bitmap = workspace.getBitmapOfCurrentLayer();
+
+		int colorInRectangle = bitmap.getPixel(bitmap.getWidth() / 2, bitmap.getHeight() / 2);
+		if (Color.alpha(color) == 0x00) {
+			assertThat(colorInRectangle, is(anyOf(is(Color.WHITE), is(0xFFC0C0C0))));
+		} else {
+			assertEquals(color, colorInRectangle);
+		}
 	}
 
 	public void selectShapeTypeAndDraw(boolean changeColor, int color) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ShapeToolOptionsViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ShapeToolOptionsViewInteraction.java
@@ -56,4 +56,18 @@ public final class ShapeToolOptionsViewInteraction extends CustomViewInteraction
 		}
 		return this;
 	}
+
+	public ShapeToolOptionsViewInteraction performSelectContour(ShapeTool.ShapeDrawType shape) {
+		switch (shape) {
+			case OUTLINE:
+				onView(withId(R.id.pocketpaint_shape_ibtn_outline))
+						.perform(click());
+				break;
+			case FILL:
+				onView(withId(R.id.pocketpaint_shape_ibtn_fill))
+						.perform(click());
+				break;
+		}
+		return this;
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
@@ -123,6 +123,18 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 		drawPaint.setColor(toolPaint.getPreviewColor());
 		drawPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
 
+		geometricFillCommandPaint = new Paint(Paint.DITHER_FLAG);
+		if (Color.alpha(toolPaint.getPreviewColor()) == 0x00) {
+			int colorWithMaxAlpha = Color.BLACK;
+			geometricFillCommandPaint.setColor(colorWithMaxAlpha);
+			geometricFillCommandPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_OUT));
+			geometricFillCommandPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
+
+			drawPaint.reset();
+			drawPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
+			drawPaint.setShader(checkeredShader);
+		}
+
 		switch (shapeDrawType) {
 			case FILL:
 				drawPaint.setStyle(Style.FILL);
@@ -134,18 +146,6 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 				break;
 			default:
 				break;
-		}
-
-		geometricFillCommandPaint = new Paint(Paint.DITHER_FLAG);
-		if (Color.alpha(toolPaint.getPreviewColor()) == 0x00) {
-			int colorWithMaxAlpha = Color.BLACK;
-			geometricFillCommandPaint.setColor(colorWithMaxAlpha);
-			geometricFillCommandPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.DST_OUT));
-			geometricFillCommandPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
-
-			drawPaint.reset();
-			drawPaint.setAntiAlias(DEFAULT_ANTIALIASING_ON);
-			drawPaint.setShader(checkeredShader);
 		}
 
 		shapeRect = new RectF(0, 0, boxWidth, boxHeight);


### PR DESCRIPTION
- Fixed Bug That ShapeTool with Transparent Outline Worked Like in Fill Mode
- added Test to ensure ShapeTool with Transparent Outline Works

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
