### PR TITLE
PAINTROID-211 Changed png to the default image format save option

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
@@ -585,7 +585,7 @@ public class MenuFileActivityIntegrationTest {
 
 		int imageNumber = launchActivityRule.getActivity().getPresenter().getImageNumber();
 
-		onView(withText("jpg"))
+		onView(withText("png"))
 				.check(matches(isDisplayed()));
 		onView(withText("image" + imageNumber))
 				.check(matches(isDisplayed()));
@@ -593,7 +593,7 @@ public class MenuFileActivityIntegrationTest {
 		onView(withId(R.id.pocketpaint_save_dialog_spinner))
 				.perform(click());
 		onData(allOf(is(instanceOf(String.class)),
-				is("jpg"))).inRoot(isPlatformPopup()).perform(click());
+				is("png"))).inRoot(isPlatformPopup()).perform(click());
 
 		onView(withText(R.string.save_button_text))
 				.perform(click());
@@ -605,7 +605,7 @@ public class MenuFileActivityIntegrationTest {
 
 		imageNumber = launchActivityRule.getActivity().getPresenter().getImageNumber();
 
-		onView(withText("jpg"))
+		onView(withText("png"))
 				.check(matches(isDisplayed()));
 		onView(withText("image" + imageNumber))
 				.check(matches(isDisplayed()));

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -51,9 +51,9 @@ import androidx.core.content.FileProvider;
 
 public final class FileIO {
 	public static String filename = "image";
-	public static String ending = ".jpg";
+	public static String ending = ".png";
 	public static int compressQuality = 100;
-	public static Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.JPEG;
+	public static Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.PNG;
 	public static boolean catroidFlag = false;
 	public static boolean isCatrobatImage = false;
 	public static boolean wasImageLoaded = false;

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.java
@@ -65,9 +65,8 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 		if (isStandard) {
 			FileIO.isCatrobatImage = false;
 			FileIO.filename = "image";
-			FileIO.compressFormat = Bitmap.CompressFormat.JPEG;
-			FileIO.ending = ".jpg";
-			FileIO.compressQuality = 100;
+			FileIO.compressFormat = Bitmap.CompressFormat.PNG;
+			FileIO.ending = ".png";
 		}
 
 		SaveInformationDialog dialog = new SaveInformationDialog();
@@ -103,9 +102,9 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 		if (FileIO.isCatrobatImage) {
 			mySpinner.setSelection(2);
 		} else if (FileIO.compressFormat == Bitmap.CompressFormat.PNG) {
-			mySpinner.setSelection(1);
-		} else {
 			mySpinner.setSelection(0);
+		} else {
+			mySpinner.setSelection(1);
 		}
 	}
 
@@ -159,8 +158,8 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 
 	private void initializeFunctioning() {
 		List<String> spinnerArray = new ArrayList<>();
-		spinnerArray.add("jpg");
 		spinnerArray.add("png");
+		spinnerArray.add("jpg");
 		spinnerArray.add("ora");
 
 		ArrayAdapter<String> adapter = new ArrayAdapter<>(mySpinner.getContext(),


### PR DESCRIPTION
Previous default save image format was .jpg, now its .png

Jira-ticket: https://jira.catrob.at/browse/PAINTROID-211

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
