### PR TITLE
PAINTROID-234 fixed bug when selecting pixel on border

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ZoomableImageView.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ZoomableImageView.kt
@@ -300,7 +300,7 @@ class ZoomableImageView : AppCompatImageView, View.OnTouchListener, GestureDetec
         inverse.mapPoints(touchPoint)
         val xPixel = touchPoint[0].toInt()
         val yPixel = touchPoint[1].toInt()
-        if (xPixel > bitmap.width || yPixel > bitmap.height || xPixel < 0 || yPixel < 0) {
+        if (xPixel >= bitmap.width || yPixel >= bitmap.height || xPixel < 0 || yPixel < 0) {
             // clicked outside of the image frame
             return
         }


### PR DESCRIPTION
When selecting a pixel that is exactly the width/height of the bitmap, the `bitmap.getPixel()` function throws a `java.lang.IllegalArgumentException`.

https://jira.catrob.at/browse/PAINTROID-234

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
