### PR TITLE
PAINTROID-171: Removed strike through option from text tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
@@ -102,7 +102,6 @@ public class TextToolIntegrationTest {
 	private ToggleButton underlinedToggleButton;
 	private ToggleButton italicToggleButton;
 	private ToggleButton boldToggleButton;
-	private ToggleButton strikeThroughToggleButton;
 	private EditText textSize;
 	private Perspective perspective;
 	private LayerContracts.Model layerModel;
@@ -127,7 +126,6 @@ public class TextToolIntegrationTest {
 		underlinedToggleButton = activity.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_underlined);
 		italicToggleButton = activity.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_italic);
 		boldToggleButton = activity.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_bold);
-		strikeThroughToggleButton = activity.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_strike_through);
 		textSize = activity.findViewById(R.id.pocketpaint_font_size_text);
 		textTool.resetBoxPosition();
 	}
@@ -137,7 +135,6 @@ public class TextToolIntegrationTest {
 		selectFormatting(FormattingOptions.ITALIC);
 		selectFormatting(FormattingOptions.BOLD);
 		selectFormatting(FormattingOptions.UNDERLINE);
-		selectFormatting(FormattingOptions.STRIKETHROUGH);
 
 		enterTestText();
 
@@ -149,7 +146,6 @@ public class TextToolIntegrationTest {
 		assertTrue(italicToggleButton.isChecked());
 		assertTrue(boldToggleButton.isChecked());
 		assertTrue(underlinedToggleButton.isChecked());
-		assertTrue(strikeThroughToggleButton.isChecked());
 		assertEquals(TEST_TEXT, textEditText.getText().toString());
 	}
 
@@ -174,13 +170,10 @@ public class TextToolIntegrationTest {
 				.check(matches(isNotChecked()));
 		onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_italic))
 				.check(matches(isNotChecked()));
-		onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_strike_through))
-				.check(matches(isNotChecked()));
 
 		assertFalse(textTool.underlined);
 		assertFalse(textTool.italic);
 		assertFalse(textTool.bold);
-		assertFalse(textTool.strikeThrough);
 	}
 
 	@Test
@@ -221,16 +214,6 @@ public class TextToolIntegrationTest {
 		assertFalse(getToolMemberBold());
 		assertFalse(boldToggleButton.isChecked());
 		assertEquals(getFontString(FormattingOptions.BOLD), boldToggleButton.getText().toString());
-
-		selectFormatting(FormattingOptions.STRIKETHROUGH);
-		assertTrue(getToolMemberStrikeThrough());
-		assertTrue(strikeThroughToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.STRIKETHROUGH), strikeThroughToggleButton.getText().toString());
-
-		selectFormatting(FormattingOptions.STRIKETHROUGH);
-		assertFalse(getToolMemberStrikeThrough());
-		assertFalse(strikeThroughToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.STRIKETHROUGH), strikeThroughToggleButton.getText().toString());
 	}
 
 	@Test
