### PR TITLE
Paintroid-160: Create file format .catrobat-image / save/load .catrobat-image.

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -59,6 +59,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class LayerIntegrationTest {
+
 	@Rule
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -348,14 +348,14 @@ public class MenuFileActivityIntegrationTest {
 
 		onView(withText(R.string.save_button_text)).perform(click());
 
-		onView(withText(R.string.pocketpaint_no)).perform(click());
-		onView(withText(R.string.pocketpaint_ok)).perform(click());
-
 		assertNotNull(activity.model.getSavedPictureUri());
 
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());
 
 		File oldFile = new File(activity.model.getSavedPictureUri().toString());
+
+		onView(withText(R.string.pocketpaint_no)).perform(click());
+		onView(withText(R.string.pocketpaint_ok)).perform(click());
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_MIDDLE));
@@ -384,6 +384,10 @@ public class MenuFileActivityIntegrationTest {
 				.performOpenMoreOptions();
 
 		onView(withText(R.string.menu_save_image)).perform(click());
+
+		onView(withId(R.id.pocketpaint_image_name_save_text))
+				.perform(replaceText("AskForSaveAfterSavedOnce"));
+
 		onView(withText(R.string.save_button_text)).perform(click());
 
 		assertNotNull(activity.model.getSavedPictureUri());
@@ -517,6 +521,9 @@ public class MenuFileActivityIntegrationTest {
 				is("jpg"))).inRoot(isPlatformPopup()).perform(click());
 		onView(withId(R.id.pocketpaint_image_name_save_text))
 				.perform(replaceText(Constants.TEMP_PICTURE_NAME));
