### PR TITLE
PAINTROID-175: other tools do not work anymore

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
@@ -33,6 +33,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.drawable.DrawableShape;
 import org.catrobat.paintroid.tools.drawable.DrawableStyle;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
+import org.catrobat.paintroid.tools.implementation.ShapeTool;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +48,7 @@ import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInte
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolPropertiesInteraction.onToolProperties;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
@@ -66,11 +68,11 @@ public class ShapeToolIntegrationTest {
 	}
 
 	private Paint getCurrentToolBitmapPaint() {
-		return launchActivityRule.getActivity().toolPaint.getPaint();
+		return ((ShapeTool) toolReference.get()).getShapeBitmapPaint();
 	}
 
-	private Paint getCurrentToolCanvasPaint() {
-		return launchActivityRule.getActivity().toolPaint.getPreviewPaint();
+	private Paint getToolPaint() {
+		return launchActivityRule.getActivity().toolPaint.getPaint();
 	}
 
 	@Test
@@ -159,10 +161,25 @@ public class ShapeToolIntegrationTest {
 		drawShape();
 
 		Paint bitmapPaint = getCurrentToolBitmapPaint();
-		Paint canvasPaint = getCurrentToolCanvasPaint();
+		Paint toolPaint = getToolPaint();
 
 		assertFalse("BITMAP_PAINT antialiasing should be off", bitmapPaint.isAntiAlias());
-		assertTrue("CANVAS_PAINT antialiasing should be on", canvasPaint.isAntiAlias());
+		assertTrue("TOOL_PAINT antialiasing should be on", toolPaint.isAntiAlias());
+	}
+
+	@Test
+	public void testDoNotUseRegularToolPaintInShapeTool() {
+		onToolBarView()
+				.performSelectTool(ToolType.SHAPE);
+		onShapeToolOptionsView()
+				.performSelectShapeDrawType(DrawableStyle.FILL);
+
+		drawShape();
+
+		Paint bitmapPaint = getCurrentToolBitmapPaint();
+		Paint toolPaint = getToolPaint();
+
+		assertNotEquals("bitmapPaint and toolPaint should differ", bitmapPaint, toolPaint);
 	}
 
 	@Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.java
@@ -50,6 +50,7 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 	private final ShapeToolOptionsView shapeToolOptionsView;
 
 	private final Paint shapePreviewPaint = new Paint();
+	private final Paint shapeBitmapPaint = new Paint();
 	private final RectF shapePreviewRect = new RectF();
 	private final DrawableFactory drawableFactory = new DrawableFactory();
 
@@ -96,6 +97,10 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 	public void setBaseShape(DrawableShape shape) {
 		baseShape = shape;
 		shapeDrawable = drawableFactory.createDrawable(shape);
+	}
+
+	public Paint getShapeBitmapPaint() {
+		return shapeBitmapPaint;
 	}
 
 	@Override
@@ -182,13 +187,13 @@ public class ShapeTool extends BaseToolWithRectangleShape {
 				&& toolPosition.x + boxWidth / 2 >= 0
 				&& toolPosition.y + boxHeight / 2 >= 0) {
 
-			Paint paint = toolPaint.getPaint();
+			shapeBitmapPaint.set(toolPaint.getPaint());
 			RectF shapeRect = new RectF();
-			preparePaint(paint);
+			preparePaint(shapeBitmapPaint);
 			prepareShapeRectangle(shapeRect, boxWidth, boxHeight);
 
 			Command command = commandFactory.createGeometricFillCommand(shapeDrawable,
-					Conversion.toPoint(toolPosition), shapeRect, boxRotation, paint);
+					Conversion.toPoint(toolPosition), shapeRect, boxRotation, shapeBitmapPaint);
 			commandManager.addCommand(command);
 			highlightBox();
 		}


### PR DESCRIPTION
Shape tool now uses a new Paint again.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
