### PR TITLE
PAINTROID-193 Implicit saving of edited image when returning to Catroid

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
@@ -54,8 +54,8 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -66,10 +66,8 @@ import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.DrawerActions.open;
 import static androidx.test.espresso.contrib.DrawerMatchers.isClosed;
-import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class ToolOnBackPressedIntegrationTest {
@@ -182,68 +180,11 @@ public class ToolOnBackPressedIntegrationTest {
 		launchActivityRule.getActivity().model.setSavedPictureUri(Uri.fromFile(saveFile));
 		launchActivityRule.getActivity().model.setOpenedFromCatroid(true);
 
-		Espresso.pressBack();
-
-		onConfirmQuitDialog()
-				.checkPositiveButton(matches(isDisplayed()))
-				.checkNegativeButton(matches(isDisplayed()))
-				.checkNeutralButton(matches(not(isDisplayed())))
-				.checkMessage(matches(isDisplayed()));
-
-		onView(withText(R.string.closing_catroid_security_question_title))
-				.check(matches(isDisplayed()));
-
-		Espresso.pressBack();
-
-		onConfirmQuitDialog()
-				.checkPositiveButton(doesNotExist())
-				.checkNegativeButton(doesNotExist())
-				.checkNeutralButton(doesNotExist())
-				.checkMessage(doesNotExist());
-
-		onView(withText(R.string.closing_catroid_security_question_title))
-				.check(doesNotExist());
-
-		Espresso.pressBack();
-
-		onConfirmQuitDialog().onPositiveButton()
-				.perform(click());
+		Espresso.pressBackUnconditionally();
 
 		assertTrue(launchActivityRule.getActivity().isFinishing());
 		assertTrue(saveFile.exists());
 		assertThat(saveFile.length(), is(greaterThan(0L)));
-	}
-
-	@Test
-	public void testBrushToolBackPressedFromCatroidAndDiscardPicture() {
-		onDrawingSurfaceView()
-				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
-
-		String pathToFile = launchActivityRule.getActivity().getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-				+ File.separator
-				+ Constants.TEMP_PICTURE_NAME
-				+ FILE_ENDING;
-
-		saveFile = new File(pathToFile);
-		launchActivityRule.getActivity().model.setSavedPictureUri(Uri.fromFile(saveFile));
-		launchActivityRule.getActivity().model.setOpenedFromCatroid(true);
-
-		Espresso.pressBack();
-
-		onConfirmQuitDialog()
-				.checkPositiveButton(matches(isDisplayed()))
-				.checkNegativeButton(matches(isDisplayed()))
-				.checkNeutralButton(matches(not(isDisplayed())))
-				.checkMessage(matches(isDisplayed()));
-
-		onView(withText(R.string.closing_catroid_security_question_title))
-				.check(matches(isDisplayed()));
-
-		onConfirmQuitDialog().onNegativeButton()
-				.perform(click());
-
-		assertTrue(launchActivityRule.getActivity().isFinishing());
-		assertFalse(saveFile.exists());
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeNewImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeNewImageTest.java
@@ -23,7 +23,6 @@ import android.content.Intent;
 
 import org.catrobat.paintroid.FileIO;
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
@@ -36,23 +35,18 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import androidx.test.espresso.Espresso;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.GrantPermissionRule;
 
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
-import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class OpenedFromPocketCodeNewImageTest {
@@ -90,16 +84,7 @@ public class OpenedFromPocketCodeNewImageTest {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
-		onTopBarView()
-			.onHomeClicked();
-
-		onView(withText(R.string.save_button_text))
-				.check(matches(isDisplayed()));
-		onView(withText(R.string.discard_button_text))
-				.check(matches(isDisplayed()));
-
-		onView(withText(R.string.save_button_text))
-				.perform(click());
+		Espresso.pressBackUnconditionally();
 
 		String path = launchActivityRule.getActivityResult().getResultData().getStringExtra(Constants.PAINTROID_PICTURE_PATH);
 		assertEquals(imageFile.getAbsolutePath(), path);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeWithImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeWithImageTest.java
@@ -23,7 +23,6 @@ import android.net.Uri;
 import android.os.Environment;
 
 import org.catrobat.paintroid.MainActivity;
-import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
@@ -37,6 +36,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import androidx.test.espresso.Espresso;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.GrantPermissionRule;
@@ -44,18 +44,11 @@ import androidx.test.rule.GrantPermissionRule;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
-import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class OpenedFromPocketCodeWithImageTest {
@@ -99,18 +92,11 @@ public class OpenedFromPocketCodeWithImageTest {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
-		onTopBarView()
-			.onHomeClicked();
-
-		onView(withText(R.string.save_button_text)).check(matches(isDisplayed()));
-		onView(withText(R.string.discard_button_text)).check(matches(isDisplayed()));
-
 		long lastModifiedBefore = imageFile.lastModified();
 		long fileSizeBefore = imageFile.length();
 
-		onView(withText(R.string.save_button_text)).perform(click());
+		Espresso.pressBackUnconditionally();
 
-		assertTrue(launchActivityRule.getActivity().isFinishing());
 		String path = launchActivityRule.getActivityResult().getResultData().getStringExtra(Constants.PAINTROID_PICTURE_PATH);
 		assertEquals(imageFile.getAbsolutePath(), path);
 
@@ -123,11 +109,7 @@ public class OpenedFromPocketCodeWithImageTest {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
-		onTopBarView()
-			.onHomeClicked();
-
-		onView(withText(R.string.save_button_text)).check(matches(isDisplayed()));
-		onView(withText(R.string.discard_button_text)).check(matches(isDisplayed()));
+		Espresso.pressBackUnconditionally();
 
 		long lastModifiedBefore = imageFile.lastModified();
 		long fileSizeBefore = imageFile.length();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -91,8 +91,6 @@ public interface MainActivityContracts {
 
 		void finishActivity();
 
-		void showSaveBeforeReturnToCatroidDialog();
-
 		void showSaveBeforeFinishDialog();
 
 		void showSaveBeforeNewImageDialog();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveBeforeFinishDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveBeforeFinishDialog.java
@@ -73,7 +73,6 @@ public class SaveBeforeFinishDialog extends MainActivityDialogFragment {
 	}
 
 	public enum SaveBeforeFinishDialogType {
-		BACK_TO_POCKET_CODE(R.string.closing_catroid_security_question_title, R.string.closing_security_question),
 		FINISH(R.string.closing_security_question_title, R.string.closing_security_question);
 
 		private final int titleResource;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -176,7 +176,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		if (isImageUnchanged() || model.isSaved()) {
 			finishActivity();
 		} else if (model.isOpenedFromCatroid()) {
-			navigator.showSaveBeforeReturnToCatroidDialog();
+			saveBeforeFinish();
 		} else {
 			navigator.showSaveBeforeFinishDialog();
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -332,13 +332,6 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	}
 
 	@Override
-	public void showSaveBeforeReturnToCatroidDialog() {
-		AppCompatDialogFragment dialog = SaveBeforeFinishDialog.newInstance(
-				SaveBeforeFinishDialogType.BACK_TO_POCKET_CODE);
-		showDialogFragmentSafely(dialog, Constants.SAVE_QUESTION_FRAGMENT_TAG);
-	}
-
-	@Override
 	public void showSaveBeforeFinishDialog() {
 		AppCompatDialogFragment dialog = SaveBeforeFinishDialog.newInstance(
 				SaveBeforeFinishDialogType.FINISH);

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -73,7 +73,6 @@
     <string name="help_content_layer">Create new layers or modify existing ones.</string>
     <string name="help_content_color_chooser">Select or adjust a color.</string>
     <string name="help_content_hand">Move your finger to move the canvas.</string>
-    <string name="closing_catroid_security_question_title">Back to project</string>
     <string name="closing_security_question_title">Quit</string>
     <string name="closing_security_question">Save changes?</string>
     <string name="menu_new_image">New image</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -224,17 +224,6 @@ public class MainActivityPresenterTest {
 	}
 
 	@Test
-	public void testBackToCatroidClickedWhenUndoAvailableAndOpenedFromCatroidThenShowSaveBeforeReturnDialog() {
-		when(model.isOpenedFromCatroid()).thenReturn(true);
-		when(commandManager.isUndoAvailable()).thenReturn(true);
-
-		presenter.backToPocketCodeClicked();
-
-		verify(navigator).showSaveBeforeReturnToCatroidDialog();
-		verifyNoMoreInteractions(navigator);
-	}
-
-	@Test
 	public void testLoadImageClickedLoad() {
 		presenter.loadImageClicked();
 


### PR DESCRIPTION
eliminated the dialog.
Removed the following tests:
testBrushToolBackPressedFromCatroidAndDiscardPicture
testBackToCatroidClickedWhenUndoAvailableAndOpenedFromCatroidThenShowSaveBeforeReturnDialog

Reason: The dialog no longer shows up which means we no longer need these tests.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