+
+		onView(withText(R.string.save_button_text))
+				.perform(click());
 
 		assertNotNull(activity.model.getSavedPictureUri());
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/OraFileFormatIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/OraFileFormatIntegrationTest.java
@@ -1,0 +1,230 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.test.espresso;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Intent;
+import android.net.Uri;
+
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
+import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
+import org.hamcrest.core.AllOf;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+
+import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.LayerMenuViewInteraction.onLayerMenuView;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public class OraFileFormatIntegrationTest {
+
+	private static ArrayList<File> deletionFileList = null;
+
+	@Rule
+	public IntentsTestRule<MainActivity> launchActivityRule = new IntentsTestRule<>(MainActivity.class);
+
+	@ClassRule
+	public static GrantPermissionRule grantPermissionRule = EspressoUtils.grantPermissionRulesVersionCheck();
+
+	private MainActivity activity;
+
+	@Before
+	public void setUp() {
+		deletionFileList = new ArrayList<>();
+		activity = launchActivityRule.getActivity();
+	}
+
+	@After
+	public void tearDown() {
+		for (File file : deletionFileList) {
+			if (file != null && file.exists()) {
+				assertTrue(file.delete());
+			}
+		}
+	}
+
+	@Test
+	public void testSaveAsOraFile() {
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
+
+		onTopBarView()
+				.performOpenMoreOptions();
+		onView(withText(R.string.menu_save_image))
+				.perform(click());
+
+		onView(withId(R.id.pocketpaint_save_dialog_spinner))
+				.perform(click());
+		onData(allOf(is(instanceOf(String.class)),
+				is("ora"))).inRoot(isPlatformPopup()).perform(click());
+		onView(withId(R.id.pocketpaint_image_name_save_text))
+				.perform(replaceText("test1337"));
+
+		onView(withText(R.string.save_button_text))
+				.perform(click());
+
+		assertNotNull(activity.model.getSavedPictureUri());
+		addUriToDeletionFileList(activity.model.getSavedPictureUri());
+	}
+
+	@Test
+	public void testSaveAndOverrideOraFile() {
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
+
+		onTopBarView()
+				.performOpenMoreOptions();
+		onView(withText(R.string.menu_save_image))
+				.perform(click());
+
+		onView(withId(R.id.pocketpaint_save_dialog_spinner))
+				.perform(click());
+		onData(allOf(is(instanceOf(String.class)),
+				is("ora"))).inRoot(isPlatformPopup()).perform(click());
+
+		onView(withId(R.id.pocketpaint_image_name_save_text))
+				.perform(replaceText("OraOverride"));
+
+		onView(withText(R.string.save_button_text))
+				.perform(click());
+
+		onView(withText(R.string.pocketpaint_no)).perform(click());
+		onView(withText(R.string.pocketpaint_ok)).perform(click());
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.BOTTOM_MIDDLE));
+
+		onTopBarView()
+				.performOpenMoreOptions();
+		onView(withText(R.string.menu_save_image))
+				.perform(click());
+
+		onView(withText(R.string.save_button_text))
+				.perform(click());
+
+		onView(withText(R.string.pocketpaint_overwrite_title))
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.overwrite_button_text))
+				.perform(click());
+
+		Uri imageUri = activity.model.getSavedPictureUri();
+
+		assertNotNull(imageUri);
+		addUriToDeletionFileList(imageUri);
+	}
+
+	@Test
+	public void testOraFileWithMultipleLayersSaveAndLoad() {
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
+
+		onLayerMenuView()
+				.performOpen()
+				.performAddLayer()
+				.checkLayerCount(2)
+				.performClose();
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.TOP_MIDDLE));
+
+		onLayerMenuView()
+				.performOpen()
+				.performAddLayer()
+				.checkLayerCount(3)
+				.performClose();
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.BOTTOM_MIDDLE));
+
+		onTopBarView()
+				.performOpenMoreOptions();
+
+		onView(withText(R.string.menu_save_image))
+				.perform(click());
+
+		onView(withId(R.id.pocketpaint_save_dialog_spinner))
+				.perform(click());
+		onData(AllOf.allOf(is(instanceOf(String.class)),
+				is("ora"))).inRoot(isPlatformPopup()).perform(click());
+		onView(withId(R.id.pocketpaint_image_name_save_text))
+				.perform(replaceText("MoreLayersOraTest"));
+
+		onView(withText(R.string.save_button_text))
+				.perform(click());
+
+		Uri fileUri = activity.model.getSavedPictureUri();
+
+		assertNotNull(fileUri);
+		addUriToDeletionFileList(fileUri);
+
+		Intent intent = new Intent();
+		intent.setData(fileUri);
+		Instrumentation.ActivityResult resultOK = new Instrumentation.ActivityResult(Activity.RESULT_OK, intent);
+		intending(hasAction(Intent.ACTION_GET_CONTENT)).respondWith(resultOK);
+
+		onTopBarView()
+				.performOpenMoreOptions();
+
+		onView(withText(R.string.menu_load_image))
+				.perform(click());
+
+		onLayerMenuView()
+				.performOpen()
+				.checkLayerCount(3);
+	}
+
+	private void addUriToDeletionFileList(Uri uri) {
+		deletionFileList.add(new File(Objects.requireNonNull(uri.getPath())));
+	}
+}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeNewImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeNewImageTest.java
@@ -1,20 +1,20 @@
 /*
- *  Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2015 The Catrobat Team
- *  (<http://developer.catrobat.org/credits>)
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.catrobat.paintroid.test.espresso.catroid;

--- a/Paintroid/src/main/AndroidManifest.xml
+++ b/Paintroid/src/main/AndroidManifest.xml
@@ -24,8 +24,8 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 
     <application
         android:largeHeap="true"
@@ -55,6 +55,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
 
                 <data android:mimeType="image/*" />
+                <data android:scheme="file" />
+                <data android:host="*"/>
+                <data android:pathPattern=".*\\.ora" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -52,11 +52,14 @@ public final class FileIO {
 	public static int compressQuality = 100;
 	public static Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.JPEG;
 	public static boolean catroidFlag = false;
+	public static boolean isCatrobatImage = false;
 
 	public static String currentFileNameJpg = null;
 	public static String currentFileNamePng = null;
+	public static String currentFileNameOra = null;
 	public static Uri uriFileJpg = null;
 	public static Uri uriFilePng = null;
+	public static Uri uriFileOra = null;
 
 	private FileIO() {
 		throw new AssertionError();
@@ -220,7 +223,7 @@ public final class FileIO {
 	}
 
 	public static int checkIfDifferentFile(String filename) {
-		if (currentFileNamePng == null && currentFileNameJpg == null) {
+		if (currentFileNamePng == null && currentFileNameJpg == null && currentFileNameOra == null) {
 			return Constants.IS_NO_FILE;
 		}
 
@@ -232,10 +235,14 @@ public final class FileIO {
 			return Constants.IS_PNG;
 		}
 
+		if (currentFileNameOra != null && currentFileNameOra.equals(filename)) {
+			return Constants.IS_ORA;
+		}
+
 		return Constants.IS_NO_FILE;
 	}
 
-	private static int calculateSampleSize(int width, int height, int maxWidth, int maxHeight) {
+	public static int calculateSampleSize(int width, int height, int maxWidth, int maxHeight) {
 		int sampleSize = 1;
 		while (width > maxWidth || height > maxHeight) {
 			width /= 2;
@@ -275,7 +282,7 @@ public final class FileIO {
 		return enableAlpha(BitmapFactory.decodeFile(bitmapFile.getAbsolutePath(), options));
 	}
 
-	private static Bitmap enableAlpha(Bitmap bitmap) {
+	public static Bitmap enableAlpha(Bitmap bitmap) {
 		if (bitmap != null) {
 			bitmap.setHasAlpha(true);
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.java
@@ -30,11 +30,15 @@ import org.catrobat.paintroid.command.implementation.FlipCommand.FlipDirection;
 import org.catrobat.paintroid.command.implementation.RotateCommand.RotateDirection;
 import org.catrobat.paintroid.tools.drawable.ShapeDrawable;
 
+import java.util.List;
+
 public interface CommandFactory {
 
 	Command createInitCommand(int width, int height);
 
 	Command createInitCommand(Bitmap bitmap);
+
+	Command createInitCommand(List<Bitmap> bitmapList);
 
 	Command createResetCommand();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.java
@@ -35,6 +35,8 @@ import org.catrobat.paintroid.tools.drawable.ShapeDrawable;
 import org.catrobat.paintroid.tools.helper.Conversion;
 import org.catrobat.paintroid.tools.helper.JavaFillAlgorithmFactory;
 
+import java.util.List;
+
 import static android.graphics.Bitmap.Config.ARGB_8888;
 
 public class DefaultCommandFactory implements CommandFactory {
@@ -54,6 +56,14 @@ public class DefaultCommandFactory implements CommandFactory {
 		CompositeCommand command = new CompositeCommand();
 		command.addCommand(new SetDimensionCommand(bitmap.getWidth(), bitmap.getHeight()));
 		command.addCommand(new LoadCommand(bitmap.copy(ARGB_8888, false)));
+		return command;
+	}
+
+	@Override
+	public Command createInitCommand(List<Bitmap> bitmapList) {
+		CompositeCommand command = new CompositeCommand();
+		command.addCommand(new SetDimensionCommand(bitmapList.get(0).getWidth(), bitmapList.get(0).getHeight()));
+		command.addCommand(new LoadBitmapListCommand(bitmapList));
 		return command;
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadBitmapListCommand.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadBitmapListCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.command.implementation;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+
+import org.catrobat.paintroid.command.Command;
+import org.catrobat.paintroid.contract.LayerContracts;
+import org.catrobat.paintroid.model.Layer;
+
+import java.util.List;
+
+import static android.graphics.Bitmap.Config.ARGB_8888;
+
+public class LoadBitmapListCommand implements Command {
+	private List<Bitmap> loadedImageList;
+
+	public LoadBitmapListCommand(List<Bitmap> newBitmapList) {
+		loadedImageList = newBitmapList;
+	}
+
+	@Override
+	public void run(Canvas canvas, LayerContracts.Model layerModel) {
+
+		int counter = 0;
+		for (Bitmap current : loadedImageList) {
+			Layer currentLayer = new Layer(current.copy(ARGB_8888, true));
+			layerModel.addLayerAt(counter, currentLayer);
+
+			counter++;
+		}
+
+		layerModel.setCurrentLayer(layerModel.getLayerAt(0));
+	}
+
+	@Override
+	public void freeResources() {
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
@@ -43,6 +43,7 @@ public final class Constants {
 	public static final String OVERWRITE_INFORMATION_DIALOG_TAG = "saveinformationdialogfragment";
 	public static final String PNG_INFORMATION_DIALOG_TAG = "pnginformationdialogfragment";
 	public static final String JPG_INFORMATION_DIALOG_TAG = "jpginformationdialogfragment";
+	public static final String ORA_INFORMATION_DIALOG_TAG = "orainformationdialogfragment";
 	public static final String CATROID_MEDIA_GALLERY_FRAGMENT_TAG = "catroidmediagalleryfragment";
 
 	public static final String PERMISSION_DIALOG_FRAGMENT_TAG = "permissiondialogfragment";
@@ -54,7 +55,10 @@ public final class Constants {
 
 	public static final int IS_JPG = 0;
 	public static final int IS_PNG = 1;
+	public static final int IS_ORA = 2;
 	public static final int IS_NO_FILE = -1;
+
+	public static final int MAX_LAYERS = 4;
 
 	private Constants() {
 		throw new AssertionError();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -32,6 +32,7 @@ import org.catrobat.paintroid.iotasks.CreateFileAsync;
 import org.catrobat.paintroid.iotasks.LoadImageAsync;
 import org.catrobat.paintroid.iotasks.SaveImageAsync;
 import org.catrobat.paintroid.tools.ToolType;
+import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.ui.LayerAdapter;
 
 import java.io.File;
@@ -62,6 +63,8 @@ public interface MainActivityContracts {
 		void showPngInformationDialog();
 
 		void showJpgInformationDialog();
+
+		void showOraInformationDialog();
 
 		void sendFeedback();
 
@@ -190,6 +193,8 @@ public interface MainActivityContracts {
 
 		void showJpgInformationDialog();
 
+		void showOraInformationDialog();
+
 		void sendFeedback();
 
 		void onNewImage();
@@ -203,6 +208,8 @@ public interface MainActivityContracts {
 		void onBackPressed();
 
 		void saveImageConfirmClicked(int requestCode, Uri uri);
+
+		void saveCopyConfirmClicked(int requestCode);
 
 		void undoClicked();
 
@@ -276,11 +283,11 @@ public interface MainActivityContracts {
 	}
 
 	interface Interactor {
-		void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Bitmap bitmap);
+		void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace);
 
 		void createFile(CreateFileAsync.CreateFileCallback callback, int requestCode, @Nullable String filename);
 
-		void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Bitmap bitmap, Uri uri);
+		void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, Uri uri);
 
 		void loadFile(LoadImageAsync.LoadImageCallback callback, int requestCode, Uri uri);
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/OraInfoDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/OraInfoDialog.java
@@ -1,0 +1,53 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.dialog;
+
+import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+
+import org.catrobat.paintroid.R;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatDialogFragment;
+
+public class OraInfoDialog extends AppCompatDialogFragment {
+	public static OraInfoDialog newInstance() {
+		return new OraInfoDialog();
+	}
+
+	@NonNull
+	@Override
+	@SuppressLint("InflateParams")
+	public Dialog onCreateDialog(Bundle savedInstanceState) {
+		return new AlertDialog.Builder(getContext(), R.style.PocketPaintAlertDialog)
+				.setMessage(R.string.pocketpaint_ora_message_dialog)
+				.setTitle(R.string.pocketpaint_ora_title_dialog)
+				.setPositiveButton(R.string.pocketpaint_ok, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						dismiss();
+					}
+				})
+				.create();
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.java
@@ -63,6 +63,7 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 
 	public static SaveInformationDialog newInstance(int permissionCode, int imageNumber, boolean isStandard) {
 		if (isStandard) {
+			FileIO.isCatrobatImage = false;
 			FileIO.filename = "image";
 			FileIO.compressFormat = Bitmap.CompressFormat.JPEG;
 			FileIO.ending = ".jpg";
@@ -99,7 +100,9 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 		initializeViews(view);
 		initializeFunctioning();
 
-		if (FileIO.compressFormat == Bitmap.CompressFormat.PNG) {
+		if (FileIO.isCatrobatImage) {
+			mySpinner.setSelection(2);
+		} else if (FileIO.compressFormat == Bitmap.CompressFormat.PNG) {
 			mySpinner.setSelection(1);
 		} else {
 			mySpinner.setSelection(0);
@@ -158,6 +161,7 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 		List<String> spinnerArray = new ArrayList<>();
 		spinnerArray.add("jpg");
 		spinnerArray.add("png");
+		spinnerArray.add("ora");
 
 		ArrayAdapter<String> adapter = new ArrayAdapter<>(mySpinner.getContext(),
 				android.R.layout.simple_spinner_item, spinnerArray);
@@ -175,7 +179,9 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 		informationButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				if (FileIO.compressFormat == Bitmap.CompressFormat.JPEG) {
+				if (FileIO.isCatrobatImage) {
+					getPresenter().showOraInformationDialog();
+				} else if (FileIO.compressFormat == Bitmap.CompressFormat.JPEG) {
 					getPresenter().showJpgInformationDialog();
 				} else {
 					getPresenter().showPngInformationDialog();
@@ -193,12 +199,20 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 				specificFormatLayout.removeAllViews();
 				specificFormatLayout.addView(jpgView);
 				FileIO.compressFormat = Bitmap.CompressFormat.JPEG;
+				FileIO.isCatrobatImage = false;
 				FileIO.ending = ".jpg";
 				break;
 			case "png":
 				specificFormatLayout.removeAllViews();
 				FileIO.compressFormat = Bitmap.CompressFormat.PNG;
+				FileIO.isCatrobatImage = false;
 				FileIO.ending = ".png";
+				break;
+			case "ora":
+				specificFormatLayout.removeAllViews();
+				FileIO.compressFormat = Bitmap.CompressFormat.PNG;
+				FileIO.isCatrobatImage = true;
+				FileIO.ending = ".ora";
 				break;
 		}
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/BitmapReturnValue.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/BitmapReturnValue.java
@@ -1,0 +1,33 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.iotasks;
+
+import android.graphics.Bitmap;
+
+import java.util.List;
+
+public class BitmapReturnValue {
+	public List<Bitmap> bitmapList;
+	public Bitmap bitmap;
+
+	public BitmapReturnValue(List<Bitmap> list, Bitmap singleBitmap) {
+		bitmapList = list;
+		bitmap = singleBitmap;
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/OpenRasterFileFormatConversion.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/OpenRasterFileFormatConversion.java
@@ -111,7 +111,7 @@ public final class OpenRasterFileFormatConversion {
 			//applefile has no file ending. which is important for api level 30.
 			// we can't save an application file in media directory so we have to save it in downloads.
 			contentValues.put(MediaStore.Files.FileColumns.DISPLAY_NAME, fileName);
-			contentValues.put(MediaStore.Files.FileColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/Pocket_Paint");
+			contentValues.put(MediaStore.Files.FileColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS);
 			contentValues.put(MediaStore.Files.FileColumns.MIME_TYPE, "application/applefile");
 
 			imageUri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/OpenRasterFileFormatConversion.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/OpenRasterFileFormatConversion.java
@@ -1,0 +1,276 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.iotasks;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.util.Log;
+
+import org.catrobat.paintroid.FileIO;
+import org.catrobat.paintroid.common.Constants;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+//
+//Source:	https://www.openraster.org/baseline/file-layout-spec.html
+//
+//Layout:
+//example.ora  [considered as a folder-like object]
+//        ├ mimetype
+//        ├ stack.xml
+//        ├ data/
+//        │  ├ [image data files referenced by stack.xml, typically layer*.png]
+//        │  └ [other data files, indexed elsewhere]
+//        ├ Thumbnails/
+//        │  └ thumbnail.png
+//        └ mergedimage.png
+public final class OpenRasterFileFormatConversion {
+	private static final String TAG = OpenRasterFileFormatConversion.class.getSimpleName();
+	private static final int COMPRESS_QUALITY = 100;
+	private static final int THUMBNAIL_WIDTH = 256;
+	private static final int THUMBNAIL_HEIGHT = 256;
+
+	private OpenRasterFileFormatConversion() {
+		throw new AssertionError();
+	}
+
+	public static Uri exportToOraFile(List<Bitmap> bitmapList, String fileName, Bitmap bitmapAllLayers, ContentResolver resolver) throws IOException {
+		Uri imageUri;
+		OutputStream outputStream;
+		ContentValues contentValues = new ContentValues();
+		float wholeSize = 0;
+
+		String mimeType = "image/openraster";
+		byte[] mimeByteArray = mimeType.getBytes();
+		byte[] xmlByteArray = getXmlStack(bitmapList);
+
+		for (Bitmap current: bitmapList) {
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			current.compress(Bitmap.CompressFormat.PNG, COMPRESS_QUALITY, bos);
+			byte[] byteArray = bos.toByteArray();
+			wholeSize += byteArray.length;
+		}
+
+		ByteArrayOutputStream bosMerged = new ByteArrayOutputStream();
+		bitmapAllLayers.compress(Bitmap.CompressFormat.PNG, COMPRESS_QUALITY, bosMerged);
+		byte[] bitmapByteArray = bosMerged.toByteArray();
+
+		Bitmap bitmapThumb = Bitmap.createScaledBitmap(bitmapAllLayers, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, false);
+		ByteArrayOutputStream bosThumb = new ByteArrayOutputStream();
+		bitmapThumb.compress(Bitmap.CompressFormat.PNG, COMPRESS_QUALITY, bosThumb);
+		byte[] bitmapThumbArray = bosThumb.toByteArray();
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+
+			//applefile has no file ending. which is important for api level 30.
+			// we can't save an application file in media directory so we have to save it in downloads.
+			contentValues.put(MediaStore.Files.FileColumns.DISPLAY_NAME, fileName);
+			contentValues.put(MediaStore.Files.FileColumns.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/Pocket_Paint");
+			contentValues.put(MediaStore.Files.FileColumns.MIME_TYPE, "application/applefile");
+
+			imageUri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues);
+			outputStream = resolver.openOutputStream(Objects.requireNonNull(imageUri));
+		} else {
+			contentValues.put(MediaStore.Images.Media.DISPLAY_NAME, fileName);
+			contentValues.put(MediaStore.Images.Media.MIME_TYPE, "application/zip");
+			contentValues.put(MediaStore.Files.FileColumns.MEDIA_TYPE, MediaStore.Files.FileColumns.MEDIA_TYPE_NONE);
+
+			long date = System.currentTimeMillis();
+			contentValues.put(MediaStore.MediaColumns.DATE_MODIFIED, date / 1000);
+
+			wholeSize += xmlByteArray.length;
+			wholeSize += mimeByteArray.length;
+			wholeSize += bitmapByteArray.length;
+			wholeSize += bitmapThumbArray.length;
+			contentValues.put(MediaStore.Images.Media.SIZE, wholeSize);
+			imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues);
+			outputStream = resolver.openOutputStream(Objects.requireNonNull(imageUri));
+		}
+
+		ZipOutputStream streamZip = new ZipOutputStream(outputStream);
+		ZipEntry mimetypeEntry = new ZipEntry("mimetype");
+		mimetypeEntry.setMethod(ZipEntry.DEFLATED);
+
+		streamZip.putNextEntry(mimetypeEntry);
+		streamZip.write(mimeByteArray, 0, mimeByteArray.length);
+		streamZip.closeEntry();
+
+		streamZip.putNextEntry(new ZipEntry("stack.xml"));
+		streamZip.write(xmlByteArray, 0, Objects.requireNonNull(xmlByteArray).length);
+		streamZip.closeEntry();
+
+		int counter = 0;
+		for (Bitmap current: bitmapList) {
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			current.compress(Bitmap.CompressFormat.PNG, COMPRESS_QUALITY, bos);
+			byte[] byteArray = bos.toByteArray();
+
+			streamZip.putNextEntry(new ZipEntry("data/layer" + counter + ".png"));
+			streamZip.write(byteArray, 0, byteArray.length);
+			streamZip.closeEntry();
+			counter++;
+		}
+
+		streamZip.putNextEntry(new ZipEntry("Thumbnails/thumbnail.png"));
+		streamZip.write(bitmapThumbArray, 0, bitmapThumbArray.length);
+		streamZip.closeEntry();
+
+		streamZip.putNextEntry(new ZipEntry("mergedimage.png"));
+		streamZip.write(bitmapByteArray, 0, bitmapByteArray.length);
+		streamZip.closeEntry();
+		streamZip.close();
+		outputStream.close();
+
+		return imageUri;
+	}
+
+	private static byte[] getXmlStack(List<Bitmap> bitmapList) {
+
+		DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+		try {
+			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+
+			Document doc = docBuilder.newDocument();
+			Element rootElement = doc.createElement("image");
+			Attr attr1 = doc.createAttribute("version");
+			Attr attr2 = doc.createAttribute("w");
+			Attr attr3 = doc.createAttribute("h");
+
+			attr1.setValue("0.0.1");
+			attr2.setValue(String.valueOf(bitmapList.get(0).getWidth()));
+			attr3.setValue(String.valueOf(bitmapList.get(0).getHeight()));
+
+			rootElement.setAttributeNode(attr1);
+			rootElement.setAttributeNode(attr2);
+			rootElement.setAttributeNode(attr3);
+			doc.appendChild(rootElement);
+
+			Element stack = doc.createElement("stack");
+			rootElement.appendChild(stack);
+
+			for (int i = bitmapList.size() - 1; i >= 0; i--) {
+				Element layer = doc.createElement("layer");
+
+				layer.setAttribute("name", "layer" + i);
+				layer.setAttribute("src", "data/layer" + i + ".png");
+				stack.appendChild(layer);
+			}
+
+			ByteArrayOutputStream stream = new ByteArrayOutputStream();
+			StreamResult result = new StreamResult(stream);
+
+			TransformerFactory transformerFactory = TransformerFactory.newInstance();
+			Transformer transformer = transformerFactory.newTransformer();
+			DOMSource source = new DOMSource(doc);
+
+			transformer.transform(source, result);
+
+			return stream.toByteArray();
+		} catch (ParserConfigurationException e) {
+			Log.e(TAG, "Could not create document.");
+			return null;
+		} catch (TransformerException e) {
+			Log.e(TAG, "Could not transform Xml file.");
+			return null;
+		}
+	}
+
+	public static Uri saveOraFileToUri(List<Bitmap> bitmapList, Uri uri, String fileName, Bitmap bitmapAllLayers, ContentResolver resolver) throws IOException {
+		String[] projection = {MediaStore.Images.Media._ID};
+
+		Cursor c = resolver.query(uri, projection, null, null, null);
+		if (c.moveToFirst()) {
+			long id = c.getLong(c.getColumnIndexOrThrow(MediaStore.Images.Media._ID));
+
+			Uri deleteUri;
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+				deleteUri = ContentUris.withAppendedId(MediaStore.Downloads.EXTERNAL_CONTENT_URI, id);
+			} else {
+				deleteUri = ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id);
+			}
+
+			resolver.delete(deleteUri, null, null);
+		} else {
+			throw new AssertionError("No file to delete was found!");
+		}
+		c.close();
+
+		return exportToOraFile(bitmapList, fileName, bitmapAllLayers, resolver);
+	}
+
+	public static List<Bitmap> importOraFile(ContentResolver resolver, Uri uri, int maxWidth, int maxHeight, boolean scaled) throws IOException {
+		BitmapFactory.Options options = new BitmapFactory.Options();
+		InputStream inputStream = resolver.openInputStream(uri);
+		ZipInputStream zipInput = new ZipInputStream(inputStream);
+
+		options.inMutable = true;
+		options.inJustDecodeBounds = false;
+		if (scaled) {
+			options.inSampleSize = FileIO.calculateSampleSize(options.outWidth, options.outHeight,
+					maxWidth, maxHeight);
+		}
+
+		ZipEntry current = zipInput.getNextEntry();
+		List<Bitmap> bitmapList = new ArrayList<>();
+		while (current != null) {
+			if (current.getName().matches("data/(.*).png")) {
+
+				Bitmap layerBitmap = FileIO.enableAlpha(BitmapFactory.decodeStream(zipInput, null, options));
+				bitmapList.add(layerBitmap);
+			}
+			current = zipInput.getNextEntry();
+		}
+
+		if (bitmapList.isEmpty() || bitmapList.size() > Constants.MAX_LAYERS) {
+			throw new IOException("Bitmap list is wrong!");
+		}
+
+		return bitmapList;
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.java
@@ -132,4 +132,14 @@ public class LayerModel implements LayerContracts.Model {
 
 		return bitmap;
 	}
+
+	public static List<Bitmap> getBitmapListOfAllLayers(List<LayerContracts.Layer> layers) {
+		List<Bitmap> bitmapList = new ArrayList<>();
+
+		for (LayerContracts.Layer layer : layers) {
+			bitmapList.add(layer.getBitmap());
+		}
+
+		return bitmapList;
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.java
@@ -27,6 +27,7 @@ import android.widget.Toast;
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.command.CommandFactory;
 import org.catrobat.paintroid.command.CommandManager;
+import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.contract.LayerContracts;
 import org.catrobat.paintroid.contract.LayerContracts.LayerViewHolder;
 import org.catrobat.paintroid.contract.LayerContracts.Model;
@@ -42,7 +43,6 @@ import java.util.List;
 
 public class LayerPresenter implements LayerContracts.Presenter, DragAndDropPresenter {
 	private static final String TAG = LayerPresenter.class.getSimpleName();
-	private static final int MAX_LAYERS = 4;
 	private final CommandManager commandManager;
 	private final CommandFactory commandFactory;
 	private final Model model;
@@ -110,7 +110,7 @@ public class LayerPresenter implements LayerContracts.Presenter, DragAndDropPres
 
 	@Override
 	public void refreshLayerMenuViewHolder() {
-		if (getLayerCount() < MAX_LAYERS) {
+		if (getLayerCount() < Constants.MAX_LAYERS) {
 			layerMenuViewHolder.enableAddLayerButton();
 		} else {
 			layerMenuViewHolder.disableAddLayerButton();
@@ -140,7 +140,7 @@ public class LayerPresenter implements LayerContracts.Presenter, DragAndDropPres
 
 	@Override
 	public void addLayer() {
-		if (getLayerCount() < MAX_LAYERS) {
+		if (getLayerCount() < Constants.MAX_LAYERS) {
 			commandManager.addCommand(commandFactory.createAddLayerCommand());
 		} else {
 			navigator.showToast(R.string.layer_too_many_layers, Toast.LENGTH_SHORT);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -55,6 +55,7 @@ import org.catrobat.paintroid.contract.MainActivityContracts.Presenter;
 import org.catrobat.paintroid.contract.MainActivityContracts.TopBarViewHolder;
 import org.catrobat.paintroid.controller.ToolController;
 import org.catrobat.paintroid.dialog.PermissionInfoDialog;
+import org.catrobat.paintroid.iotasks.BitmapReturnValue;
 import org.catrobat.paintroid.iotasks.CreateFileAsync.CreateFileCallback;
 import org.catrobat.paintroid.iotasks.LoadImageAsync.LoadImageCallback;
 import org.catrobat.paintroid.iotasks.SaveImageAsync.SaveImageCallback;
@@ -288,6 +289,11 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	}
 
 	@Override
+	public void showOraInformationDialog() {
+		navigator.showOraInformationDialog();
+	}
+
+	@Override
 	public void sendFeedback() {
 		navigator.sendFeedback();
 	}
@@ -325,8 +331,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 					showLikeUsDialogIfFirstTimeSave();
 					break;
 				case PERMISSION_EXTERNAL_STORAGE_SAVE_COPY:
-					Bitmap bitmap = workspace.getBitmapOfAllLayers();
-					interactor.saveCopy(this, SAVE_IMAGE_DEFAULT, bitmap);
+					saveCopyConfirmClicked(SAVE_IMAGE_DEFAULT);
 					checkforDefaultFilename();
 					break;
 				case PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW:
@@ -430,17 +435,14 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		if (permissions.length == 1 && (permissions[0].equals(Manifest.permission.READ_EXTERNAL_STORAGE)
 				|| permissions[0].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE))) {
 			if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-				Bitmap bitmap;
 				switch (requestCode) {
 					case PERMISSION_EXTERNAL_STORAGE_SAVE:
-						bitmap = workspace.getBitmapOfAllLayers();
-						interactor.saveImage(this, SAVE_IMAGE_DEFAULT, bitmap, model.getSavedPictureUri());
+						saveImageConfirmClicked(SAVE_IMAGE_DEFAULT, model.getSavedPictureUri());
 						checkforDefaultFilename();
 						showLikeUsDialogIfFirstTimeSave();
 						break;
 					case PERMISSION_EXTERNAL_STORAGE_SAVE_COPY:
-						bitmap = workspace.getBitmapOfAllLayers();
-						interactor.saveCopy(this, SAVE_IMAGE_DEFAULT, bitmap);
+						saveCopyConfirmClicked(SAVE_IMAGE_DEFAULT);
 						checkforDefaultFilename();
 						break;
 					case PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH:
@@ -499,8 +501,12 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void saveImageConfirmClicked(int requestCode, Uri uri) {
-		Bitmap bitmap = workspace.getBitmapOfAllLayers();
-		interactor.saveImage(this, requestCode, bitmap, uri);
+		interactor.saveImage(this, requestCode, workspace, uri);
+	}
+
+	@Override
+	public void saveCopyConfirmClicked(int requestCode) {
+		interactor.saveCopy(this, requestCode, workspace);
 	}
 
 	@Override
@@ -693,7 +699,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	}
 
 	@Override
-	public void onLoadImagePostExecute(@LoadImageRequestCode int requestCode, Uri uri, Bitmap bitmap) {
+	public void onLoadImagePostExecute(@LoadImageRequestCode int requestCode, Uri uri, BitmapReturnValue bitmap) {
 		if (bitmap == null) {
 			navigator.showLoadErrorDialog();
 			return;
@@ -702,21 +708,25 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		switch (requestCode) {
 			case LOAD_IMAGE_DEFAULT:
 				resetPerspectiveAfterNextCommand = true;
-				commandManager.setInitialStateCommand(commandFactory.createInitCommand(bitmap));
+				if (bitmap.bitmap != null) {
+					commandManager.setInitialStateCommand(commandFactory.createInitCommand(bitmap.bitmap));
+				} else {
+					commandManager.setInitialStateCommand(commandFactory.createInitCommand(bitmap.bitmapList));
+				}
 				commandManager.reset();
 				model.setSavedPictureUri(null);
 				model.setCameraImageUri(null);
 				break;
 			case LOAD_IMAGE_IMPORTPNG:
 				if (toolController.getToolType() == ToolType.IMPORTPNG) {
-					toolController.setBitmapFromSource(bitmap);
+					toolController.setBitmapFromSource(bitmap.bitmap);
 				} else {
 					Log.e(MainActivity.TAG, "importPngToFloatingBox: Current tool is no ImportTool as required");
 				}
 				break;
 			case LOAD_IMAGE_CATROID:
 				resetPerspectiveAfterNextCommand = true;
-				commandManager.setInitialStateCommand(commandFactory.createInitCommand(bitmap));
+				commandManager.setInitialStateCommand(commandFactory.createInitCommand(bitmap.bitmap));
 				commandManager.reset();
 				model.setSavedPictureUri(uri);
 				model.setCameraImageUri(null);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.java
@@ -25,6 +25,8 @@ import android.graphics.RectF;
 
 import org.catrobat.paintroid.ui.Perspective;
 
+import java.util.List;
+
 public interface Workspace {
 	boolean contains(PointF point);
 
@@ -39,6 +41,8 @@ public interface Workspace {
 	int getSurfaceHeight();
 
 	Bitmap getBitmapOfAllLayers();
+
+	List<Bitmap> getBitmapLisOfAllLayers();
 
 	Bitmap getBitmapOfCurrentLayer();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.java
@@ -29,6 +29,8 @@ import org.catrobat.paintroid.model.LayerModel;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.ui.Perspective;
 
+import java.util.List;
+
 public class DefaultWorkspace implements Workspace {
 
 	private final LayerContracts.Model layerModel;
@@ -81,6 +83,11 @@ public class DefaultWorkspace implements Workspace {
 	@Override
 	public Bitmap getBitmapOfAllLayers() {
 		return LayerModel.getBitmapOfAllLayersToSave(layerModel.getLayers());
+	}
+
+	@Override
+	public List<Bitmap> getBitmapLisOfAllLayers() {
+		return LayerModel.getBitmapListOfAllLayers(layerModel.getLayers());
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
@@ -19,19 +19,19 @@
 
 package org.catrobat.paintroid.ui;
 
-import android.graphics.Bitmap;
 import android.net.Uri;
 
 import org.catrobat.paintroid.contract.MainActivityContracts;
 import org.catrobat.paintroid.iotasks.CreateFileAsync;
 import org.catrobat.paintroid.iotasks.LoadImageAsync;
 import org.catrobat.paintroid.iotasks.SaveImageAsync;
+import org.catrobat.paintroid.tools.Workspace;
 
 public class MainActivityInteractor implements MainActivityContracts.Interactor {
 
 	@Override
-	public void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Bitmap bitmap) {
-		new SaveImageAsync(callback, requestCode, bitmap, null, true).execute();
+	public void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace) {
+		new SaveImageAsync(callback, requestCode, workspace, null, true).execute();
 	}
 
 	@Override
@@ -40,8 +40,8 @@ public class MainActivityInteractor implements MainActivityContracts.Interactor 
 	}
 
 	@Override
-	public void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Bitmap bitmap, Uri uri) {
-		new SaveImageAsync(callback, requestCode, bitmap, uri, false).execute();
+	public void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, Uri uri) {
+		new SaveImageAsync(callback, requestCode, workspace, uri, false).execute();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -46,6 +46,7 @@ import org.catrobat.paintroid.dialog.IndeterminateProgressDialog;
 import org.catrobat.paintroid.dialog.InfoDialog;
 import org.catrobat.paintroid.dialog.JpgInfoDialog;
 import org.catrobat.paintroid.dialog.LikeUsDialog;
+import org.catrobat.paintroid.dialog.OraInfoDialog;
 import org.catrobat.paintroid.dialog.OverwriteDialog;
 import org.catrobat.paintroid.dialog.PermanentDenialPermissionInfoDialog;
 import org.catrobat.paintroid.dialog.PermissionInfoDialog;
@@ -182,7 +183,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	@Override
 	public void startLoadImageActivity(@ActivityRequestCode int requestCode) {
 		Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-		intent.setType("image/*");
+		intent.setType("*/*");
 		intent.setFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
 		mainActivity.startActivityForResult(intent, requestCode);
 	}
