### PR TITLE
PAINTROID-139 Using certain tools should not reset the center and zoom level of the canvas

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ImportToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ImportToolIntegrationTest.java
@@ -28,10 +28,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
+
+import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
+import static org.junit.Assert.assertEquals;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -46,9 +47,11 @@ public class ImportToolIntegrationTest {
 
 	@Rule
 	public ActivityTestRule<MainActivity> launchActivityRule = new RtlActivityTestRule<>(MainActivity.class, "ar");
+	private MainActivity mainActivity;
 
 	@Before
 	public void setUp() {
+		mainActivity = launchActivityRule.getActivity();
 		onToolBarView()
 				.performSelectTool(ToolType.IMPORTPNG);
 	}
@@ -65,5 +68,24 @@ public class ImportToolIntegrationTest {
 
 		onView(withId(R.id.pocketpaint_dialog_import_stickers)).check(doesNotExist());
 		onView(withId(R.id.pocketpaint_dialog_import_gallery)).check(doesNotExist());
+	}
+
+	@Test
+	public void testImportDoesNotResetPerspectiveScale() {
+		onView(withText(R.string.pocketpaint_cancel)).perform(click());
+
+		onToolBarView()
+				.performSelectTool(ToolType.BRUSH);
+
+		float scale = 2.0f;
+		mainActivity.perspective.setScale(scale);
+		mainActivity.refreshDrawingSurface();
+
+		onToolBarView()
+				.performSelectTool(ToolType.IMPORTPNG);
+
+		onView(withText(R.string.pocketpaint_cancel)).perform(click());
+
+		assertEquals(scale, mainActivity.perspective.getScale(), Float.MIN_VALUE);
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.java
@@ -57,11 +57,12 @@ public class ShapeToolIntegrationTest {
 	@Rule
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
 	private ToolReference toolReference;
+	private MainActivity mainActivity;
 
 	@Before
 	public void setUp() {
-		MainActivity activity = launchActivityRule.getActivity();
-		toolReference = activity.toolReference;
+		mainActivity = launchActivityRule.getActivity();
+		toolReference = mainActivity.toolReference;
 
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
@@ -72,7 +73,7 @@ public class ShapeToolIntegrationTest {
 	}
 
 	private Paint getToolPaint() {
-		return launchActivityRule.getActivity().toolPaint.getPaint();
+		return mainActivity.toolPaint.getPaint();
 	}
 
 	@Test
@@ -207,6 +208,30 @@ public class ShapeToolIntegrationTest {
 				.checkPixelColor(Color.BLACK, DrawingSurfaceLocationProvider.TOOL_POSITION);
 		onDrawingSurfaceView()
 				.checkPixelColor(Color.TRANSPARENT, DrawingSurfaceLocationProvider.TOP_MIDDLE);
+	}
+
+	@Test
+	public void testShapeToolBoxGetsPlacedCorrectWhenZoomedIn() {
+		onToolBarView()
+				.performSelectTool(ToolType.BRUSH);
+
+		mainActivity.perspective.setSurfaceTranslationY(200);
+		mainActivity.perspective.setSurfaceTranslationX(50);
+		mainActivity.perspective.setScale(2.0f);
+		mainActivity.refreshDrawingSurface();
+
+		onToolBarView()
+				.performSelectTool(ToolType.SHAPE);
+		onShapeToolOptionsView()
+				.performSelectShape(DrawableShape.RECTANGLE);
+		onShapeToolOptionsView()
+				.performSelectShapeDrawType(DrawableStyle.FILL);
+		onTopBarView()
+				.performClickCheckmark();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, mainActivity.perspective.surfaceCenterX - mainActivity.perspective.surfaceTranslationX,
+						mainActivity.perspective.surfaceCenterY - mainActivity.perspective.surfaceTranslationY);
 	}
 
 	public void drawShape() {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
@@ -79,15 +79,16 @@ public class StampToolIntegrationTest {
 	private Workspace workspace;
 	private Perspective perspective;
 	private ToolReference toolReference;
+	private MainActivity mainActivity;
 
 	@Before
 	public void setUp() {
 		onToolBarView()
 				.performSelectTool(ToolType.BRUSH);
-		MainActivity activity = launchActivityRule.getActivity();
-		workspace = activity.workspace;
-		perspective = activity.perspective;
-		toolReference = activity.toolReference;
+		mainActivity = launchActivityRule.getActivity();
+		workspace = mainActivity.workspace;
+		perspective = mainActivity.perspective;
+		toolReference = mainActivity.toolReference;
 	}
 
 	@Ignore("Causes crashes on jenkins")
@@ -271,12 +272,26 @@ public class StampToolIntegrationTest {
 
 		assertFalse(expectedBitmap.sameAs(emptyBitmap));
 
-		launchActivityRule.getActivity()
-				.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+		mainActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
 
 		Bitmap actualBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
 				toolReference.get()).drawingBitmap);
 
 		assertTrue(expectedBitmap.sameAs(actualBitmap));
+	}
+
+	@Test
+	public void testStampToolDoesNotResetPerspectiveScale() {
+		float scale = 2.0f;
+
+		perspective.setScale(scale);
+		perspective.setSurfaceTranslationX(50);
+		perspective.setSurfaceTranslationY(200);
+		mainActivity.refreshDrawingSurface();
+
+		onToolBarView()
+				.performSelectTool(ToolType.STAMP);
+
+		assertEquals(scale, perspective.getScale(), 0.0001f);
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.java
@@ -90,6 +90,7 @@ public class TransformToolIntegrationTest {
 	private Perspective perspective;
 	private LayerContracts.Model layerModel;
 	private ToolReference toolReference;
+	private MainActivity mainActivity;
 
 	private static void drawPlus(Bitmap bitmap, int lineLength) {
 		int horizontalStartX = bitmap.getWidth() / 4;
@@ -150,11 +151,11 @@ public class TransformToolIntegrationTest {
 
 	@Before
 	public void setUp() {
-		MainActivity activity = launchActivityRule.getActivity();
-		activityHelper = new MainActivityHelper(activity);
-		perspective = activity.perspective;
-		layerModel = activity.layerModel;
-		toolReference = activity.toolReference;
+		mainActivity = launchActivityRule.getActivity();
+		activityHelper = new MainActivityHelper(mainActivity);
+		perspective = mainActivity.perspective;
+		layerModel = mainActivity.layerModel;
+		toolReference = mainActivity.toolReference;
 
 		displayWidth = activityHelper.getDisplayWidth();
 		displayHeight = activityHelper.getDisplayHeight();
@@ -1338,7 +1339,7 @@ public class TransformToolIntegrationTest {
 		onToolBarView()
 				.performSelectTool(ToolType.TRANSFORM);
 
-		SeekBar seekBar = launchActivityRule.getActivity().findViewById(R.id.pocketpaint_transform_resize_seekbar);
+		SeekBar seekBar = mainActivity.findViewById(R.id.pocketpaint_transform_resize_seekbar);
 		int progress = seekBar.getProgress();
 
 		onTransformToolOptionsView()
@@ -1366,5 +1367,20 @@ public class TransformToolIntegrationTest {
 		progress = seekBar.getProgress();
 		onTransformToolOptionsView()
 				.checkPercentageTextMatches(progress);
+	}
+
+	@Test
+	public void testTransformToolDoesNotResetPerspectiveScale() {
+		float scale = 2.0f;
+
+		perspective.setScale(scale);
+		perspective.setSurfaceTranslationX(50);
+		perspective.setSurfaceTranslationY(200);
+		mainActivity.refreshDrawingSurface();
+
+		onToolBarView()
+				.performSelectTool(ToolType.TRANSFORM);
+
+		assertEquals(scale, perspective.getScale(), 0.0001f);
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -31,6 +31,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,6 +91,7 @@ public class BaseToolWithRectangleShapeToolTest {
 		when(contextCallback.getDisplayMetrics()).thenReturn(metrics);
 		when(workspace.getScale()).thenReturn(1f);
 		when(workspace.getWidth()).thenReturn(screenWidth);
+		when(workspace.getPerspective()).thenReturn(new Perspective(screenWidth, screenHeight));
 		when(workspace.getHeight()).thenReturn(screenHeight);
 		when(workspace.contains(any(PointF.class))).thenAnswer(new Answer<Boolean>() {
 			@Override

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/CursorToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/CursorToolTest.java
@@ -36,6 +36,7 @@ import org.catrobat.paintroid.tools.common.Constants;
 import org.catrobat.paintroid.tools.implementation.CursorTool;
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,6 +80,7 @@ public class CursorToolTest {
 		when(toolPaint.getPaint()).thenReturn(paint);
 		when(workspace.getHeight()).thenReturn(1920);
 		when(workspace.getWidth()).thenReturn(1080);
+		when(workspace.getPerspective()).thenReturn(new Perspective(1080, 1920));
 
 		toolToTest = new CursorTool(brushToolOptionsView, contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
@@ -28,6 +28,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.ImportTool;
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,6 +74,7 @@ public class ImportToolTest {
 		when(workspace.getWidth()).thenReturn(20);
 		when(workspace.getHeight()).thenReturn(30);
 		when(workspace.getScale()).thenReturn(1f);
+		when(workspace.getPerspective()).thenReturn(new Perspective(20, 30));
 
 		tool = new ImportTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
@@ -30,6 +30,7 @@ import org.catrobat.paintroid.tools.drawable.DrawableShape;
 import org.catrobat.paintroid.tools.implementation.ShapeTool;
 import org.catrobat.paintroid.tools.options.ShapeToolOptionsView;
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,6 +84,7 @@ public class ShapeToolTest {
 		when(workspace.getWidth()).thenReturn(100);
 		when(workspace.getHeight()).thenReturn(100);
 		when(workspace.getScale()).thenReturn(1f);
+		when(workspace.getPerspective()).thenReturn(new Perspective(100, 100));
 
 		when(contextCallback.getDisplayMetrics()).thenReturn(displayMetrics);
 		displayMetrics.widthPixels = 100;

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
@@ -33,6 +33,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.StampTool;
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -73,6 +74,7 @@ public class StampToolTest {
 		when(workspace.getScale()).thenReturn(1f);
 		when(workspace.getWidth()).thenReturn(200);
 		when(workspace.getHeight()).thenReturn(300);
+		when(workspace.getPerspective()).thenReturn(new Perspective(200, 300));
 		when(workspace.getCanvasPointFromSurfacePoint(any(PointF.class))).then(new Answer<PointF>() {
 			@Override
 			public PointF answer(InvocationOnMock invocation) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.java
@@ -23,6 +23,8 @@ import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.graphics.RectF;
 
+import org.catrobat.paintroid.ui.Perspective;
+
 public interface Workspace {
 	boolean contains(PointF point);
 
@@ -57,4 +59,6 @@ public interface Workspace {
 	PointF getCanvasPointFromSurfacePoint(PointF surfacePoint);
 
 	void invalidate();
+
+	Perspective getPerspective();
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.java
@@ -19,6 +19,7 @@
 
 package org.catrobat.paintroid.tools.implementation;
 
+import android.annotation.SuppressLint;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Point;
@@ -32,6 +33,7 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.ui.Perspective;
 
 import androidx.annotation.VisibleForTesting;
 
@@ -49,15 +51,22 @@ public abstract class BaseToolWithShape extends BaseTool {
 	final Paint linePaint;
 	final DisplayMetrics metrics;
 
-	public BaseToolWithShape(ContextCallback contextCallback, ToolOptionsVisibilityController toolOptionsViewController,
-			ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
+	@SuppressLint("VisibleForTests")
+	public BaseToolWithShape(ContextCallback contextCallback, ToolOptionsVisibilityController toolOptionsViewController, ToolPaint toolPaint, Workspace workspace, CommandManager commandManager) {
 		super(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager);
 
 		metrics = contextCallback.getDisplayMetrics();
 
 		primaryShapeColor = contextCallback.getColor(R.color.pocketpaint_main_rectangle_tool_primary_color);
 		secondaryShapeColor = contextCallback.getColor(R.color.pocketpaint_colorAccent);
-		toolPosition = new PointF(workspace.getWidth() / 2f, workspace.getHeight() / 2f);
+		Perspective perspective = workspace.getPerspective();
+
+		if (perspective.getScale() > 1) {
+			toolPosition = new PointF(perspective.surfaceCenterX - perspective.surfaceTranslationX, perspective.surfaceCenterY - perspective.surfaceTranslationY);
+		} else {
+			toolPosition = new PointF(workspace.getWidth() / 2f, workspace.getHeight() / 2f);
+		}
+
 		linePaint = new Paint();
 		linePaint.setColor(primaryShapeColor);
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.java
@@ -41,6 +41,10 @@ public class DefaultWorkspace implements Workspace {
 		this.listener = listener;
 	}
 
+	public Perspective getPerspective() {
+		return perspective;
+	}
+
 	@Override
 	public boolean contains(PointF point) {
 		return point.x < getWidth() && point.x >= 0 && point.y < getHeight() && point.y >= 0;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.java
@@ -289,8 +289,10 @@ public class TextTool extends BaseToolWithRectangleShape {
 
 	@VisibleForTesting
 	public void resetBoxPosition() {
-		toolPosition.x = workspace.getWidth() / 2.0f;
-		toolPosition.y = boxHeight / 2.0f + MARGIN_TOP;
+		if (workspace.getScale() <= 1) {
+			toolPosition.x = workspace.getWidth() / 2.0f;
+			toolPosition.y = boxHeight / 2.0f + MARGIN_TOP;
+		}
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.java
@@ -88,8 +88,6 @@ public class TransformTool extends BaseToolWithRectangleShape {
 
 		cropAlgorithm = new JavaCropAlgorithm();
 
-		resetScaleAndTranslation();
-
 		cropRunFinished = true;
 
 		this.maximumBoxResolution = metrics.widthPixels * metrics.heightPixels * MAXIMUM_BITMAP_SIZE_FACTOR;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.java
@@ -207,8 +207,12 @@ public class DrawingSurface extends SurfaceView implements SurfaceHolder.Callbac
 	@Override
 	public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
 		surfaceReady = true;
+		ToolType currentToolType = toolReference.get().getToolType();
+
+		if (currentToolType != ToolType.IMPORTPNG && currentToolType != ToolType.TRANSFORM && currentToolType != ToolType.TEXT) {
+			perspective.resetScaleAndTranslation();
+		}
 		perspective.setSurfaceFrame(holder.getSurfaceFrame());
-		perspective.resetScaleAndTranslation();
 
 		if (drawingThread != null) {
 			drawingThread.start();


### PR DESCRIPTION
Implemented that perspective scale does not reset when choosing certain tools (text, shape, transform, importpng, stamp) and the tool box gets placed in the middle of the screen if scale > 1 (if zoomed). Also added tests to check behavior for affected tools. https://jira.catrob.at/browse/PAINTROID-139

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
