### PR TITLE
PAINTROID-196 Share images from other apps

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/FileFromOtherSourceIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/FileFromOtherSourceIntegrationTest.java
@@ -1,0 +1,141 @@
+package org.catrobat.paintroid.test.espresso;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.util.Log;
+
+import org.catrobat.paintroid.FileIO;
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
+import org.catrobat.paintroid.tools.ToolType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FileFromOtherSourceIntegrationTest {
+
+	private static ArrayList<File> deletionFileList = null;
+
+	@Rule
+	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
+
+	@ClassRule
+	public static GrantPermissionRule grantPermissionRule = EspressoUtils.grantPermissionRulesVersionCheck();
+
+	private ContentResolver resolver;
+
+	@Before
+	public void setUp() {
+		onToolBarView().performSelectTool(ToolType.BRUSH);
+		deletionFileList = new ArrayList<>();
+		resolver = launchActivityRule.getActivity().getContentResolver();
+	}
+
+	@Test
+	public void testGetSharedPictureFromOtherApp() {
+		Intent intent = new Intent();
+		Uri receivedUri = createTestImageFile();
+		Bitmap receivedBitmap = null;
+
+		try {
+			receivedBitmap = FileIO.getBitmapFromUri(resolver, receivedUri);
+		} catch (Exception e) {
+			Log.e("Can't read", "Can't get Bitmap from File");
+		}
+
+		Objects.requireNonNull(receivedBitmap);
+		intent.setData(receivedUri);
+		intent.setType("image/png");
+		intent.setAction(Intent.ACTION_SEND);
+		intent.putExtra(Intent.EXTRA_STREAM, receivedUri);
+
+		launchActivityRule.launchActivity(intent);
+		Intent mainActivityIntent = launchActivityRule.getActivity().getIntent();
+
+		String intentAction = intent.getAction();
+		String intentType = intent.getType();
+		Bundle intentBundle = intent.getExtras();
+		Objects.requireNonNull(intentBundle);
+		Uri intentUri = (Uri) intentBundle.get(Intent.EXTRA_STREAM);
+
+		String mainActivityIntentAction = mainActivityIntent.getAction();
+		String mainActivityIntentType = mainActivityIntent.getType();
+		Bundle mainActivityIntentBundle = mainActivityIntent.getExtras();
+		Objects.requireNonNull(mainActivityIntentBundle);
+		Uri mainActivityIntentUri = (Uri) mainActivityIntentBundle.get(Intent.EXTRA_STREAM);
+		Bitmap mainActivityIntentBitmap = null;
+		Objects.requireNonNull(mainActivityIntentUri);
+
+		try {
+			mainActivityIntentBitmap = FileIO.getBitmapFromUri(resolver, mainActivityIntentUri);
+		} catch (Exception e) {
+			Log.e("Can't read", "Can't get Bitmap from File");
+		}
+
+		Objects.requireNonNull(mainActivityIntentBitmap);
+
+		assertEquals(intentAction, mainActivityIntentAction);
+		assertEquals(intentType, mainActivityIntentType);
+		assertEquals(intentUri, mainActivityIntentUri);
+		assertEquals(receivedBitmap.getWidth(), mainActivityIntentBitmap.getWidth());
+		assertEquals(receivedBitmap.getHeight(), mainActivityIntentBitmap.getHeight());
+	}
+
+	@After
+	public void tearDown() {
+		for (File file : deletionFileList) {
+			if (file != null && file.exists()) {
+				assertTrue(file.delete());
+			}
+		}
+	}
+
+	private Uri createTestImageFile() {
+		Bitmap bitmap = Bitmap.createBitmap(400, 400, Bitmap.Config.ARGB_8888);
+
+		ContentValues contentValues = new ContentValues();
+		contentValues.put(MediaStore.Images.Media.DISPLAY_NAME, "testfile.jpg");
+		contentValues.put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg");
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+			contentValues.put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES);
+		}
+
+		Uri imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues);
+
+		try {
+			OutputStream fos = resolver.openOutputStream(Objects.requireNonNull(imageUri));
+			assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos));
+			assert fos != null;
+			fos.close();
+		} catch (IOException e) {
+			throw new AssertionError("Picture file could not be created.", e);
+		}
+
+		File imageFile = new File(imageUri.getPath(), "testfile.jpg");
+		deletionFileList.add(imageFile);
+
+		return imageUri;
+	}
+}

