### PR TITLE
PAINTROID-225 Visible format information and blueish dialog text buttons

### DIFF
--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_save_info.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_save_info.xml
@@ -2,8 +2,7 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:viewportHeight="24">
   <path
       android:fillColor="@android:color/darker_gray"
       android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>

--- a/Paintroid/src/main/res/values/style.xml
+++ b/Paintroid/src/main/res/values/style.xml
@@ -26,6 +26,7 @@
 
     <style name="PocketPaintAlertDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:windowTitleStyle">@style/PocketPaintTitleTextStyle</item>
+        <item name="android:textColor">@color/pocketpaint_colorAccent</item>
         <item name="android:textColorLink">@color/pocketpaint_text_color_link</item>
         <item name="colorAccent">@color/pocketpaint_colorAccent</item>
     </style>


### PR DESCRIPTION
The ImageButton for format information is visiable again, and dialog text buttons now have a blueish color again.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