@@ -256,6 +257,12 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	public void showJpgInformationDialog() {
 		JpgInfoDialog jpgInfoDialog = JpgInfoDialog.newInstance();
 		jpgInfoDialog.show(mainActivity.getSupportFragmentManager(), Constants.JPG_INFORMATION_DIALOG_TAG);
+	}
+
+	@Override
+	public void showOraInformationDialog() {
+		OraInfoDialog oraInfoDialog = OraInfoDialog.newInstance();
+		oraInfoDialog.show(mainActivity.getSupportFragmentManager(), Constants.ORA_INFORMATION_DIALOG_TAG);
 	}
 
 	@Override
@@ -389,6 +396,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 			FileIO.compressFormat = Bitmap.CompressFormat.PNG;
 			FileIO.ending = ".png";
 			FileIO.catroidFlag = true;
+			FileIO.isCatrobatImage = false;
 			mainActivity.getPresenter().switchBetweenVersions(permissionCode);
 			return;
 		}

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -159,6 +159,9 @@
     <string name="pocketpaint_jpg_message_dialog">Takes up <b>minimal storage space</b>. <b>No transparency</b> is remembered.</string>
     <string name="pocketpaint_png_title_dialog" translatable="false">png</string>
     <string name="pocketpaint_png_message_dialog">Lossless compression. Transparency is preserved.</string>
