### PR TITLE
PAINTROID-188 - Obtrusive flicker/blinking whenever stroke or drawing action is performed on Android 10 & 11

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -470,11 +470,6 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 	}
 
 	@Override
-	public void commandPreExecute() {
-		presenter.onCommandPreExecute();
-	}
-
-	@Override
 	public void commandPostExecute() {
 		if (!isFinishing()) {
 			layerPresenter.invalidate();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.java
@@ -44,8 +44,6 @@ public interface CommandManager {
 	boolean isBusy();
 
 	interface CommandListener {
-		void commandPreExecute();
-
 		void commandPostExecute();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.java
@@ -98,7 +98,7 @@ public class AsyncCommandManager implements CommandManager {
 		new AsyncTask<Void, Void, Void>() {
 			@Override
 			protected void onPreExecute() {
-				notifyCommandPreExecute();
+				busy = true;
 			}
 
 			@Override
@@ -128,7 +128,7 @@ public class AsyncCommandManager implements CommandManager {
 
 			@Override
 			protected void onPreExecute() {
-				notifyCommandPreExecute();
+				busy = true;
 			}
 
 			@Override
@@ -175,11 +175,6 @@ public class AsyncCommandManager implements CommandManager {
 
 	private void notifyCommandPreExecute() {
 		busy = true;
-		if (!shuttingDown) {
-			for (CommandListener listener : commandListeners) {
-				listener.commandPreExecute();
-			}
-		}
 	}
 
 	private void notifyCommandPostExecute() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -198,8 +198,6 @@ public interface MainActivityContracts {
 
 		void showLayerMenuClicked();
 
-		void onCommandPreExecute();
-
 		void onCommandPostExecute();
 
 		void setBottomNavigationColor(int color);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -480,11 +480,6 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	}
 
 	@Override
-	public void onCommandPreExecute() {
-		navigator.showIndeterminateProgressDialog();
-	}
-
-	@Override
 	public void onCommandPostExecute() {
 		if (resetPerspectiveAfterNextCommand) {
 			resetPerspectiveAfterNextCommand = false;
@@ -495,8 +490,6 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		toolController.resetToolInternalState();
 		view.refreshDrawingSurface();
 		refreshTopBarButtons();
-
-		navigator.dismissIndeterminateProgressDialog();
 	}
 
 	@Override

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -539,13 +539,6 @@ public class MainActivityPresenterTest {
 	}
 
 	@Test
-	public void testOnCommandPreExecuteThenShowProgressDialog() {
-		presenter.onCommandPreExecute();
-
-		verify(navigator).showIndeterminateProgressDialog();
-	}
-
-	@Test
 	public void testOnCommandPostExecuteThenSetModelUnsaved() {
 		presenter.onCommandPostExecute();
 
@@ -572,13 +565,6 @@ public class MainActivityPresenterTest {
 
 		verify(topBarViewHolder).disableRedoButton();
 		verify(topBarViewHolder).disableUndoButton();
-	}
-
-	@Test
-	public void testOnCommandPostExecuteThenDismissDialog() {
-		presenter.onCommandPostExecute();
-
-		verify(navigator).dismissIndeterminateProgressDialog();
 	}
 
 	@Test


### PR DESCRIPTION
I detected the blinking on every device and API I tested, so implemented that the dialog will only show up for saving images/copies and for importing stickers from catroid gallery

https://jira.catrob.at/browse/PAINTROID-188

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
