### PR TITLE
PAINTROID-222: Keyboard appears when clicked on color picker.

### DIFF
--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
@@ -82,7 +82,8 @@
         android:layout_alignParentBottom="true"
         android:layout_marginStart="8dp"
         app:singleSelection="true"
-        app:singleLine="true">
+        app:singleLine="true"
+        android:layoutDirection="ltr">
 
         <com.google.android.material.chip.Chip
             android:id="@+id/pocketpaint_stroke_ibtn_circle"

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_tool_options.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_tool_options.xml
@@ -28,7 +28,7 @@
         android:id="@+id/pocketpaint_layout_tool_specific_options"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
         android:orientation="vertical"
-        android:layout_alignParentBottom="true">
-    </LinearLayout>
+        android:visibility="visible"></LinearLayout>
 </RelativeLayout>

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
@@ -117,7 +117,7 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
 
         materialDialog.setOnShowListener {
             materialDialog.window?.clearFlags(FLAG_NOT_FOCUSABLE or FLAG_ALT_FOCUSABLE_IM)
-            materialDialog.window?.setSoftInputMode(SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+            materialDialog.window?.setSoftInputMode(SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         }
 
         return materialDialog

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.java
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.java
@@ -149,7 +149,12 @@ public class ColorPickerView extends LinearLayoutCompat {
 		tabHost.setOnTabChangedListener(new TabHost.OnTabChangeListener() {
 			@Override
 			public void onTabChanged(String tabId) {
-				hideKeyboard();
+				if(tabId.equals(rgbTab.getTag())){
+					showKeyboard();
+				}
+				else {
+					hideKeyboard();
+				}
 			}
 		});
 	}
@@ -158,6 +163,16 @@ public class ColorPickerView extends LinearLayoutCompat {
 		InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 		if (inputMethodManager != null) {
 			inputMethodManager.hideSoftInputFromWindow(getRootView().getWindowToken(), 0);
+		}
+
+	}
+
+	private void showKeyboard(){
+		InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+		if (inputMethodManager != null) {
+			inputMethodManager.toggleSoftInputFromWindow(
+					getRootView().getApplicationWindowToken(),
+					InputMethodManager.SHOW_FORCED, 0);
 		}
 	}
 


### PR DESCRIPTION
PAINTROID-222 Keyboard appears when clicked on color picker 

Keyboard used to appear in color picker dialog when clicked on hsvtab and pretab and was hidden in rgb tab.
After the changes made now the keyboard only opens when you are in rgb tab view of color picker and not in hsv or pre tab views. This error used to occur in android 5 to 8 now its been resolved for all versions.
![after](https://user-images.githubusercontent.com/32453754/113518589-ed19d380-95a4-11eb-9bd2-dc506f8d1f35.gif)
![before](https://user-images.githubusercontent.com/32453754/113518591-eee39700-95a4-11eb-8242-5c0433ba760a.gif)