+    <string name="pocketpaint_ora_title_dialog" translatable="false">Ora</string>
+    <string name="pocketpaint_ora_message_dialog">Need a break and want to <b>continue later?</b> This format remembers all your <b>layers</b>. <b>Keep in mind that it can only be opened by apps that support Openraster.</b></string>
+
 
     <string name="permission_info_external_storage_text">This app needs the requested permission to function properly. In order to save images to the local memory, the app needs read and write access to it.</string>
     <string name="permission_info_permanent_denial_text">This app needs the requested permission to function properly. In order to save images to the local memory, the app needs read and write access to it.

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -160,7 +160,7 @@
     <string name="pocketpaint_png_title_dialog" translatable="false">png</string>
     <string name="pocketpaint_png_message_dialog">Lossless compression. Transparency is preserved.</string>
     <string name="pocketpaint_ora_title_dialog" translatable="false">Ora</string>
-    <string name="pocketpaint_ora_message_dialog">Need a break and want to <b>continue later?</b> This format remembers all your <b>layers</b>. <b>Keep in mind that it can only be opened by apps that support Openraster.</b></string>
+    <string name="pocketpaint_ora_message_dialog">This format remembers <b>layers</b>. <b>It can be opened by apps that support the Openraster format.</b></string>
 
 
     <string name="permission_info_external_storage_text">This app needs the requested permission to function properly. In order to save images to the local memory, the app needs read and write access to it.</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -39,6 +39,7 @@ import org.catrobat.paintroid.command.CommandManager;
 import org.catrobat.paintroid.contract.MainActivityContracts;
 import org.catrobat.paintroid.controller.ToolController;
 import org.catrobat.paintroid.dialog.PermissionInfoDialog;
