### PR TITLE
PAINTROID-233 fixed bug when empty text in spray radius

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/SprayToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/SprayToolIntegrationTest.kt
@@ -1,0 +1,49 @@
+package org.catrobat.paintroid.test.espresso.tools
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import org.catrobat.paintroid.MainActivity
+import org.catrobat.paintroid.R
+import org.catrobat.paintroid.test.espresso.util.UiMatcher.withProgress
+import org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction
+import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule
+import org.catrobat.paintroid.tools.ToolType
+import org.catrobat.paintroid.ui.tools.DefaultSprayToolOptionsView
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+class SprayToolIntegrationTest {
+
+    @get:Rule
+    var launchActivityRule = ActivityTestRule(MainActivity::class.java)
+
+    @get:Rule
+    var screenshotOnFailRule = ScreenshotOnFailRule()
+
+    @Before
+    fun setUp() {
+        ToolBarViewInteraction.onToolBarView()
+                .performSelectTool(ToolType.SPRAY)
+    }
+
+    @Test
+    fun testEmptyRadius()
+    {
+        val emptyString:String = ""
+        onView(withId(R.id.pocketpaint_radius_text))
+                .perform(replaceText(emptyString))
+                .check(matches(withText(emptyString)))
+
+        onView(withId(R.id.pocketpaint_spray_radius_seek_bar))
+                .check(matches(withProgress(DefaultSprayToolOptionsView.MIN_RADIUS)))
+    }
+}


### PR DESCRIPTION
After deleting the input from the spray radius text field, it would try to parseInt() this message, resulting in a `java.lang.NumberFormatException`. Also changed the behaviour of the EditTextInput for the radius. Now it behaves like the TextInputs for other tools sizes. Added testcase for empty string.

https://jira.catrob.at/browse/PAINTROID-233

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
