### PR TITLE
PAINTROID-201 fixed loading images when opened via catroid and added …

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeNewImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeNewImageTest.java
@@ -19,13 +19,22 @@
 
 package org.catrobat.paintroid.test.espresso.catroid;
 
+import android.app.Activity;
+import android.app.Instrumentation;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.net.Uri;
 
 import org.catrobat.paintroid.FileIO;
 import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.common.Constants;
+import org.catrobat.paintroid.test.espresso.util.BitmapLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
+import org.catrobat.paintroid.tools.ToolType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -34,6 +43,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Objects;
 
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
@@ -42,16 +55,25 @@ import androidx.test.rule.GrantPermissionRule;
 
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class OpenedFromPocketCodeNewImageTest {
 
 	private static final String IMAGE_NAME = "testFile";
+	private static final String IMAGE_TO_LOAD_NAME = "loadFile";
 
 	@Rule
 	public IntentsTestRule<MainActivity> launchActivityRule = new IntentsTestRule<>(MainActivity.class, false, false);
@@ -60,6 +82,8 @@ public class OpenedFromPocketCodeNewImageTest {
 	public static GrantPermissionRule grantPermissionRule = EspressoUtils.grantPermissionRulesVersionCheck();
 
 	private File imageFile = null;
+	private MainActivity activity;
+	private ArrayList<File> deletionFileList = null;
 
 	@Before
 	public void setUp() {
@@ -68,14 +92,21 @@ public class OpenedFromPocketCodeNewImageTest {
 		intent.putExtra(Constants.PAINTROID_PICTURE_NAME, IMAGE_NAME);
 
 		launchActivityRule.launchActivity(intent);
+		deletionFileList = new ArrayList<>();
+		activity = launchActivityRule.getActivity();
+		imageFile = getNewImageFile(IMAGE_NAME);
+		deletionFileList.add(imageFile);
 
-		imageFile = getImageFile(IMAGE_NAME);
+		onToolBarView()
+				.performSelectTool(ToolType.BRUSH);
 	}
 
 	@After
 	public void tearDown() {
-		if (imageFile.exists()) {
-			imageFile.delete();
+		for (File file : deletionFileList) {
+			if (file != null && file.exists()) {
+				assertTrue(file.delete());
+			}
 		}
 	}
 
@@ -85,19 +116,88 @@ public class OpenedFromPocketCodeNewImageTest {
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
 		Espresso.pressBackUnconditionally();
-
-		String path = launchActivityRule.getActivityResult().getResultData().getStringExtra(Constants.PAINTROID_PICTURE_PATH);
-		assertEquals(imageFile.getAbsolutePath(), path);
-
-		assertTrue(imageFile.exists());
-		assertThat(imageFile.length(), greaterThan(0L));
+		verifyImageFile();
 	}
 
-	private File getImageFile(String filename) {
+	@Test
+	public void testLoadWithoutChange() {
+		createImageIntent();
+
+		onTopBarView()
+				.performOpenMoreOptions();
+
+		onView(withText(R.string.menu_load_image)).perform(click());
+		onView(withText(R.string.dialog_warning_new_image)).check(doesNotExist());
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.WHITE, BitmapLocationProvider.MIDDLE);
+
+		Espresso.pressBackUnconditionally();
+		verifyImageFile();
+	}
+
+	@Test
+	public void testLoadWithChange() {
+		createImageIntent();
+
+		onTopBarView()
+				.performOpenMoreOptions();
+
+		onView(withText(R.string.menu_load_image)).perform(click());
+		onView(withText(R.string.dialog_warning_new_image)).check(doesNotExist());
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.WHITE, BitmapLocationProvider.MIDDLE);
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE);
+
+		Espresso.pressBackUnconditionally();
+		verifyImageFile();
+	}
+
+	private File getNewImageFile(String filename) {
 		try {
 			return FileIO.createNewEmptyPictureFile(filename, launchActivityRule.getActivity());
 		} catch (NullPointerException e) {
 			throw new AssertionError("Could not create temp file", e);
 		}
+	}
+
+	private void createImageIntent() {
+		Intent intent = new Intent();
+		intent.setData(createTestImageFile());
+		Instrumentation.ActivityResult resultOK = new Instrumentation.ActivityResult(Activity.RESULT_OK, intent);
+		intending(hasAction(Intent.ACTION_GET_CONTENT)).respondWith(resultOK);
+	}
+
+	private Uri createTestImageFile() {
+		Bitmap bitmap = Bitmap.createBitmap(400, 400, Bitmap.Config.ARGB_8888);
+		Canvas canvas = new Canvas(bitmap);
+		canvas.drawColor(Color.WHITE);
+		canvas.drawBitmap(bitmap, 0F, 0F, null);
+
+		File imageFile = new File(activity.getExternalFilesDir(null).getAbsolutePath(), IMAGE_TO_LOAD_NAME + ".jpg");
+		Uri imageUri = Uri.fromFile(imageFile);
+		try {
+			OutputStream fos = activity.getContentResolver().openOutputStream(Objects.requireNonNull(imageUri));
+			assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos));
+			assert fos != null;
+			fos.close();
+		} catch (IOException e) {
+			throw new AssertionError("Picture file could not be created.", e);
+		}
+
+		deletionFileList.add(imageFile);
+		return imageUri;
+	}
+
+	private void verifyImageFile() {
+		String path = launchActivityRule.getActivityResult().getResultData().getStringExtra(Constants.PAINTROID_PICTURE_PATH);
+		assertEquals(imageFile.getAbsolutePath(), path);
+
+		assertTrue(imageFile.exists());
+		assertThat(imageFile.length(), greaterThan(0L));
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeWithImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeWithImageTest.java
@@ -19,11 +19,19 @@
 
 package org.catrobat.paintroid.test.espresso.catroid;
 
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
 import android.net.Uri;
-import android.os.Environment;
 
+import org.catrobat.paintroid.FileIO;
 import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.common.Constants;
+import org.catrobat.paintroid.test.espresso.util.BitmapLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils;
 import org.catrobat.paintroid.tools.ToolType;
@@ -35,6 +43,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Objects;
 
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
@@ -44,17 +56,25 @@ import androidx.test.rule.GrantPermissionRule;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
 @RunWith(AndroidJUnit4.class)
 public class OpenedFromPocketCodeWithImageTest {
 
 	private static final String IMAGE_NAME = "testFile";
-	private static final String FILE_ENDING = ".png";
+	private static final String IMAGE_TO_LOAD_NAME = "loadFile";
 
 	@Rule
 	public IntentsTestRule<MainActivity> launchActivityRule = new IntentsTestRule<>(MainActivity.class, false, true);
@@ -63,16 +83,16 @@ public class OpenedFromPocketCodeWithImageTest {
 	public static GrantPermissionRule grantPermissionRule = EspressoUtils.grantPermissionRulesVersionCheck();
 
 	private File imageFile = null;
+	private MainActivity activity;
+	private ArrayList<File> deletionFileList = null;
 
 	@Before
 	public void setUp() {
-		String pathToFile =
-				launchActivityRule.getActivity().getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-						+ File.separator
-						+ IMAGE_NAME
-						+ FILE_ENDING;
+		deletionFileList = new ArrayList<>();
+		activity = launchActivityRule.getActivity();
 
-		imageFile = new File(pathToFile);
+		imageFile = getNewImageFile(IMAGE_NAME);
+		deletionFileList.add(imageFile);
 		launchActivityRule.getActivity().model.setSavedPictureUri(Uri.fromFile(imageFile));
 		launchActivityRule.getActivity().model.setOpenedFromCatroid(true);
 
@@ -82,8 +102,10 @@ public class OpenedFromPocketCodeWithImageTest {
 
 	@After
 	public void tearDown() {
-		if (imageFile != null && imageFile.exists()) {
-			assertTrue(imageFile.delete());
+		for (File file : deletionFileList) {
+			if (file != null && file.exists()) {
+				assertTrue(file.delete());
+			}
 		}
 	}
 
@@ -96,12 +118,49 @@ public class OpenedFromPocketCodeWithImageTest {
 		long fileSizeBefore = imageFile.length();
 
 		Espresso.pressBackUnconditionally();
+		verifyImageFile(lastModifiedBefore, fileSizeBefore);
+	}
 
-		String path = launchActivityRule.getActivityResult().getResultData().getStringExtra(Constants.PAINTROID_PICTURE_PATH);
-		assertEquals(imageFile.getAbsolutePath(), path);
+	@Test
+	public void testLoadWithoutChange() {
+		long lastModifiedBefore = imageFile.lastModified();
+		long fileSizeBefore = imageFile.length();
+		createImageIntent();
 
-		assertThat("Image modification not saved", imageFile.lastModified(), greaterThan(lastModifiedBefore));
-		assertThat("Saved image length not changed", imageFile.length(), greaterThan(fileSizeBefore));
+		onTopBarView()
+				.performOpenMoreOptions();
+
+		onView(withText(R.string.menu_load_image)).perform(click());
+		onView(withText(R.string.dialog_warning_new_image)).check(doesNotExist());
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.WHITE, BitmapLocationProvider.MIDDLE);
+
+		Espresso.pressBackUnconditionally();
+		verifyImageFile(lastModifiedBefore, fileSizeBefore);
+	}
+
+	@Test
+	public void testLoadWithChange() {
+		long lastModifiedBefore = imageFile.lastModified();
+		long fileSizeBefore = imageFile.length();
+		createImageIntent();
+
+		onTopBarView()
+				.performOpenMoreOptions();
+
+		onView(withText(R.string.menu_load_image)).perform(click());
+		onView(withText(R.string.dialog_warning_new_image)).check(doesNotExist());
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.WHITE, BitmapLocationProvider.MIDDLE);
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE);
+
+		Espresso.pressBackUnconditionally();
+		verifyImageFile(lastModifiedBefore, fileSizeBefore);
 	}
 
 	@Test
@@ -116,5 +175,49 @@ public class OpenedFromPocketCodeWithImageTest {
 
 		assertThat("Image modified", imageFile.lastModified(), equalTo(lastModifiedBefore));
 		assertThat("Saved image length changed", imageFile.length(), equalTo(fileSizeBefore));
+	}
+
+	private File getNewImageFile(String filename) {
+		try {
+			return FileIO.createNewEmptyPictureFile(filename, launchActivityRule.getActivity());
+		} catch (NullPointerException e) {
+			throw new AssertionError("Could not create temp file", e);
+		}
+	}
+
+	private void createImageIntent() {
+		Intent intent = new Intent();
+		intent.setData(createTestImageFile());
+		Instrumentation.ActivityResult resultOK = new Instrumentation.ActivityResult(Activity.RESULT_OK, intent);
+		intending(hasAction(Intent.ACTION_GET_CONTENT)).respondWith(resultOK);
+	}
+
+	private Uri createTestImageFile() {
+		Bitmap bitmap = Bitmap.createBitmap(400, 400, Bitmap.Config.ARGB_8888);
+		Canvas canvas = new Canvas(bitmap);
+		canvas.drawColor(Color.WHITE);
+		canvas.drawBitmap(bitmap, 0F, 0F, null);
+
+		File imageFile = new File(activity.getExternalFilesDir(null).getAbsolutePath(), IMAGE_TO_LOAD_NAME + ".jpg");
+		Uri imageUri = Uri.fromFile(imageFile);
+		try {
+			OutputStream fos = activity.getContentResolver().openOutputStream(Objects.requireNonNull(imageUri));
+			assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos));
+			assert fos != null;
+			fos.close();
+		} catch (IOException e) {
+			throw new AssertionError("Picture file could not be created.", e);
+		}
+
+		deletionFileList.add(imageFile);
+		return imageUri;
+	}
+
+	private void verifyImageFile(long lastModifiedBefore, long fileSizeBefore) {
+		String path = launchActivityRule.getActivityResult().getResultData().getStringExtra(Constants.PAINTROID_PICTURE_PATH);
+		assertEquals(imageFile.getAbsolutePath(), path);
+
+		assertThat("Image modification not saved", imageFile.lastModified(), greaterThan(lastModifiedBefore));
+		assertThat("Saved image length not changed", imageFile.length(), greaterThan(fileSizeBefore));
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -53,6 +53,7 @@ public final class FileIO {
 	public static Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.JPEG;
 	public static boolean catroidFlag = false;
 	public static boolean isCatrobatImage = false;
+	public static boolean wasImageLoaded = false;
 
 	public static String currentFileNameJpg = null;
 	public static String currentFileNamePng = null;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -174,7 +174,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	}
 
 	private void showSecurityQuestionBeforeExit() {
-		if (isImageUnchanged() || model.isSaved()) {
+		if ((isImageUnchanged() || model.isSaved()) && (!model.isOpenedFromCatroid() || !FileIO.wasImageLoaded)) {
 			finishActivity();
 		} else if (model.isOpenedFromCatroid()) {
 			saveBeforeFinish();
@@ -557,6 +557,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	public void initializeFromCleanState(String extraPicturePath, String extraPictureName) {
 		boolean isOpenedFromCatroid = extraPicturePath != null;
 		model.setOpenedFromCatroid(isOpenedFromCatroid);
+		FileIO.wasImageLoaded = false;
 		if (isOpenedFromCatroid) {
 			File imageFile = new File(extraPicturePath);
 			if (imageFile.exists()) {
@@ -712,8 +713,11 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 					commandManager.setInitialStateCommand(commandFactory.createInitCommand(bitmap.bitmapList));
 				}
 				commandManager.reset();
-				model.setSavedPictureUri(null);
+				if (!model.isOpenedFromCatroid()) {
+					model.setSavedPictureUri(null);
+				}
 				model.setCameraImageUri(null);
+				FileIO.wasImageLoaded = true;
 				break;
 			case LOAD_IMAGE_IMPORTPNG:
 				if (toolController.getToolType() == ToolType.IMPORTPNG) {


### PR DESCRIPTION
Fixed two small bugs where you couldn't load images when Paintroid was opened via catroid.
Bugs descriptions:
https://jira.catrob.at/projects/PAINTROID/issues/PAINTROID-201?filter=allopenissues
(Created new pull request with this ticket because I f*** up with git..)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