+import org.catrobat.paintroid.iotasks.BitmapReturnValue;
 import org.catrobat.paintroid.iotasks.SaveImageAsync;
 import org.catrobat.paintroid.presenter.MainActivityPresenter;
 import org.catrobat.paintroid.tools.ToolType;
@@ -255,7 +256,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, bitmap);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace);
 		verifyNoMoreInteractions(interactor);
 	}
 
@@ -268,7 +269,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, workspace, uri);
 
 		verifyNoMoreInteractions(interactor);
 	}
@@ -470,7 +471,7 @@ public class MainActivityPresenterTest {
 
 		presenter.saveImageConfirmClicked(0, uri);
 
-		verify(interactor).saveImage(presenter, 0, bitmap, uri);
+		verify(interactor).saveImage(presenter, 0, workspace, uri);
 	}
 
 	@Test
@@ -479,7 +480,21 @@ public class MainActivityPresenterTest {
 
 		presenter.saveImageConfirmClicked(-1, uri);
 
-		verify(interactor).saveImage(presenter, -1, bitmap, uri);
+		verify(interactor).saveImage(presenter, -1, workspace, uri);
+	}
+
+	@Test
+	public void testSaveCopyConfirmCLickedThenSaveImage() {
+		presenter.saveCopyConfirmClicked(0);
+
+		verify(interactor).saveCopy(presenter, 0, workspace);
+	}
+
+	@Test
+	public void testSaveCopyConfirmClickedThenUseRequestCode() {
+		presenter.saveCopyConfirmClicked(-1);
+
+		verify(interactor).saveCopy(presenter, -1, workspace);
 	}
 
 	@Test
