### PR TITLE
PAINTROID-211 : Reverse order of jpg and png in save / copy / export settings

### DIFF
--- a/Paintroid/src/test/java/org/catrobat/paintroid/dialog/SaveInformationDialogTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/dialog/SaveInformationDialogTest.java
@@ -1,0 +1,60 @@
+package org.catrobat.paintroid.dialog;
+
+import android.content.res.Resources;
+import android.graphics.PointF;
+import android.os.Build;
+import android.util.DisplayMetrics;
+
+import androidx.annotation.RequiresApi;
+
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.common.Constants;
+import org.catrobat.paintroid.common.MainActivityConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class SaveInformationDialogTest {
+
+
+    private MainActivity mainActivity;
+    int permissionCode = MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_COPY;
+    int imageNumber = 0;
+    SaveInformationDialog dialog = SaveInformationDialog.newInstance(permissionCode, imageNumber, true);
+
+    public SaveInformationDialogTest(MainActivity mainActivity) {
+        this.mainActivity = mainActivity;
+    }
+
+    @Before
+    public void setUp() {
+
+
+        dialog.show(mainActivity.getSupportFragmentManager(), Constants.ABOUT_DIALOG_FRAGMENT_TAG);
+    }
+    
+    @Test
+    public void testDialogIsShown() {
+        //test code here
+    }
+
+    @Test
+    public void testDialogIsNotCancelable() {
+        //test code here
+    }
+
+    @Test
+    public void testDialogIsNotCancelableOnBack() {
+        //test code here
+    }
+
+    @After
+    public void tearDown() {
+        dialog.dismiss();
+    }
+}


### PR DESCRIPTION
Fixes [Paintroid-211](https://jira.catrob.at/projects/PAINTROID/issues/PAINTROID-211?filter=allopenissues)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