--- a/Paintroid/src/main/AndroidManifest.xml
+++ b/Paintroid/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission  android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 
@@ -54,6 +54,12 @@
                 <category android:name="android.intent.category.ALTERNATIVE" />
                 <category android:name="android.intent.category.DEFAULT" />
 
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.EDIT" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
         </activity>

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -21,11 +21,13 @@ package org.catrobat.paintroid;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -78,6 +80,8 @@ import org.catrobat.paintroid.ui.viewholder.LayerMenuViewHolder;
 import org.catrobat.paintroid.ui.viewholder.TopBarViewHolder;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
@@ -127,6 +131,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 	private PaintroidApplicationFragment appFragment;
 	private DefaultToolController defaultToolController;
 	private BottomNavigationViewHolder bottomNavigationViewHolder;
+	private CommandFactory commandFactory;
 
 	private Runnable deferredRequestPermissionsResult;
 
@@ -169,7 +174,35 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 
 		presenter.onCreateTool();
 
-		if (savedInstanceState == null) {
+		Intent receivedIntent = getIntent();
+		String receivedAction = receivedIntent.getAction();
+		String receivedType = receivedIntent.getType();
+
+		if (receivedAction != null && receivedType != null && (receivedAction.equals(Intent.ACTION_SEND) || receivedAction.equals(Intent.ACTION_EDIT)) && receivedType.startsWith("image/")) {
+			Uri receivedUri = receivedIntent
+					.getParcelableExtra(Intent.EXTRA_STREAM);
+
+			if (receivedUri == null) {
+				receivedUri = receivedIntent.getData();
+			}
+
+			Objects.requireNonNull(receivedUri);
+			Bitmap receivedBitmap = null;
+
+			try {
+				receivedBitmap = FileIO.getBitmapFromUri(getContentResolver(), receivedUri);
+			} catch (IOException e) {
+				Log.e("Can not read", "Unable to retrieve Bitmap from Uri");
+			}
+
+			commandManager.setInitialStateCommand(commandFactory.createInitCommand(receivedBitmap));
+			commandManager.reset();
+			model.setSavedPictureUri(null);
+			model.setCameraImageUri(null);
+			workspace.resetPerspective();
+
+			presenter.initializeFromCleanState(null, null);
+		} else if (savedInstanceState == null) {
 			Intent intent = getIntent();
 			String picturePath = intent.getStringExtra(PAINTROID_PICTURE_PATH);
 			String pictureName = intent.getStringExtra(PAINTROID_PICTURE_NAME);
@@ -250,7 +283,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 		if (appFragment.getCommandManager() == null) {
 			DisplayMetrics metrics = getResources().getDisplayMetrics();
 
-			CommandFactory commandFactory = new DefaultCommandFactory();
+			commandFactory = new DefaultCommandFactory();
 			CommandManager synchronousCommandManager = new DefaultCommandManager(new CommonFactory(), layerModel);
 			commandManager = new AsyncCommandManager(synchronousCommandManager, layerModel);
 			Command initCommand = commandFactory.createInitCommand(metrics.widthPixels, metrics.heightPixels);


### PR DESCRIPTION
Implemented sharing/editing pictures with Paintroid and the app shows up when the user clicks on any image and tries to share/edit it. A bitmap with the picture will be created (equal to load image) and when user saves the image a new image is saved. When the user clicks on the share/edit button the MainActivity gets invoked and identifies, that someone tries to share data with us. So each time there will be a new instance of the app.
https://jira.catrob.at/browse/PAINTROID-196

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