@@ -814,8 +829,9 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenDefaultThenResetModelUris() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
 
-		presenter.onLoadImagePostExecute(LOAD_IMAGE_DEFAULT, uri, bitmap);
+		presenter.onLoadImagePostExecute(LOAD_IMAGE_DEFAULT, uri, returnValue);
 
 		verify(model).setSavedPictureUri(null);
 		verify(model).setCameraImageUri(null);
@@ -825,10 +841,11 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenDefaultThenResetCommandManager() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
 		Command command = mock(Command.class);
 		when(commandFactory.createInitCommand(bitmap)).thenReturn(command);
 
-		presenter.onLoadImagePostExecute(LOAD_IMAGE_DEFAULT, uri, bitmap);
+		presenter.onLoadImagePostExecute(LOAD_IMAGE_DEFAULT, uri, returnValue);
 
 		verify(commandManager).setInitialStateCommand(command);
 		verify(commandManager).reset();
@@ -839,9 +856,10 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenImportThenSetBitmap() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
 		when(toolController.getToolType()).thenReturn(ToolType.IMPORTPNG);
 
-		presenter.onLoadImagePostExecute(LOAD_IMAGE_IMPORTPNG, uri, bitmap);
+		presenter.onLoadImagePostExecute(LOAD_IMAGE_IMPORTPNG, uri, returnValue);
 
 		verify(toolController).setBitmapFromSource(bitmap);
 		verifyZeroInteractions(commandManager);
