### PR TITLE
PAINTROID-128

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -20,8 +20,10 @@
 package org.catrobat.paintroid;
 
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -34,6 +36,7 @@ import android.provider.MediaStore;
 import android.util.Log;
 
 import org.catrobat.paintroid.common.Constants;
+import org.catrobat.paintroid.iotasks.BitmapReturnValue;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -257,7 +260,14 @@ public final class FileIO {
 		return enableAlpha(decodeBitmapFromUri(resolver, bitmapUri, options));
 	}
 
-	public static Bitmap getBitmapFromUri(ContentResolver resolver, @NonNull Uri bitmapUri, int maxWidth, int maxHeight) throws IOException {
+	public static boolean hasEnoughMemory(ContentResolver resolver, @NonNull Uri bitmapUri, Context context) throws IOException {
+		long requiredMemory;
+		long availableMemory;
+		boolean scaling = false;
+
+		ActivityManager.MemoryInfo memoryinfo = new ActivityManager.MemoryInfo();
+		ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+		activityManager.getMemoryInfo(memoryinfo);
 		BitmapFactory.Options options = new BitmapFactory.Options();
 		options.inJustDecodeBounds = true;
 		decodeBitmapFromUri(resolver, bitmapUri, options);
@@ -265,14 +275,58 @@ public final class FileIO {
 			throw new IOException("Can't load bitmap from uri");
 		}
 
-		int sampleSize = calculateSampleSize(options.outWidth, options.outHeight,
-				maxWidth, maxHeight);
+		if (((memoryinfo.availMem - memoryinfo.threshold) * 0.9) > 5000 * 5000 * 4) {
+			availableMemory = (long) 5000 * 5000 * 4;
+		} else {
+			availableMemory = (long) ((memoryinfo.availMem - memoryinfo.threshold) * 0.9);
+		}
+		requiredMemory = options.outWidth * options.outHeight * 4;
+		if (requiredMemory > availableMemory) {
+			scaling = true;
+		}
 
+		return scaling;
+	}
+
+	public static int getScaleFactor(ContentResolver resolver, @NonNull Uri bitmapUri, Context context) throws IOException {
+		float heightToWidthFactor;
+		float availablePixels;
+		float availableHeight;
+		float availableWidth;
+		float availableMemory;
+
+		ActivityManager.MemoryInfo memoryinfo = new ActivityManager.MemoryInfo();
+		ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+		activityManager.getMemoryInfo(memoryinfo);
+		BitmapFactory.Options options = new BitmapFactory.Options();
+		decodeBitmapFromUri(resolver, bitmapUri, options);
+		if (options.outHeight <= 0 || options.outWidth <= 0) {
+			throw new IOException("Can't load bitmap from uri");
+		}
+		Runtime info = Runtime.getRuntime();
+		availableMemory = (float) ((info.maxMemory() - info.totalMemory() + info.freeMemory()) * 0.9);
+		heightToWidthFactor = (float) (options.outWidth / (options.outHeight * 1.0));
+		availablePixels = (float) ((availableMemory * 0.9) / 4.0); //4 byte per pixel, 10% safety buffer on memory
+		availableHeight = (float) Math.sqrt(availablePixels / heightToWidthFactor);
+		availableWidth = availablePixels / availableHeight;
+		return calculateSampleSize(options.outWidth, options.outHeight,
+				(int) availableWidth, (int) availableHeight);
+	}
+
+	public static BitmapReturnValue getBitmapFromUri(ContentResolver resolver, @NonNull Uri bitmapUri, Context context) throws IOException {
+		BitmapFactory.Options options = new BitmapFactory.Options();
 		options.inMutable = true;
 		options.inJustDecodeBounds = false;
-		options.inSampleSize = sampleSize;
+		boolean scaling = hasEnoughMemory(resolver, bitmapUri, context);
+		return new BitmapReturnValue(null, enableAlpha(decodeBitmapFromUri(resolver, bitmapUri, options)), scaling);
+	}
 
-		return enableAlpha(decodeBitmapFromUri(resolver, bitmapUri, options));
+	public static BitmapReturnValue getScaledBitmapFromUri(ContentResolver resolver, @NonNull Uri bitmapUri, Context context) throws IOException {
+		BitmapFactory.Options options = new BitmapFactory.Options();
+		options.inMutable = true;
+		options.inJustDecodeBounds = false;
+		options.inSampleSize = getScaleFactor(resolver, bitmapUri, context);
+		return new BitmapReturnValue(null, enableAlpha(decodeBitmapFromUri(resolver, bitmapUri, options)), false);
 	}
 
 	public static Bitmap getBitmapFromFile(File bitmapFile) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -338,7 +338,7 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 
 		presenter = new MainActivityPresenter(this, this, model, workspace,
 				navigator, interactor, topBarViewHolder, bottomBarViewHolder, drawerLayoutViewHolder,
-				bottomNavigationViewHolder, new DefaultCommandFactory(), commandManager, perspective, defaultToolController, preferences);
+				bottomNavigationViewHolder, new DefaultCommandFactory(), commandManager, perspective, defaultToolController, preferences, context);
 		defaultToolController.setOnColorPickedListener(new PresenterColorPickedListener(presenter));
 
 		keyboardListener = new KeyboardListener(drawerLayout);

