### PR TITLE
Improved keyboard facility in Color Picker

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.java
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.java
@@ -47,6 +47,8 @@ public class ColorPickerView extends LinearLayoutCompat {
 	private int selectedColor = Color.BLACK;
 	private int initialColor;
 
+	private InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+
 	private OnColorChangedListener listener;
 
 	public ColorPickerView(Context context) {
@@ -149,16 +151,23 @@ public class ColorPickerView extends LinearLayoutCompat {
 		tabHost.setOnTabChangedListener(new TabHost.OnTabChangeListener() {
 			@Override
 			public void onTabChanged(String tabId) {
-				hideKeyboard();
+				if(tabHost.getCurrentTab() != 2){
+					hideKeyboard();
+				}else if(tabHost.getCurrentTab()==2){
+					showKeyboard();
+				}
 			}
 		});
 	}
 
 	private void hideKeyboard() {
-		InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 		if (inputMethodManager != null) {
 			inputMethodManager.hideSoftInputFromWindow(getRootView().getWindowToken(), 0);
 		}
+	}
+
+	private void showKeyboard(){
+		inputMethodManager.toggleSoftInputFromWindow(getRootView().getWindowToken(),InputMethodManager.SHOW_FORCED,0);
 	}
 
 	@Override

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/PresetSelectorView.java
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/PresetSelectorView.java
@@ -25,6 +25,7 @@ import android.graphics.Color;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.TableRow;
@@ -62,6 +63,7 @@ public class PresetSelectorView extends LinearLayout {
 			public void onClick(View v) {
 				selectedColor = ((ColorPickerPresetColorButton) v).getColor();
 				onColorChanged();
+				hideKeyboard();
 			}
 		};
 
@@ -112,5 +114,12 @@ public class PresetSelectorView extends LinearLayout {
 
 	interface OnColorChangedListener {
 		void colorChanged(int color);
+	}
+
+	private void hideKeyboard() {
+		InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+		if (inputMethodManager != null) {
+			inputMethodManager.hideSoftInputFromWindow(getRootView().getWindowToken(), 0);
+		}
 	}
 }


### PR DESCRIPTION
Improved keyboard facility  in Color Picker , So that user can use keyboard in RGB Selection and also hide Keyboard during Present Selection without pressing back key.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