@@ -851,8 +869,9 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenImportAndNotImportToolSetThenIgnore() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
 
-		presenter.onLoadImagePostExecute(LOAD_IMAGE_IMPORTPNG, uri, bitmap);
+		presenter.onLoadImagePostExecute(LOAD_IMAGE_IMPORTPNG, uri, returnValue);
 
 		verify(toolController, never()).setBitmapFromSource(any(Bitmap.class));
 		verifyZeroInteractions(commandManager);
@@ -862,8 +881,9 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenCatroidThenSetModelUris() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
 
-		presenter.onLoadImagePostExecute(LOAD_IMAGE_CATROID, uri, bitmap);
+		presenter.onLoadImagePostExecute(LOAD_IMAGE_CATROID, uri, returnValue);
 
 		verify(model).setSavedPictureUri(uri);
 		verify(model).setCameraImageUri(null);
@@ -874,10 +894,11 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenCatroidThenResetCommandManager() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
 		Command command = mock(Command.class);
 		when(commandFactory.createInitCommand(bitmap)).thenReturn(command);
 
-		presenter.onLoadImagePostExecute(LOAD_IMAGE_CATROID, uri, bitmap);
+		presenter.onLoadImagePostExecute(LOAD_IMAGE_CATROID, uri, returnValue);
 
 		verify(commandManager).setInitialStateCommand(command);
 		verify(commandManager).reset();