@@ -240,7 +223,6 @@ public class TextToolIntegrationTest {
 		selectFormatting(FormattingOptions.UNDERLINE);
 		selectFormatting(FormattingOptions.ITALIC);
 		selectFormatting(FormattingOptions.BOLD);
-		selectFormatting(FormattingOptions.STRIKETHROUGH);
 
 		onToolBarView()
 				.performCloseToolOptionsView();
@@ -259,7 +241,6 @@ public class TextToolIntegrationTest {
 		assertTrue(underlinedToggleButton.isChecked());
 		assertTrue(italicToggleButton.isChecked());
 		assertTrue(boldToggleButton.isChecked());
-		assertTrue(strikeThroughToggleButton.isChecked());
 		checkTextBoxDimensions();
 	}
 
@@ -270,7 +251,6 @@ public class TextToolIntegrationTest {
 		selectFormatting(FormattingOptions.UNDERLINE);
 		selectFormatting(FormattingOptions.ITALIC);
 		selectFormatting(FormattingOptions.BOLD);
-		selectFormatting(FormattingOptions.STRIKETHROUGH);
 
 		final PointF toolMemberBoxPosition = getToolMemberBoxPosition();
 		PointF expectedPosition = new PointF(toolMemberBoxPosition.x, toolMemberBoxPosition.y);
@@ -284,7 +264,6 @@ public class TextToolIntegrationTest {
 		assertTrue(underlinedToggleButton.isChecked());
 		assertTrue(italicToggleButton.isChecked());
 		assertTrue(boldToggleButton.isChecked());
-		assertTrue(strikeThroughToggleButton.isChecked());
 
 		assertEquals(expectedPosition, getToolMemberBoxPosition());
 		checkTextBoxDimensions();
@@ -297,7 +276,6 @@ public class TextToolIntegrationTest {
 		assertFalse(underlinedToggleButton.isChecked());
 		assertFalse(boldToggleButton.isChecked());
 		assertFalse(italicToggleButton.isChecked());
-		assertFalse(strikeThroughToggleButton.isChecked());
 
 		ArrayList<FormattingOptions> fonts = new ArrayList<>();
 		fonts.add(FormattingOptions.SERIF);
@@ -315,14 +293,6 @@ public class TextToolIntegrationTest {
 			assertFalse(boxWidth == getToolMemberBoxWidth() && boxHeight == getToolMemberBoxHeight());
 
 			Bitmap bitmap = getToolMemberDrawingBitmap();
-			pixelsBefore = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsBefore, 0, 1, textTool.BOX_OFFSET, 0, 1, bitmap.getHeight());
-			selectFormatting(FormattingOptions.STRIKETHROUGH);
-			assertTrue(strikeThroughToggleButton.isChecked());
-			bitmap = getToolMemberDrawingBitmap();
-			pixelsAfter = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsAfter, 0, 1, textTool.BOX_OFFSET, 0, 1, bitmap.getHeight());
-			assertTrue(countPixelsWithColor(pixelsAfter, Color.BLACK) > countPixelsWithColor(pixelsBefore, Color.BLACK));
 
 			pixelsBefore = new int[bitmap.getHeight()];
 			bitmap.getPixels(pixelsBefore, 0, 1, bitmap.getWidth() / 2, 0, 1, bitmap.getHeight());
@@ -357,8 +327,6 @@ public class TextToolIntegrationTest {
 			assertFalse(italicToggleButton.isChecked());
 			selectFormatting(FormattingOptions.BOLD);
 			assertFalse(boldToggleButton.isChecked());
-			selectFormatting(FormattingOptions.STRIKETHROUGH);
-			assertFalse(strikeThroughToggleButton.isChecked());
 		}
 	}
 
@@ -369,7 +337,6 @@ public class TextToolIntegrationTest {
 		assertFalse(underlinedToggleButton.isChecked());
 		assertFalse(boldToggleButton.isChecked());
 		assertFalse(italicToggleButton.isChecked());
-		assertFalse(strikeThroughToggleButton.isChecked());
 
 		List<FormattingOptions> fonts = Arrays.asList(FormattingOptions.STC, FormattingOptions.DUBAI);
 
@@ -384,14 +351,6 @@ public class TextToolIntegrationTest {
 			assertFalse(boxWidth == getToolMemberBoxWidth() && boxHeight == getToolMemberBoxHeight());
 
 			Bitmap bitmap = getToolMemberDrawingBitmap();
-			pixelsBefore = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsBefore, 0, 1, textTool.BOX_OFFSET, 0, 1, bitmap.getHeight());
-			selectFormatting(FormattingOptions.STRIKETHROUGH);
-			assertTrue(strikeThroughToggleButton.isChecked());
-			bitmap = getToolMemberDrawingBitmap();
-			pixelsAfter = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsAfter, 0, 1, textTool.BOX_OFFSET, 0, 1, bitmap.getHeight());
-			assertTrue(countPixelsWithColor(pixelsAfter, Color.BLACK) > countPixelsWithColor(pixelsBefore, Color.BLACK));
 
 			pixelsBefore = new int[bitmap.getHeight()];
 			bitmap.getPixels(pixelsBefore, 0, 1, bitmap.getWidth() / 2, 0, 1, bitmap.getHeight());
@@ -426,8 +385,6 @@ public class TextToolIntegrationTest {
 			assertFalse(italicToggleButton.isChecked());
 			selectFormatting(FormattingOptions.BOLD);
 			assertFalse(boldToggleButton.isChecked());
-			selectFormatting(FormattingOptions.STRIKETHROUGH);
-			assertFalse(strikeThroughToggleButton.isChecked());
 		}
 	}
 
@@ -685,7 +642,6 @@ public class TextToolIntegrationTest {
 			case UNDERLINE:
 			case ITALIC:
 			case BOLD:
-			case STRIKETHROUGH:
 				onView(withText(getFontString(format))).perform(click());
 				break;
 			default:
@@ -711,8 +667,6 @@ public class TextToolIntegrationTest {
 				return activity.getString(R.string.text_tool_dialog_italic_shortcut);
 			case BOLD:
 				return activity.getString(R.string.text_tool_dialog_bold_shortcut);
-			case STRIKETHROUGH:
-				return activity.getString(R.string.text_tool_dialog_strike_through_shortcut);
 			default:
 				return null;
 		}
@@ -760,10 +714,6 @@ public class TextToolIntegrationTest {
 		return textTool.bold;
 	}
 
-	private boolean getToolMemberStrikeThrough() {
-		return textTool.strikeThrough;
-	}
-
 	private Bitmap getToolMemberDrawingBitmap() {
 		return textTool.drawingBitmap;
 	}
@@ -773,6 +723,6 @@ public class TextToolIntegrationTest {
 	}
 
 	private enum FormattingOptions {
-		UNDERLINE, ITALIC, BOLD, STRIKETHROUGH, MONOSPACE, SERIF, SANS_SERIF, STC, DUBAI
+		UNDERLINE, ITALIC, BOLD, MONOSPACE, SERIF, SANS_SERIF, STC, DUBAI
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
@@ -53,7 +53,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 	private static final String BUNDLE_TOOL_UNDERLINED = "BUNDLE_TOOL_UNDERLINED";
 	private static final String BUNDLE_TOOL_ITALIC = "BUNDLE_TOOL_ITALIC";
 	private static final String BUNDLE_TOOL_BOLD = "BUNDLE_TOOL_BOLD";
-	private static final String BUNDLE_TOOL_STRIKETHROUGH = "BUNDLE_TOOL_STRIKETHROUGH";
 	private static final String BUNDLE_TOOL_TEXT = "BUNDLE_TOOL_TEXT";
 	private static final String BUNDLE_TOOL_TEXT_SIZE = "BUNDLE_TOOL_TEXT_SIZE";
 	private static final String BUNDLE_TOOL_FONT = "BUNDLE_TOOL_FONT";
@@ -73,8 +72,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 	public boolean italic = false;
 	@VisibleForTesting
 	public boolean bold = false;
-	@VisibleForTesting
-	public boolean strikeThrough = false;
 	@VisibleForTesting
 	public int textSize = 20;
 	private TextToolOptionsView textToolOptionsView;
@@ -146,13 +143,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 					}
 
 					@Override
-					public void setStrikeThrough(boolean strikeThrough) {
-						TextTool.this.strikeThrough = strikeThrough;
-						textPaint.setStrikeThruText(TextTool.this.strikeThrough);
-						createAndSetBitmap();
-					}
-
-					@Override
 					public void setTextSize(int size) {
 						textSize = size;
 						textPaint.setTextSize(textSize * TEXT_SIZE_MAGNIFICATION_FACTOR);
@@ -176,7 +166,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 		textPaint.setTextSize(textSize * TEXT_SIZE_MAGNIFICATION_FACTOR);
 		textPaint.setUnderlineText(underlined);
 		textPaint.setFakeBoldText(bold);
-		textPaint.setStrikeThruText(strikeThrough);
 
 		updateTypeface();
 	}
@@ -213,7 +202,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 		bundle.putBoolean(BUNDLE_TOOL_UNDERLINED, underlined);
 		bundle.putBoolean(BUNDLE_TOOL_ITALIC, italic);
 		bundle.putBoolean(BUNDLE_TOOL_BOLD, bold);
-		bundle.putBoolean(BUNDLE_TOOL_STRIKETHROUGH, strikeThrough);
 		bundle.putString(BUNDLE_TOOL_TEXT, text);
 		bundle.putInt(BUNDLE_TOOL_TEXT_SIZE, textSize);
 		bundle.putString(BUNDLE_TOOL_FONT, font);
@@ -225,7 +213,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 		underlined = bundle.getBoolean(BUNDLE_TOOL_UNDERLINED, underlined);
 		italic = bundle.getBoolean(BUNDLE_TOOL_ITALIC, italic);
 		bold = bundle.getBoolean(BUNDLE_TOOL_BOLD, bold);
-		strikeThrough = bundle.getBoolean(BUNDLE_TOOL_STRIKETHROUGH, strikeThrough);
 		text = bundle.getString(BUNDLE_TOOL_TEXT, text);
 		textSize = bundle.getInt(BUNDLE_TOOL_TEXT_SIZE, textSize);
 		font = bundle.getString(BUNDLE_TOOL_FONT, font);
@@ -233,7 +220,6 @@ public class TextTool extends BaseToolWithRectangleShape {
 		textToolOptionsView.setState(bold, italic, underlined, text, textSize, font);
 		textPaint.setUnderlineText(underlined);
 		textPaint.setFakeBoldText(bold);
-		textPaint.setStrikeThruText(strikeThrough);
 		updateTypeface();
 		createAndSetBitmap();
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.java
@@ -35,8 +35,6 @@ public interface TextToolOptionsView {
 
 		void setBold(boolean bold);
 
-		void setStrikeThrough(boolean strikeThrough);
-
 		void setTextSize(int size);
 
 		void hideToolOptions();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.java
@@ -50,7 +50,6 @@ public class DefaultTextToolOptionsView implements TextToolOptionsView {
 	private final ToggleButton underlinedToggleButton;
 	private final ToggleButton italicToggleButton;
 	private final ToggleButton boldToggleButton;
-	private final ToggleButton strikeThroughToggleButton;
 	private final Button doneButton;
 	private final List<String> fonts;
 	private static final String DEFAULT_TEXTSIZE = "20";
@@ -68,7 +67,6 @@ public class DefaultTextToolOptionsView implements TextToolOptionsView {
 		underlinedToggleButton = textToolView.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_underlined);
 		italicToggleButton = textToolView.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_italic);
 		boldToggleButton = textToolView.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_bold);
-		strikeThroughToggleButton = textToolView.findViewById(R.id.pocketpaint_text_tool_dialog_toggle_strike_through);
 		doneButton = textToolView.findViewById(R.id.pocketpaint_text_tool_dialog_done_button);
 		fontSizeText = textToolView.findViewById(R.id.pocketpaint_font_size_text);
 		fontSizeText.setText(DEFAULT_TEXTSIZE);
@@ -150,16 +148,6 @@ public class DefaultTextToolOptionsView implements TextToolOptionsView {
 			}
 		});
 
-		strikeThroughToggleButton.setPaintFlags(strikeThroughToggleButton.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
-		strikeThroughToggleButton.setOnClickListener(new ToggleButton.OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				boolean strikeThrough = ((Checkable) v).isChecked();
-				notifyStrikeThroughChanged(strikeThrough);
-				hideKeyboard();
-			}
-		});
-
 		doneButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
@@ -224,12 +212,6 @@ public class DefaultTextToolOptionsView implements TextToolOptionsView {
 	private void notifyBoldChanged(boolean bold) {
 		if (callback != null) {
 			callback.setBold(bold);
-		}
-	}
-
-	private void notifyStrikeThroughChanged(boolean strikeThrough) {
-		if (callback != null) {
-			callback.setStrikeThrough(strikeThrough);
 		}
 	}
 

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
@@ -97,14 +97,6 @@
                 android:textOff="@string/text_tool_dialog_bold_shortcut"
                 android:layout_weight="1" />
 
-            <ToggleButton
-                android:id="@+id/pocketpaint_text_tool_dialog_toggle_strike_through"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:textStyle="normal"
-                android:textOn="@string/text_tool_dialog_strike_through_shortcut"
-                android:textOff="@string/text_tool_dialog_strike_through_shortcut"
-                android:layout_weight="1" />
         </LinearLayout>
 
         <TextView


### PR DESCRIPTION
Removed strike through option from text tool

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
