### PR TITLE
PAINTROID-138: unselected background not dimmed

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.java
@@ -29,7 +29,6 @@ import android.graphics.Path;
 import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.RectF;
-import android.graphics.Region.Op;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.CountDownTimer;
@@ -67,7 +66,6 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 	protected static final boolean DEFAULT_ANTIALIASING_ON = true;
 
 	private static final boolean DEFAULT_ROTATION_ENABLED = false;
-	private static final boolean DEFAULT_BACKGROUND_SHADOW_ENABLED = true;
 	private static final boolean DEFAULT_RESIZE_POINTS_VISIBLE = true;
 	private static final boolean DEFAULT_RESPECT_MAXIMUM_BORDER_RATIO = true;
 	private static final boolean DEFAULT_RESPECT_MAXIMUM_BOX_RESOLUTION = false;
@@ -86,7 +84,6 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 	private final Paint arrowPaint;
 	private final Path arcPath;
 	private final Path arrowPath;
-	private final Paint backgroundPaint;
 	private final RectF tempDrawingRectangle;
 	private final PointF tempToolPosition;
 	@VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
@@ -109,7 +106,6 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 	protected RotatePosition rotatePosition;
 	protected Drawable overlayDrawable;
 	protected float maximumBoxResolution;
-	protected boolean backgroundShadowEnabled;
 	protected boolean resizePointsVisible;
 	protected boolean respectMaximumBorderRatio;
 	protected boolean respectMaximumBoxResolution;
@@ -149,7 +145,6 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		resizeAction = ResizeAction.NONE;
 
 		rotationEnabled = DEFAULT_ROTATION_ENABLED;
-		backgroundShadowEnabled = DEFAULT_BACKGROUND_SHADOW_ENABLED;
 		resizePointsVisible = DEFAULT_RESIZE_POINTS_VISIBLE;
 		respectMaximumBorderRatio = DEFAULT_RESPECT_MAXIMUM_BORDER_RATIO;
 		respectMaximumBoxResolution = DEFAULT_RESPECT_MAXIMUM_BOX_RESOLUTION;
@@ -171,10 +166,6 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		arrowPaint = new Paint();
 		arrowPaint.setColor(Color.WHITE);
 		arrowPaint.setStyle(Paint.Style.FILL);
-
-		backgroundPaint = new Paint();
-		backgroundPaint.setColor(Color.argb(128, 0, 0, 0));
-		backgroundPaint.setStyle(Style.FILL);
 
 		arcPath = new Path();
 		arrowPath = new Path();
@@ -305,10 +296,6 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		canvas.translate(tempToolPosition.x, tempToolPosition.y);
 		canvas.rotate(boxRotation);
 
-		if (backgroundShadowEnabled) {
-			drawBackgroundShadow(canvas, boxWidth, boxHeight, boxRotation, tempToolPosition);
-		}
-
 		if (resizePointsVisible) {
 			drawToolSpecifics(canvas, boxWidth, boxHeight);
 		}
@@ -326,18 +313,6 @@ public abstract class BaseToolWithRectangleShape extends BaseToolWithShape {
 		drawRectangle(canvas, boxWidth, boxHeight);
 		drawToolSpecifics(canvas, boxWidth, boxHeight);
 
-		canvas.restore();
-	}
-
-	private void drawBackgroundShadow(Canvas canvas, float boxWidth, float boxHeight, float boxRotation, PointF toolPosition) {
-		canvas.save();
-		canvas.clipRect((-boxWidth + toolStrokeWidth) / 2,
-				(boxHeight - toolStrokeWidth) / 2,
-				(boxWidth - toolStrokeWidth) / 2,
-				(-boxHeight + toolStrokeWidth) / 2, Op.DIFFERENCE);
-		canvas.rotate(-boxRotation);
-		canvas.translate(-toolPosition.x, -toolPosition.y);
-		canvas.drawRect(0, 0, workspace.getWidth(), workspace.getHeight(), backgroundPaint);
 		canvas.restore();
 	}
 


### PR DESCRIPTION
Deleted all references to background shadow. 
https://jira.catrob.at/browse/PAINTROID-138

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