@@ -888,8 +909,9 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenInvalidRequestThenThrowException() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
 
-		presenter.onLoadImagePostExecute(0, uri, bitmap);
+		presenter.onLoadImagePostExecute(0, uri, returnValue);
 	}
 
 	@Test
@@ -945,7 +967,7 @@ public class MainActivityPresenterTest {
 
 		Uri uri = model.getSavedPictureUri();
 
-		verify(interactor).saveImage(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(bitmap), eq(uri));
+		verify(interactor).saveImage(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace), eq(uri));
 	}
 
 	@Test
@@ -976,7 +998,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveCopy(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(bitmap));
+		verify(interactor).saveCopy(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace));
 	}
 
 	@Test
@@ -1012,7 +1034,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, workspace, uri);
 	}
 
 	@Test
@@ -1072,7 +1094,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, workspace, uri);
 	}
 
 	@Test
@@ -1108,7 +1130,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, workspace, uri);
 	}
 
 	@Test
@@ -1150,7 +1172,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, bitmap);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace);
 	}
 
 	@Test
@@ -1175,7 +1197,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH);
-		verify(interactor).saveImage(any(MainActivityPresenter.class), anyInt(), any(Bitmap.class), eq((Uri) null));
+		verify(interactor).saveImage(any(MainActivityPresenter.class), anyInt(), any(Workspace.class), eq((Uri) null));
 	}
 
 	@Test
@@ -1200,7 +1222,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, workspace, uri);
 	}
 
 	@Test
@@ -1224,7 +1246,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, workspace, uri);
 	}
 
 	@Test
@@ -1248,7 +1270,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, workspace, uri);
 	}
 
 	@Test
@@ -1272,7 +1294,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, bitmap, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, workspace, uri);
 	}
 
 	@Test


### PR DESCRIPTION
Saving files as Openraster file format and also being able to load them.
Implemented it into the Save dialog. (https://www.openraster.org/baseline/file-layout-spec.html)
Also added new test class for OraFile testing.

Behaviour: When saving a file you have a new option in the spinner menu called "ora".
It saves layers. And on load opens the layers again. Can also load other ora files created by other application like mypaint.

Apis:
If the api < 29 the picture will be saved in the "normal" image folder. 
otherwise it will be saved into the downloads folder in a subdirectory called "Pocket_Paint" since it 
is not really possible to store it in the image folder. (this was already discussed)


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