--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/Constants.java
@@ -59,6 +59,7 @@ public final class Constants {
 	public static final int IS_NO_FILE = -1;
 
 	public static final int MAX_LAYERS = 4;
+	public static final String SCALE_IMAGE_FRAGMENT_TAG = "showscaleimagedialog";
 
 	private Constants() {
 		throw new AssertionError();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -20,6 +20,7 @@
 package org.catrobat.paintroid.contract;
 
 import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -119,6 +120,8 @@ public interface MainActivityContracts {
 		void showImageImportDialog();
 
 		void showCatroidMediaGallery();
+
+		void showScaleImageRequestDialog(Uri uri, int requestCode);
 	}
 
 	interface MainView {
@@ -254,6 +257,10 @@ public interface MainActivityContracts {
 		int getImageNumber();
 
 		Bitmap getBitmap();
+
+		Context getContext();
+
+		void loadScaledImage(Uri uri, @ActivityRequestCode int requestCode);
 	}
 
 	interface Model {
@@ -289,9 +296,7 @@ public interface MainActivityContracts {
 
 		void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, Uri uri);
 
-		void loadFile(LoadImageAsync.LoadImageCallback callback, int requestCode, Uri uri);
-
-		void loadFile(LoadImageAsync.LoadImageCallback callback, int requestCode, int maxWidth, int maxHeight, Uri uri);
+		void loadFile(LoadImageAsync.LoadImageCallback callback, int requestCode, Uri uri, Context context, boolean scaling);
 	}
 
 	interface TopBarViewHolder {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/ScaleImageOnLoadDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/ScaleImageOnLoadDialog.java
@@ -1,0 +1,72 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.dialog;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.net.Uri;
+import android.os.Bundle;
+
+import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.common.MainActivityConstants;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+
+public class ScaleImageOnLoadDialog extends MainActivityDialogFragment {
+
+	private Uri uri;
+	private int requestCode;
+
+	public static ScaleImageOnLoadDialog newInstance(Uri uri, @MainActivityConstants.LoadImageRequestCode int requestCode) {
+		ScaleImageOnLoadDialog scaleImageDialog = new ScaleImageOnLoadDialog();
+
+		Bundle bundle = new Bundle();
+		bundle.putString("Uri", uri.toString());
+		bundle.putInt("requestCode", requestCode);
+		scaleImageDialog.setArguments(bundle);
+		return scaleImageDialog;
+	}
+
+	@Override
+	public void onCreate(@Nullable Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		Bundle arguments = getArguments();
+		uri = Uri.parse(arguments.getString("Uri"));
+		requestCode = arguments.getInt("requestCode");
+	}
+
+	@NonNull
+	@Override
+	public Dialog onCreateDialog(Bundle savedInstanceState) {
+		return new AlertDialog.Builder(getActivity(), R.style.PocketPaintAlertDialog)
+				.setTitle(R.string.dialog_scale_title)
+				.setMessage(R.string.dialog_scale_message)
+				.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int id) {
+						getPresenter().loadScaledImage(uri, requestCode);
+					}
+				})
+				.setNegativeButton(android.R.string.cancel, null)
+				.create();
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/BitmapReturnValue.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/BitmapReturnValue.java
@@ -25,9 +25,11 @@ import java.util.List;
 public class BitmapReturnValue {
 	public List<Bitmap> bitmapList;
 	public Bitmap bitmap;
+	public boolean toBeScaled;
 
-	public BitmapReturnValue(List<Bitmap> list, Bitmap singleBitmap) {
+	public BitmapReturnValue(List<Bitmap> list, Bitmap singleBitmap, boolean scaling) {
 		bitmapList = list;
 		bitmap = singleBitmap;
+		toBeScaled = scaling;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/LoadImageAsync.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/LoadImageAsync.java
@@ -20,6 +20,7 @@
 package org.catrobat.paintroid.iotasks;
 
 import android.content.ContentResolver;
+import android.content.Context;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.util.Log;
@@ -34,26 +35,17 @@ import java.util.Locale;
 public class LoadImageAsync extends AsyncTask<Void, Void, BitmapReturnValue> {
 	private static final String TAG = LoadImageAsync.class.getSimpleName();
 	private WeakReference<LoadImageCallback> callbackRef;
-	private int maxWidth;
-	private int maxHeight;
 	private int requestCode;
 	private Uri uri;
 	private boolean scaleImage;
+	private Context context;
 
-	public LoadImageAsync(LoadImageCallback callback, int requestCode, int maxWidth, int maxHeight, Uri uri) {
+	public LoadImageAsync(LoadImageCallback callback, int requestCode, Uri uri, Context context, boolean scaling) {
 		this.callbackRef = new WeakReference<>(callback);
 		this.requestCode = requestCode;
 		this.uri = uri;
-		this.maxWidth = maxWidth;
-		this.maxHeight = maxHeight;
-		this.scaleImage = true;
-	}
-
-	public LoadImageAsync(LoadImageCallback callback, int requestCode, Uri uri) {
-		this.callbackRef = new WeakReference<>(callback);
-		this.requestCode = requestCode;
-		this.uri = uri;
-		this.scaleImage = false;
+		this.scaleImage = scaling;
+		this.context = context;
 	}
 
 	@Override
@@ -92,13 +84,12 @@ public class LoadImageAsync extends AsyncTask<Void, Void, BitmapReturnValue> {
 			BitmapReturnValue returnValue;
 
 			if (mimeType.equals("application/zip") || mimeType.equals("application/octet-stream")) {
-				returnValue = new BitmapReturnValue(
-						OpenRasterFileFormatConversion.importOraFile(resolver, uri, maxWidth, maxHeight, scaleImage), null);
+				returnValue = OpenRasterFileFormatConversion.importOraFile(resolver, uri, context);
 			} else {
 				if (scaleImage) {
-					returnValue = new BitmapReturnValue(null, FileIO.getBitmapFromUri(resolver, uri, maxWidth, maxHeight));
+					returnValue = FileIO.getScaledBitmapFromUri(resolver, uri, context);
 				} else {
-					returnValue = new BitmapReturnValue(null, FileIO.getBitmapFromUri(resolver, uri));
+					returnValue = FileIO.getBitmapFromUri(resolver, uri, context);
 				}
 			}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/OpenRasterFileFormatConversion.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/OpenRasterFileFormatConversion.java
@@ -22,6 +22,7 @@ package org.catrobat.paintroid.iotasks;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -244,33 +245,23 @@ public final class OpenRasterFileFormatConversion {
 		return exportToOraFile(bitmapList, fileName, bitmapAllLayers, resolver);
 	}
 
-	public static List<Bitmap> importOraFile(ContentResolver resolver, Uri uri, int maxWidth, int maxHeight, boolean scaled) throws IOException {
+	public static BitmapReturnValue importOraFile(ContentResolver resolver, Uri uri, Context context) throws IOException {
 		BitmapFactory.Options options = new BitmapFactory.Options();
 		InputStream inputStream = resolver.openInputStream(uri);
 		ZipInputStream zipInput = new ZipInputStream(inputStream);
-
-		options.inMutable = true;
-		options.inJustDecodeBounds = false;
-		if (scaled) {
-			options.inSampleSize = FileIO.calculateSampleSize(options.outWidth, options.outHeight,
-					maxWidth, maxHeight);
-		}
-
-		ZipEntry current = zipInput.getNextEntry();
 		List<Bitmap> bitmapList = new ArrayList<>();
+		ZipEntry current = zipInput.getNextEntry();
+
 		while (current != null) {
 			if (current.getName().matches("data/(.*).png")) {
-
 				Bitmap layerBitmap = FileIO.enableAlpha(BitmapFactory.decodeStream(zipInput, null, options));
 				bitmapList.add(layerBitmap);
 			}
 			current = zipInput.getNextEntry();
 		}
-
 		if (bitmapList.isEmpty() || bitmapList.size() > Constants.MAX_LAYERS) {
 			throw new IOException("Bitmap list is wrong!");
 		}
-
-		return bitmapList;
+		return new BitmapReturnValue(bitmapList, null, false);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -22,6 +22,7 @@ package org.catrobat.paintroid.presenter;
 import android.Manifest;
 import android.app.Activity;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
@@ -108,11 +109,13 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	private boolean resetPerspectiveAfterNextCommand;
 	private ToolController toolController;
 	private UserPreferences sharedPreferences;
+	private Context context;
 
 	public MainActivityPresenter(Activity activity, MainView view, Model model, Workspace workspace, Navigator navigator,
 			Interactor interactor, TopBarViewHolder topBarViewHolder, BottomBarViewHolder bottomBarViewHolder,
 			DrawerLayoutViewHolder drawerLayoutViewHolder, BottomNavigationViewHolder bottomNavigationViewHolder,
-			CommandFactory commandFactory, CommandManager commandManager, Perspective perspective, ToolController toolController, UserPreferences sharedPreferences) {
+			CommandFactory commandFactory, CommandManager commandManager, Perspective perspective, ToolController toolController,
+			UserPreferences sharedPreferences, Context context) {
 		this.fileActivity = activity;
 		this.view = view;
 		this.model = model;
@@ -128,6 +131,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		this.commandFactory = commandFactory;
 		this.bottomNavigationViewHolder = bottomNavigationViewHolder;
 		this.sharedPreferences = sharedPreferences;
+		this.context = context;
 	}
 
 	private boolean isImageUnchanged() {
@@ -401,9 +405,6 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void handleActivityResult(@ActivityRequestCode int requestCode, int resultCode, Intent data) {
-		DisplayMetrics metrics = view.getDisplayMetrics();
-		int maxWidth = metrics.widthPixels;
-		int maxHeight = metrics.heightPixels;
 		switch (requestCode) {
 			case REQUEST_CODE_IMPORTPNG:
 				if (resultCode != Activity.RESULT_OK) {
@@ -412,13 +413,13 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 				Uri selectedGalleryImageUri = data.getData();
 				setTool(ToolType.IMPORTPNG);
 				toolController.switchTool(ToolType.IMPORTPNG, false);
-				interactor.loadFile(this, LOAD_IMAGE_IMPORTPNG, maxWidth, maxHeight, selectedGalleryImageUri);
+				interactor.loadFile(this, LOAD_IMAGE_IMPORTPNG, selectedGalleryImageUri, getContext(), false);
 				break;
 			case REQUEST_CODE_LOAD_PICTURE:
 				if (resultCode != Activity.RESULT_OK) {
 					return;
 				}
-				interactor.loadFile(this, LOAD_IMAGE_DEFAULT, maxWidth, maxHeight, data.getData());
+				interactor.loadFile(this, LOAD_IMAGE_DEFAULT, data.getData(), getContext(), false);
 				break;
 			case REQUEST_CODE_INTRO:
 				if (resultCode == RESULT_INTRO_MW_NOT_SUPPORTED) {
@@ -562,7 +563,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 			if (imageFile.exists()) {
 				model.setSavedPictureUri(view.getUriFromFile(imageFile));
 
-				interactor.loadFile(this, LOAD_IMAGE_CATROID, model.getSavedPictureUri());
+				interactor.loadFile(this, LOAD_IMAGE_CATROID, model.getSavedPictureUri(), getContext(), false);
 			} else {
 				interactor.createFile(this, CREATE_FILE_DEFAULT, extraPictureName);
 			}
@@ -697,9 +698,33 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	}
 
 	@Override
+	public void loadScaledImage(Uri uri, @LoadImageRequestCode int requestCode) {
+		switch (requestCode) {
+			case LOAD_IMAGE_IMPORTPNG:
+				setTool(ToolType.IMPORTPNG);
+				toolController.switchTool(ToolType.IMPORTPNG, false);
+				interactor.loadFile(this, LOAD_IMAGE_IMPORTPNG, uri, context, true);
+				break;
+			case LOAD_IMAGE_CATROID:
+			case LOAD_IMAGE_DEFAULT:
+				interactor.loadFile(this, LOAD_IMAGE_DEFAULT, uri, context, true);
+				break;
+			default:
+				Log.e(MainActivity.TAG, "wrong request code for loading pictures");
+				break;
+		}
+	}
+
+	@Override
 	public void onLoadImagePostExecute(@LoadImageRequestCode int requestCode, Uri uri, BitmapReturnValue bitmap) {
+
 		if (bitmap == null) {
 			navigator.showLoadErrorDialog();
+			return;
+		}
+
+		if (bitmap.toBeScaled) {
+			navigator.showScaleImageRequestDialog(uri, requestCode);
 			return;
 		}
 
@@ -869,5 +894,10 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	@Override
 	public Bitmap getBitmap() {
 		return workspace.getBitmapOfAllLayers();
+	}
+
+	@Override
+	public Context getContext() {
+		return this.context;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
@@ -19,6 +19,7 @@
 
 package org.catrobat.paintroid.ui;
 
+import android.content.Context;
 import android.net.Uri;
 
 import org.catrobat.paintroid.contract.MainActivityContracts;
@@ -45,12 +46,7 @@ public class MainActivityInteractor implements MainActivityContracts.Interactor 
 	}
 
 	@Override
-	public void loadFile(LoadImageAsync.LoadImageCallback callback, int requestCode, Uri uri) {
-		new LoadImageAsync(callback, requestCode, uri).execute();
-	}
-
-	@Override
-	public void loadFile(LoadImageAsync.LoadImageCallback callback, int requestCode, int maxWidth, int maxHeight, Uri uri) {
-		new LoadImageAsync(callback, requestCode, maxWidth, maxHeight, uri).execute();
+	public void loadFile(LoadImageAsync.LoadImageCallback callback, int requestCode, Uri uri, Context context, boolean scaling) {
+		new LoadImageAsync(callback, requestCode, uri, context, scaling).execute();
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -59,6 +59,7 @@ import org.catrobat.paintroid.dialog.SaveBeforeFinishDialog.SaveBeforeFinishDial
 import org.catrobat.paintroid.dialog.SaveBeforeLoadImageDialog;
 import org.catrobat.paintroid.dialog.SaveBeforeNewImageDialog;
 import org.catrobat.paintroid.dialog.SaveInformationDialog;
+import org.catrobat.paintroid.dialog.ScaleImageOnLoadDialog;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.ui.fragments.CatroidMediaGalleryFragment;
 
@@ -385,6 +386,12 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	public void showSaveBeforeLoadImageDialog() {
 		AppCompatDialogFragment dialog = SaveBeforeLoadImageDialog.newInstance();
 		showDialogFragmentSafely(dialog, Constants.SAVE_QUESTION_FRAGMENT_TAG);
+	}
+
+	@Override
+	public void showScaleImageRequestDialog(Uri uri, int requestCode) {
+		AppCompatDialogFragment dialog = ScaleImageOnLoadDialog.newInstance(uri, requestCode);
+		showDialogFragmentSafely(dialog, Constants.SCALE_IMAGE_FRAGMENT_TAG);
 	}
 
 	@SuppressLint("VisibleForTests")

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -228,6 +228,6 @@
     <string name="pocketpaint_tool_icon_description">Current tool icon</string>
 
     <string name="dialog_scale_title">Image is too big to load</string>
-    <string name="dialog_scale_message">The image is too big to load, click OK to scale the Image down</string>
+    <string name="dialog_scale_message">The image is too big to load. Click OK to scale down the image automatically.</string>
 
 </resources>

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -226,4 +226,8 @@
     <string name="intro_bottom_navigation_layers_description">Opens the layer menu and lets you manage your layers.</string>
 
     <string name="pocketpaint_tool_icon_description">Current tool icon</string>
+
+    <string name="dialog_scale_title">Image is too big to load</string>
+    <string name="dialog_scale_message">The image is too big to load, click OK to scale the Image down</string>
+
 </resources>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -22,6 +22,7 @@ package org.catrobat.paintroid.test.presenter;
 import android.Manifest;
 import android.app.Activity;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
@@ -122,6 +123,8 @@ public class MainActivityPresenterTest {
 	private Menu menu;
 	@Mock
 	private UserPreferences sharedPreferences;
+	@Mock
+	private Context context;
 
 	@InjectMocks
 	private MainActivityPresenter presenter;
@@ -391,8 +394,7 @@ public class MainActivityPresenterTest {
 		when(intent.getData()).thenReturn(uri);
 
 		presenter.handleActivityResult(REQUEST_CODE_LOAD_PICTURE, Activity.RESULT_OK, intent);
-
-		verify(interactor).loadFile(presenter, LOAD_IMAGE_DEFAULT, 13, 17, uri);
+		verify(interactor).loadFile(presenter, LOAD_IMAGE_DEFAULT, uri, context, false);
 	}
 
 	@Test
@@ -607,7 +609,7 @@ public class MainActivityPresenterTest {
 
 		verify(model).setOpenedFromCatroid(true);
 		verify(model).setSavedPictureUri(uri);
-		verify(interactor).loadFile(presenter, LOAD_IMAGE_CATROID, uri);
+		verify(interactor).loadFile(presenter, LOAD_IMAGE_CATROID, uri, context, false);
 	}
 
 	@Test
@@ -829,7 +831,7 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenDefaultThenResetModelUris() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
-		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap, false);
 
 		presenter.onLoadImagePostExecute(LOAD_IMAGE_DEFAULT, uri, returnValue);
 
@@ -841,7 +843,7 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenDefaultThenResetCommandManager() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
-		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap, false);
 		Command command = mock(Command.class);
 		when(commandFactory.createInitCommand(bitmap)).thenReturn(command);
 
@@ -856,7 +858,7 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenImportThenSetBitmap() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
-		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap, false);
 		when(toolController.getToolType()).thenReturn(ToolType.IMPORTPNG);
 
 		presenter.onLoadImagePostExecute(LOAD_IMAGE_IMPORTPNG, uri, returnValue);
@@ -869,7 +871,7 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenImportAndNotImportToolSetThenIgnore() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
-		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap, false);
 
 		presenter.onLoadImagePostExecute(LOAD_IMAGE_IMPORTPNG, uri, returnValue);
 
@@ -881,7 +883,7 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenCatroidThenSetModelUris() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
-		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap, false);
 
 		presenter.onLoadImagePostExecute(LOAD_IMAGE_CATROID, uri, returnValue);
 
@@ -894,7 +896,7 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenCatroidThenResetCommandManager() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
-		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap, false);
 		Command command = mock(Command.class);
 		when(commandFactory.createInitCommand(bitmap)).thenReturn(command);
 
@@ -909,7 +911,7 @@ public class MainActivityPresenterTest {
 	public void testOnLoadImagePostExecuteWhenInvalidRequestThenThrowException() {
 		Uri uri = mock(Uri.class);
 		Bitmap bitmap = mock(Bitmap.class);
-		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap);
+		BitmapReturnValue returnValue = new BitmapReturnValue(null, bitmap, false);
 
 		presenter.onLoadImagePostExecute(0, uri, returnValue);
 	}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,22 +1,4 @@
-#
-#  Paintroid: An image manipulation application for Android.
-#  Copyright (C) 2010-2015 The Catrobat Team
-#  (<http://developer.catrobat.org/credits>)
-#
-#  This program is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU Affero General Public License as
-#  published by the Free Software Foundation, either version 3 of the
-#  License, or (at your option) any later version.
-#
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#  GNU Affero General Public License for more details.
-#
-#  You should have received a copy of the GNU Affero General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-
+#Tue Feb 02 16:23:53 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
checks how much memory png or jpg files would take and asks to scale them down if it is more than the available memory

evolved from combination with Paintroid-129

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
