### PR TITLE
PAINTROID-137: Stamp tool capture current layer

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/DrawingSurfaceInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/DrawingSurfaceInteraction.java
@@ -70,6 +70,24 @@ public final class DrawingSurfaceInteraction extends CustomViewInteraction {
 		return this;
 	}
 
+	public DrawingSurfaceInteraction checkPixelColor(@ColorInt final int expectedColor, final float x, final float y) {
+		check(matches(new TypeSafeMatcher<View>() {
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("Color at coordinates is " + Integer.toHexString(expectedColor));
+			}
+
+			@Override
+			protected boolean matchesSafely(View view) {
+				MainActivity activity = getMainActivityFromView(view);
+				LayerContracts.Layer currentLayer = activity.layerModel.getCurrentLayer();
+				int actualColor = currentLayer.getBitmap().getPixel((int) x, (int) y);
+				return expectedColor == actualColor;
+			}
+		}));
+		return this;
+	}
+
 	public DrawingSurfaceInteraction checkPixelColorResource(@ColorRes int expectedColorRes, CoordinatesProvider coordinateProvider) {
 		int expectedColor = ContextCompat.getColor(InstrumentationRegistry.getTargetContext(), expectedColorRes);
 		return checkPixelColor(expectedColor, coordinateProvider);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.java
@@ -71,7 +71,7 @@ public class StampTool extends BaseToolWithRectangleShape {
 			drawingBitmap = Bitmap.createBitmap((int) boxWidth, (int) boxHeight, Config.ARGB_8888);
 		}
 
-		Bitmap layerBitmap = workspace.getBitmapOfAllLayers();
+		Bitmap layerBitmap = workspace.getBitmapOfCurrentLayer();
 
 		Canvas canvas = new Canvas(drawingBitmap);
 		canvas.translate(-toolPosition.x + boxWidth / 2, -toolPosition.y + boxHeight / 2);


### PR DESCRIPTION
Changed stamp tool behaviour to only capture current layer contents.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
