### PR TITLE
PAINTROID-147 - Confirm tool application by selecting another tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
@@ -70,6 +70,7 @@ import static org.junit.Assert.fail;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -525,6 +526,36 @@ public class TextToolIntegrationTest {
 		assertArrayEquals(expectedTextSplitUp, actualTextSplitUp);
 
 		checkTextBoxDimensionsAndDefaultPosition();
+	}
+
+	@Test
+	public void testTextToolAppliedWhenSelectingOtherTool() {
+		enterTestText();
+
+		onToolBarView()
+				.performSelectTool(ToolType.BRUSH);
+
+		int surfaceBitmapWidth = layerModel.getWidth();
+		int[] pixelsDrawingSurface = new int[surfaceBitmapWidth];
+		layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, surfaceBitmapWidth, 0, (int) textTool.toolPosition.y, surfaceBitmapWidth, 1);
+		int numberOfBlackPixels = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
+		assertTrue(numberOfBlackPixels > 0);
+	}
+
+	@Test
+	public void testTextToolNotAppliedWhenPressingBack() {
+		enterTestText();
+
+		onToolBarView()
+				.performCloseToolOptionsView();
+
+		pressBack();
+
+		int surfaceBitmapWidth = layerModel.getWidth();
+		int[] pixelsDrawingSurface = new int[surfaceBitmapWidth];
+		layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, surfaceBitmapWidth, 0, (int) textTool.toolPosition.y, surfaceBitmapWidth, 1);
+		int numberOfBlackPixels = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
+		assertEquals(0, numberOfBlackPixels);
 	}
 
 	@Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.java
@@ -31,6 +31,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
+import org.catrobat.paintroid.tools.implementation.BaseToolWithShape;
 import org.catrobat.paintroid.tools.implementation.ImportTool;
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 
@@ -65,8 +66,8 @@ public class DefaultToolController implements ToolController {
 	}
 
 	@Override
-	public void switchTool(ToolType toolType) {
-		switchTool(createAndSetupTool(toolType));
+	public void switchTool(ToolType toolType, boolean backPressed) {
+		switchTool(createAndSetupTool(toolType), backPressed);
 	}
 
 	@Override
@@ -104,8 +105,15 @@ public class DefaultToolController implements ToolController {
 		return toolReference.get().getDrawPaint().getColor();
 	}
 
-	private void switchTool(Tool tool) {
+	private void switchTool(Tool tool, boolean backPressed) {
 		Tool currentTool = toolReference.get();
+		ToolType currentToolType = currentTool.getToolType();
+
+		if ((currentToolType == ToolType.TEXT || currentToolType == ToolType.TRANSFORM
+				|| currentToolType == ToolType.IMPORTPNG || currentToolType == ToolType.SHAPE) && !backPressed) {
+			BaseToolWithShape toolToApply = (BaseToolWithShape) currentTool;
+			toolToApply.onClickOnButton();
+		}
 
 		if (currentTool.getToolType() == tool.getToolType()) {
 			Bundle toolBundle = new Bundle();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
@@ -27,7 +27,7 @@ import org.catrobat.paintroid.tools.ToolType;
 public interface ToolController {
 	void setOnColorPickedListener(ColorPickerDialog.OnColorPickedListener onColorPickedListener);
 
-	void switchTool(ToolType toolType);
+	void switchTool(ToolType toolType, boolean backPressed);
 
 	boolean isDefaultTool();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.java
@@ -167,7 +167,7 @@ public class LayerPresenter implements LayerContracts.Presenter, DragAndDropPres
 		drawingSurface.refreshDrawingSurface();
 
 		if (model.getCurrentLayer().equals(destinationLayer)) {
-			defaultToolController.switchTool(ToolType.HAND);
+			defaultToolController.switchTool(ToolType.HAND, false);
 			bottomNavigationViewHolder.showCurrentTool(ToolType.HAND);
 		}
 	}
@@ -185,7 +185,7 @@ public class LayerPresenter implements LayerContracts.Presenter, DragAndDropPres
 		drawingSurface.refreshDrawingSurface();
 
 		if (model.getCurrentLayer().equals(destinationLayer)) {
-			defaultToolController.switchTool(ToolType.BRUSH);
+			defaultToolController.switchTool(ToolType.BRUSH, false);
 			bottomNavigationViewHolder.showCurrentTool(ToolType.BRUSH);
 		}
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -356,7 +356,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 				}
 				Uri selectedGalleryImageUri = data.getData();
 				setTool(ToolType.IMPORTPNG);
-				toolController.switchTool(ToolType.IMPORTPNG);
+				toolController.switchTool(ToolType.IMPORTPNG, false);
 				interactor.loadFile(this, LOAD_IMAGE_IMPORTPNG, maxWidth, maxHeight, selectedGalleryImageUri);
 				break;
 			case REQUEST_CODE_LOAD_PICTURE:
@@ -435,7 +435,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 			toolController.hideToolOptionsView();
 		} else if (!toolController.isDefaultTool()) {
 			setTool(ToolType.BRUSH);
-			toolController.switchTool(ToolType.BRUSH);
+			toolController.switchTool(ToolType.BRUSH, true);
 		} else {
 			showSecurityQuestionBeforeExit();
 		}
@@ -617,7 +617,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	private void switchTool(ToolType type) {
 		setTool(type);
-		toolController.switchTool(type);
+		toolController.switchTool(type, false);
 
 		if (type == ToolType.IMPORTPNG) {
 			showImportDialog();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.java
@@ -125,7 +125,7 @@ public class LayerAdapter extends BaseAdapter implements LayerContracts.Adapter 
 		@Override
 		public void setSelected(int position, BottomNavigationViewHolder bottomNavigationViewHolder, DefaultToolController defaultToolController) {
 			if (!layerPresenter.getLayerItem(position).getCheckBox()) {
-				defaultToolController.switchTool(ToolType.HAND);
+				defaultToolController.switchTool(ToolType.HAND, false);
 				bottomNavigationViewHolder.showCurrentTool(ToolType.HAND);
 			}
 			layerBackground.setBackgroundColor(Color.BLUE);


### PR DESCRIPTION
Implemented applying text/shape/importpng/transform tool when selecting other tool. It will not apply the tool when pressing back, only brush tool will be set. Also wrote 2 tests to test the correct behavior.

https://jira.catrob.at/browse/PAINTROID-147

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
