### PR TITLE
Paintroid 159 Hide/Unhide Layer

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -103,6 +103,10 @@ android {
         xmlOutput file("build/reports/lint-report.xml")
         htmlOutput file("build/reports/lint-report.html")
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.Matchers.not;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -658,5 +659,83 @@ public class LayerIntegrationTest {
 
 		onDrawingSurfaceView()
 				.checkLayerDimensions(bitmapHeight, bitmapWidth);
+	}
+
+	@Test
+	public void testHideLayer() {
+		onLayerMenuView()
+				.performOpen()
+				.performAddLayer()
+				.checkLayerCount(2)
+				.performClose();
+
+		onToolBarView()
+				.performSelectTool(ToolType.FILL);
+
+		onDrawingSurfaceView().perform(click());
+		onDrawingSurfaceView().checkPixelColor(Color.BLACK, 1, 1);
+
+		onLayerMenuView()
+				.performOpen()
+				.perfomToggleLayerVisibility(0)
+				.performClose();
+
+		onDrawingSurfaceView().checkPixelColor(Color.TRANSPARENT, 1, 1);
+	}
+
+	@Test
+	public void testHideThenUnhideLayer() {
+		onLayerMenuView()
+				.performOpen()
+				.performAddLayer()
+				.checkLayerCount(2)
+				.performClose();
+
+		onToolBarView()
+				.performSelectTool(ToolType.FILL);
+
+		onDrawingSurfaceView().perform(click());
+		onDrawingSurfaceView().checkPixelColor(Color.BLACK, 1, 1);
+
+		onLayerMenuView()
+				.performOpen()
+				.perfomToggleLayerVisibility(0)
+				.performClose();
+
+		onDrawingSurfaceView().checkPixelColor(Color.TRANSPARENT, 1, 1);
+
+		onLayerMenuView()
+				.performOpen()
+				.perfomToggleLayerVisibility(0)
+				.performClose();
+
+		onDrawingSurfaceView().checkPixelColor(Color.BLACK, 1, 1);
+	}
+
+	@Test
+	public void testTryMergeOrReorderWhileALayerIsHidden() {
+		onLayerMenuView()
+				.performOpen()
+				.performAddLayer()
+				.checkLayerCount(2)
+				.perfomToggleLayerVisibility(0)
+				.performLongClickLayer(0);
+
+		onView(withText(R.string.no_longclick_on_hidden_layer)).inRoot(withDecorView(not(launchActivityRule.getActivity().getWindow().getDecorView()))).check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testTryChangeToolWhileALayerIsHidden() {
+		onLayerMenuView()
+				.performOpen()
+				.performAddLayer()
+				.checkLayerCount(2)
+				.perfomToggleLayerVisibility(0)
+				.performClose();
+
+		onToolBarView()
+				.onToolsClicked();
+
+		onView(withText(R.string.no_tools_on_hidden_layer)).inRoot(withDecorView(not(launchActivityRule.getActivity().getWindow().getDecorView()))).check(matches(isDisplayed()));
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
@@ -20,9 +20,13 @@
 package org.catrobat.paintroid.test.espresso.util.wrappers;
 
 import android.view.Gravity;
+import android.view.View;
 
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.model.Layer;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 
 import androidx.test.espresso.DataInteraction;
 import androidx.test.espresso.ViewInteraction;
@@ -35,6 +39,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -93,6 +98,13 @@ public final class LayerMenuViewInteraction extends CustomViewInteraction {
 		return this;
 	}
 
+	public LayerMenuViewInteraction performLongClickLayer(int listPosition) {
+		check(matches(isDisplayed()));
+		onLayerAt(listPosition)
+				.perform(longClick());
+		return this;
+	}
+
 	public LayerMenuViewInteraction performAddLayer() {
 		check(matches(isDisplayed()));
 		onButtonAdd()
@@ -105,5 +117,29 @@ public final class LayerMenuViewInteraction extends CustomViewInteraction {
 		onButtonDelete()
 				.perform(click());
 		return this;
+	}
+
+	public LayerMenuViewInteraction perfomToggleLayerVisibility(int position) {
+		check(matches(isDisplayed()));
+		onView(withIndex(withId(R.id.pocketpaint_checkbox_layer), position)).perform(click());
+		return this;
+	}
+
+	public static Matcher<View> withIndex(final Matcher<View> matcher, final int index) {
+		return new TypeSafeMatcher<View>() {
+			int currentIndex = 0;
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("with index: ");
+				description.appendValue(index);
+				matcher.describeTo(description);
+			}
+
+			@Override
+			public boolean matchesSafely(View view) {
+				return matcher.matches(view) && currentIndex++ == index;
+			}
+		};
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.java
@@ -60,6 +60,12 @@ public final class ToolBarViewInteraction extends CustomViewInteraction {
 		return this;
 	}
 
+	public ToolBarViewInteraction onToolsClicked() {
+		onBottomNavigationView()
+				.onToolsClicked();
+		return this;
+	}
+
 	public ToolBarViewInteraction performSelectTool(ToolType toolType) {
 		if (getCurrentToolType() != toolType) {
 			onBottomNavigationView()

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/model/LayerTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/model/LayerTest.java
@@ -128,4 +128,31 @@ public class LayerTest {
 		assertThat(firstLayer.getBitmap().getPixel(2, 1), is(Color.BLUE));
 		assertThat(firstLayer.getBitmap().getPixel(1, 1), is(Color.BLUE));
 	}
+
+	@Test
+	public void testHideThenUnhideLayer() {
+		LayerContracts.Layer layerToHide = layerModel.getLayerAt(0);
+
+		layerToHide.getBitmap().setPixel(1, 1, Color.BLACK);
+		layerToHide.getBitmap().setPixel(2, 1, Color.BLACK);
+		layerToHide.getBitmap().setPixel(3, 1, Color.BLACK);
+		layerToHide.getBitmap().setPixel(4, 1, Color.BLACK);
+
+		Bitmap bitmapCopy = layerToHide.getTransparentBitmap();
+
+		layerToHide.switchBitmaps(false);
+		layerToHide.setBitmap(bitmapCopy);
+
+		assertThat(layerToHide.getBitmap().getPixel(1, 1), is(Color.TRANSPARENT));
+		assertThat(layerToHide.getBitmap().getPixel(2, 1), is(Color.TRANSPARENT));
+		assertThat(layerToHide.getBitmap().getPixel(3, 1), is(Color.TRANSPARENT));
+		assertThat(layerToHide.getBitmap().getPixel(4, 1), is(Color.TRANSPARENT));
+
+		layerToHide.switchBitmaps(true);
+
+		assertThat(layerToHide.getBitmap().getPixel(1, 1), is(Color.BLACK));
+		assertThat(layerToHide.getBitmap().getPixel(2, 1), is(Color.BLACK));
+		assertThat(layerToHide.getBitmap().getPixel(3, 1), is(Color.BLACK));
+		assertThat(layerToHide.getBitmap().getPixel(4, 1), is(Color.BLACK));
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.java
@@ -3,6 +3,10 @@ package org.catrobat.paintroid.contract;
 import android.graphics.Bitmap;
 import android.view.View;
 
+import org.catrobat.paintroid.controller.DefaultToolController;
+import org.catrobat.paintroid.ui.DrawingSurface;
+import org.catrobat.paintroid.ui.viewholder.BottomNavigationViewHolder;
+
 import java.util.List;
 import java.util.ListIterator;
 
@@ -10,6 +14,7 @@ import androidx.annotation.StringRes;
 
 public interface LayerContracts {
 	interface Adapter {
+
 		void notifyDataSetChanged();
 
 		LayerViewHolder getViewHolderAt(int position);
@@ -31,12 +36,26 @@ public interface LayerContracts {
 
 		void removeLayer();
 
+		void hideLayer(int position);
+
+		void unhideLayer(int position, LayerViewHolder viewHolder);
+
 		void setAdapter(LayerContracts.Adapter layerAdapter);
 
+		void setDrawingSurface(DrawingSurface drawingSurface);
+
 		void invalidate();
+
+		void setDefaultToolController(DefaultToolController defaultToolController);
+
+		void setbottomNavigationViewHolder(BottomNavigationViewHolder bottomNavigationViewHolder);
+
+		LayerContracts.Presenter getPresenter();
 	}
 
 	interface LayerViewHolder {
+
+		void setSelected(int position, BottomNavigationViewHolder bottomNavigationViewHolder, DefaultToolController defaultToolController);
 
 		void setSelected();
 
@@ -47,6 +66,10 @@ public interface LayerContracts {
 		View getView();
 
 		void setMergable();
+
+		Bitmap getBitmap();
+
+		void setCheckBox(boolean setTo);
 	}
 
 	interface LayerMenuViewHolder {
@@ -65,6 +88,14 @@ public interface LayerContracts {
 		Bitmap getBitmap();
 
 		void setBitmap(Bitmap bitmap);
+
+		Bitmap getTransparentBitmap();
+
+		void switchBitmaps(boolean isUnhide);
+
+		void setCheckBox(boolean setTo);
+
+		boolean getCheckBox();
 	}
 
 	interface Model {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -32,6 +32,7 @@ import org.catrobat.paintroid.iotasks.CreateFileAsync;
 import org.catrobat.paintroid.iotasks.LoadImageAsync;
 import org.catrobat.paintroid.iotasks.SaveImageAsync;
 import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.ui.LayerAdapter;
 
 import java.io.File;
 
@@ -212,6 +213,8 @@ public interface MainActivityContracts {
 		void actionCurrentToolClicked();
 
 		void rateUsClicked();
+
+		void setLayerAdapter(LayerAdapter layerAdapter);
 	}
 
 	interface Model {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/Layer.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/Layer.java
@@ -20,18 +20,47 @@
 package org.catrobat.paintroid.model;
 
 import android.graphics.Bitmap;
+import android.graphics.Color;
 
 import org.catrobat.paintroid.contract.LayerContracts;
 
 public class Layer implements LayerContracts.Layer {
 	private Bitmap bitmap;
+	private Bitmap transparentBitmap;
+	private boolean checkBox;
 
 	public Layer(Bitmap bitmap) {
 		this.bitmap = bitmap;
+		if (bitmap != null) {
+			this.transparentBitmap = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(),
+					Bitmap.Config.ARGB_8888);
+		}
+		this.checkBox = true;
+	}
+
+	public void setCheckBox(boolean setTo) {
+		this.checkBox = setTo;
+	}
+
+	public boolean getCheckBox() {
+		return checkBox;
 	}
 
 	public Bitmap getBitmap() {
 		return bitmap;
+	}
+
+	public Bitmap getTransparentBitmap() {
+		return transparentBitmap;
+	}
+
+	public void switchBitmaps(boolean isUnhide) {
+		Bitmap tmpBitmap = transparentBitmap.copy(transparentBitmap.getConfig(), transparentBitmap.isMutable());
+		this.transparentBitmap = bitmap;
+		this.bitmap = tmpBitmap;
+		if (isUnhide) {
+			transparentBitmap.eraseColor(Color.TRANSPARENT);
+		}
 	}
 
 	public void setBitmap(Bitmap bitmap) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -59,6 +59,7 @@ import org.catrobat.paintroid.iotasks.LoadImageAsync.LoadImageCallback;
 import org.catrobat.paintroid.iotasks.SaveImageAsync.SaveImageCallback;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.ui.LayerAdapter;
 import org.catrobat.paintroid.ui.Perspective;
 
 import java.io.File;
@@ -99,6 +100,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	private BottomBarViewHolder bottomBarViewHolder;
 	private DrawerLayoutViewHolder drawerLayoutViewHolder;
 	private BottomNavigationViewHolder bottomNavigationViewHolder;
+	private LayerAdapter layerAdapter;
 
 	private CommandManager commandManager;
 	private CommandFactory commandFactory;
@@ -134,6 +136,13 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	@Override
 	public void loadImageClicked() {
 		switchBetweenVersions(PERMISSION_REQUEST_CODE_LOAD_PICTURE);
+		setFirstCheckBoxInLayerMenu();
+	}
+
+	public void setFirstCheckBoxInLayerMenu() {
+		if (layerAdapter != null && layerAdapter.getViewHolderAt(0) != null) {
+			layerAdapter.getViewHolderAt(0).setCheckBox(true);
+		}
 	}
 
 	@Override
@@ -144,14 +153,17 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	@Override
 	public void loadNewImage() {
 		navigator.startLoadImageActivity(REQUEST_CODE_LOAD_PICTURE);
+		setFirstCheckBoxInLayerMenu();
 	}
 
 	@Override
 	public void newImageClicked() {
 		if (isImageUnchanged() || model.isSaved()) {
 			onNewImage();
+			setFirstCheckBoxInLayerMenu();
 		} else {
 			navigator.showSaveBeforeNewImageDialog();
+			setFirstCheckBoxInLayerMenu();
 		}
 	}
 
@@ -285,8 +297,10 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 			if (requestCode == PERMISSION_REQUEST_CODE_LOAD_PICTURE) {
 				if (isImageUnchanged() || model.isSaved()) {
 					navigator.startLoadImageActivity(REQUEST_CODE_LOAD_PICTURE);
+					setFirstCheckBoxInLayerMenu();
 				} else {
 					navigator.showSaveBeforeLoadImageDialog();
+					setFirstCheckBoxInLayerMenu();
 				}
 			} else {
 				askForReadAndWriteExternalStoragePermission(requestCode);
@@ -735,6 +749,10 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		if (bottomBarViewHolder.isVisible()) {
 			bottomBarViewHolder.hide();
 		} else {
+			if (!layerAdapter.getPresenter().getLayerItem(workspace.getCurrentLayerIndex()).getCheckBox()) {
+				navigator.showToast(R.string.no_tools_on_hidden_layer, Toast.LENGTH_SHORT);
+				return;
+			}
 			bottomBarViewHolder.show();
 		}
 	}
@@ -757,5 +775,9 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	@Override
 	public void rateUsClicked() {
 		navigator.rateUsClicked();
+	}
+
+	public void setLayerAdapter(LayerAdapter layerAdapter) {
+		this.layerAdapter = layerAdapter;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.java
@@ -40,6 +40,8 @@ public interface Workspace {
 
 	Bitmap getBitmapOfCurrentLayer();
 
+	int getCurrentLayerIndex();
+
 	int getPixelOfCurrentLayer(PointF coordinate);
 
 	void resetPerspective();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.java
@@ -85,6 +85,11 @@ public class DefaultWorkspace implements Workspace {
 	}
 
 	@Override
+	public int getCurrentLayerIndex() {
+		return layerModel.getLayerIndexOf(layerModel.getCurrentLayer());
+	}
+
+	@Override
 	public void resetPerspective() {
 		perspective.setBitmapDimensions(getWidth(), getHeight());
 		perspective.resetScaleAndTranslation();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropListView.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropListView.java
@@ -124,7 +124,6 @@ public class DragAndDropListView extends ListView implements ListItemLongClickHa
 		if (this.view != null) {
 			this.view.setVisibility(VISIBLE);
 		}
-
 		this.view = view;
 		this.initialPosition = position;
 		this.position = position;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.java
@@ -26,6 +26,7 @@ package org.catrobat.paintroid.ui.dragndrop;
 import android.view.View;
 
 public interface DragAndDropPresenter {
+
 	int swapItemsVisually(int position, int swapWith);
 
 	void mergeItems(int position, int mergeWith);

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_layers_visibility.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_layers_visibility.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0 0h24v24H0z"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/>
+</vector>

--- a/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
@@ -93,7 +93,7 @@
 
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/pocketpaint_nav_view_layer"
-        android:layout_width="100dp"
+        android:layout_width="150dp"
         android:layout_height="wrap_content"
         android:layout_gravity="end|center">
 

--- a/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
@@ -82,13 +82,15 @@
             </LinearLayout>
         </RelativeLayout>
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/pocketpaint_nav_view_layer"
-        android:layout_width="100dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|center">
+        <com.google.android.material.navigation.NavigationView
+            android:id="@+id/pocketpaint_nav_view_layer"
+            android:layout_width="150dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|center">
 
-            <include layout="@layout/pocketpaint_layout_main_menu_layer" />
+            <include layout="@layout/pocketpaint_layout_main_menu_layer"
+                android:layout_width="150dp"
+                android:layout_height="wrap_content" />
         </com.google.android.material.navigation.NavigationView>
 
     </androidx.drawerlayout.widget.DrawerLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
@@ -19,23 +19,33 @@
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/pocketpaint_item_layer_background"
-    android:layout_width="wrap_content"
+    android:layout_width="150dp"
     android:layout_height="wrap_content"
-    android:paddingTop="10dp"
-    android:paddingBottom="10dp"
-    android:paddingStart="5dp"
-    android:paddingEnd="5dp"
-    android:gravity="center_vertical"
     android:background="@drawable/pocketpaint_attribute_button_selector"
-    android:orientation="horizontal">
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="5dp"
+    android:paddingTop="10dp"
+    android:paddingEnd="5dp"
+    android:paddingBottom="10dp"
+    android:descendantFocusability="blocksDescendants" >
+
+    <CheckBox
+        android:id="@+id/pocketpaint_checkbox_layer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:focusable="false"
+        android:translationX="3dp"
+        android:checked="true"/>
 
     <ImageView
         android:id="@+id/pocketpaint_item_layer_image"
         android:layout_width="75dp"
         android:layout_height="100dp"
-        android:adjustViewBounds="true"
-        android:scaleType="fitXY"
+        android:adjustViewBounds="false"
         android:background="@drawable/pocketpaint_checkeredbg_repeat"
-        android:contentDescription="@string/layer_background" />
-
+        android:contentDescription="@string/layer_background"
+        android:scaleType="fitXY"
+        android:translationX="20dp"
+        android:focusable="false" />
 </LinearLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
@@ -24,35 +24,54 @@
     android:layout_height="wrap_content">
 
     <ImageButton
-        android:id="@+id/pocketpaint_layer_side_nav_button_add"
+        android:id="@+id/pocketpaint_layer_side_nav_button_visibility"
         style="?borderlessButtonStyle"
         android:layout_width="50dp"
         android:layout_height="wrap_content"
         android:contentDescription="@string/layer_new"
         android:padding="5dp"
         android:scaleType="fitXY"
-        android:tint="@android:color/white"
+        android:src="@drawable/ic_pocketpaint_layers_visibility"
+        android:theme="@style/PocketPaintHighlightColorTheme"
+        android:tint="@android:color/white" />
+
+
+    <ImageButton
+        android:id="@+id/pocketpaint_layer_side_nav_button_add"
+        style="?borderlessButtonStyle"
+        android:layout_width="50dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="-2dp"
+        android:layout_toEndOf="@+id/pocketpaint_layer_side_nav_button_visibility"
+        android:contentDescription="@string/layer_new"
+        android:padding="5dp"
+        android:scaleType="fitXY"
         android:src="@drawable/ic_pocketpaint_layers_add_selector"
-        android:theme="@style/PocketPaintHighlightColorTheme" />
+        android:theme="@style/PocketPaintHighlightColorTheme"
+        android:tint="@android:color/white" />
 
     <ImageButton
         android:id="@+id/pocketpaint_layer_side_nav_button_delete"
         style="?borderlessButtonStyle"
         android:layout_width="50dp"
         android:layout_height="wrap_content"
-        android:layout_toEndOf="@id/pocketpaint_layer_side_nav_button_add"
+        android:layout_marginStart="-1dp"
+        android:layout_toEndOf="@+id/pocketpaint_layer_side_nav_button_add"
         android:contentDescription="@string/layer_delete"
         android:padding="5dp"
         android:scaleType="fitXY"
-        android:tint="@android:color/white"
         android:src="@drawable/ic_pocketpaint_layers_delete_selector"
-        android:theme="@style/PocketPaintHighlightColorTheme" />
+        android:theme="@style/PocketPaintHighlightColorTheme"
+        android:tint="@android:color/white" />
 
     <org.catrobat.paintroid.ui.dragndrop.DragAndDropListView
         android:id="@+id/pocketpaint_layer_side_nav_list"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/pocketpaint_layer_side_nav_button_add"
-        android:splitMotionEvents="false"
-        tools:listitem="@layout/pocketpaint_item_layer" />
+        android:splitMotionEvents="true"
+        tools:listitem="@layout/pocketpaint_item_layer">
+
+    </org.catrobat.paintroid.ui.dragndrop.DragAndDropListView>
+
 </RelativeLayout>

--- a/Paintroid/src/main/res/values-de-rDE/string.xml
+++ b/Paintroid/src/main/res/values-de-rDE/string.xml
@@ -104,6 +104,7 @@
     <string name="transform_height_text">Höhe</string>
     <string name="pixel">px</string>
     <string name="stamp_tool_copy_hint">Lange drücken um Inhalte zu kopieren</string>
+    <string name="share_image_title">Send image via</string>
     <string name="layers_title">Ebenen</string>
     <string name="layer_new">Neue Ebene</string>
     <string name="layer_delete">Ebene löschen</string>

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -67,6 +67,8 @@
     <string name="closing_security_question">Save changes?</string>
     <string name="menu_new_image">New image</string>
     <string name="menu_discard_image">Discard image</string>
+    <string name="no_longclick_on_hidden_layer">You are only able to merge or reorder if all layers are visible</string>
+    <string name="no_tools_on_hidden_layer">No tools are available on hidden layer</string>
     <string name="menu_load_image">Load image</string>
     <string name="menu_save_image">Save image</string>
     <string name="menu_save_copy">Save copy</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/model/LayerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/model/LayerTest.java
@@ -29,7 +29,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LayerTest {
@@ -45,7 +45,10 @@ public class LayerTest {
 
 		assertEquals(bitmap, layer.getBitmap());
 		assertEquals(secondBitmap, secondLayer.getBitmap());
-		verifyZeroInteractions(bitmap, secondBitmap);
+		verify(secondBitmap).getWidth();
+		verify(secondBitmap).getHeight();
+		verify(bitmap).getWidth();
+		verify(bitmap).getHeight();
 	}
 
 	@Test
@@ -56,6 +59,7 @@ public class LayerTest {
 		layer.setBitmap(secondBitmap);
 
 		assertEquals(secondBitmap, layer.getBitmap());
-		verifyZeroInteractions(bitmap, secondBitmap);
+		verify(bitmap).getWidth();
+		verify(bitmap).getHeight();
 	}
 }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
@@ -95,7 +95,7 @@ public class LayerPresenterTest {
 		Layer firstLayer = mock(Layer.class);
 
 		Bitmap firstLayerBitmap = mock(Bitmap.class);
-		when(firstLayer.getBitmap()).thenReturn(firstLayerBitmap);
+		when(firstLayer.getTransparentBitmap()).thenReturn(firstLayerBitmap);
 
 		layerModel.addLayerAt(0, firstLayer);
 		layerModel.setCurrentLayer(firstLayer);
@@ -103,8 +103,9 @@ public class LayerPresenterTest {
 		createPresenter();
 		layerPresenter.onBindLayerViewHolderAtPosition(0, layerViewHolder);
 
-		verify(layerViewHolder).setSelected();
+		verify(layerViewHolder).setSelected(0, null, null);
 		verify(layerViewHolder).setBitmap(firstLayerBitmap);
+		verify(layerViewHolder).setCheckBox(false);
 		verifyNoMoreInteractions(layerViewHolder);
 		verifyZeroInteractions(commandManager, commandFactory, layerAdapter,
 				listItemLongClickHandler, layerMenuViewHolder);
@@ -116,7 +117,7 @@ public class LayerPresenterTest {
 		Layer firstLayer = mock(Layer.class);
 		Layer secondLayer = mock(Layer.class);
 		Bitmap secondLayerBitmap = mock(Bitmap.class);
-		when(secondLayer.getBitmap()).thenReturn(secondLayerBitmap);
+		when(secondLayer.getTransparentBitmap()).thenReturn(secondLayerBitmap);
 		layerModel.addLayerAt(0, firstLayer);
 		layerModel.addLayerAt(1, secondLayer);
 		layerModel.setCurrentLayer(firstLayer);
@@ -125,9 +126,10 @@ public class LayerPresenterTest {
 		layerPresenter.onBindLayerViewHolderAtPosition(1, layerViewHolder);
 
 		verify(layerViewHolder).setDeselected();
-		verify(layerViewHolder).setBitmap(secondLayerBitmap);
+		verify(layerViewHolder).setBitmap(secondLayer.getTransparentBitmap());
+		verify(layerViewHolder).setCheckBox(false);
 		verifyNoMoreInteractions(layerViewHolder);
-		verifyZeroInteractions(firstLayer, commandManager, commandFactory, layerAdapter,
+		verifyZeroInteractions(firstLayer, commandManager, layerAdapter,
 				listItemLongClickHandler, layerMenuViewHolder);
 	}
 
@@ -265,9 +267,12 @@ public class LayerPresenterTest {
 	@Test
 	public void testOnLongClickLayerAtPosition() {
 		View view = mock(View.class);
-		layerModel.addLayerAt(0, mock(Layer.class));
-		layerModel.addLayerAt(1, mock(Layer.class));
-
+		Layer firstLayer = new Layer(null);
+		Layer secondLayer = new Layer(null);
+		firstLayer.setCheckBox(true);
+		secondLayer.setCheckBox(true);
+		layerModel.addLayerAt(0, firstLayer);
+		layerModel.addLayerAt(1, secondLayer);
 		createPresenter();
 		layerPresenter.onLongClickLayerAtPosition(0, view);
 
@@ -378,6 +383,7 @@ public class LayerPresenterTest {
 	public void testMergeItems() {
 		Layer firstLayer = mock(Layer.class);
 		Layer secondLayer = mock(Layer.class);
+
 		layerModel.addLayerAt(0, firstLayer);
 		layerModel.addLayerAt(1, secondLayer);
 		Command command = mock(Command.class);
@@ -419,11 +425,10 @@ public class LayerPresenterTest {
 		createPresenter();
 		layerPresenter.swapItemsVisually(0, 1);
 		layerPresenter.mergeItems(0, 0);
-
 		verify(commandManager).addCommand(command);
 		verify(navigator).showToast(R.string.layer_merged, Toast.LENGTH_SHORT);
-		verifyNoMoreInteractions(commandManager);
-		verifyZeroInteractions(layerMenuViewHolder, firstLayer, secondLayer, thirdLayer, command);
+		verifyNoMoreInteractions(commandManager, firstLayer, secondLayer, thirdLayer);
+		verifyZeroInteractions(layerMenuViewHolder, command);
 	}
 
 	@Test


### PR DESCRIPTION
Allow to set visibility of layers with checkbox, users are not allowed to merge or reorder when layers are visible due to problems with undo/redo. Users can not choose between different tools while on hidden layer, otherwise the original bitmap would be overwritten.
https://jira.catrob.at/browse/PAINTROID-159

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
