### PR TITLE
PAINTROID-223: Large images that are scaled down are upside-down (turned by 180 degrees)

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -119,6 +119,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.8'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8'
+    implementation 'androidx.exifinterface:exifinterface:1.3.2'
 
     debugImplementation 'androidx.multidex:multidex:2.0.0'
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/FileIOTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/FileIOTest.java
@@ -1,0 +1,41 @@
+package org.catrobat.paintroid.test.junit;
+
+import android.graphics.Bitmap;
+
+import org.catrobat.paintroid.FileIO;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import androidx.exifinterface.media.ExifInterface;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FileIOTest {
+
+	@Mock
+	Bitmap bitmap;
+	@Mock
+	ExifInterface exifInterface;
+
+	@Test
+	public void testGetOrientedBitmap() {
+		assertNull(FileIO.getOrientedBitmap(bitmap, 0));
+	}
+
+	@Test
+	public void testGetBitmapOrientation() {
+		assertEquals(0, FileIO.getBitmapOrientation(exifInterface), 0);
+		exifInterface = mock(ExifInterface.class);
+		when(exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)).thenReturn(ExifInterface.ORIENTATION_ROTATE_90);
+		assertEquals(90f, FileIO.getBitmapOrientation(exifInterface), 0);
+		when(exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)).thenReturn(ExifInterface.ORIENTATION_ROTATE_180);
+		assertEquals(180f, FileIO.getBitmapOrientation(exifInterface), 0);
+		when(exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)).thenReturn(ExifInterface.ORIENTATION_ROTATE_270);
+		assertEquals(270f, FileIO.getBitmapOrientation(exifInterface), 0);
+		when(exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)).thenReturn(ExifInterface.ORIENTATION_NORMAL);
+		assertEquals(0f, FileIO.getBitmapOrientation(exifInterface), 0);
+	}
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -29,6 +29,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Matrix;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -47,7 +48,9 @@ import java.util.Locale;
 import java.util.Objects;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.core.content.FileProvider;
+import androidx.exifinterface.media.ExifInterface;
 
 public final class FileIO {
 	public static String filename = "image";
@@ -185,14 +188,84 @@ public final class FileIO {
 
 	private static Bitmap decodeBitmapFromUri(ContentResolver resolver, @NonNull Uri uri, BitmapFactory.Options options) throws IOException {
 		InputStream inputStream = resolver.openInputStream(uri);
+		Bitmap bitmap;
+		float angle;
 		if (inputStream == null) {
 			throw new IOException("Can't open input stream");
 		}
 		try {
-			return BitmapFactory.decodeStream(inputStream, null, options);
+			bitmap = BitmapFactory.decodeStream(inputStream, null, options);
+			if (options.inJustDecodeBounds) {
+				return bitmap;
+			}
+
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+				angle = getBitmapOrientationFromInputStream(resolver, uri);
+			} else {
+				angle = getBitmapOrientationFromUri(uri);
+			}
+
+			return getOrientedBitmap(bitmap, angle);
 		} finally {
 			inputStream.close();
 		}
+	}
+
+	@RequiresApi(api = Build.VERSION_CODES.N)
+	private static float getBitmapOrientationFromInputStream(ContentResolver resolver, @NonNull Uri uri) throws IOException {
+		InputStream inputStream = resolver.openInputStream(uri);
+		if (inputStream == null) {
+			return 0f;
+		}
+
+		try {
+			ExifInterface exifInterface = new ExifInterface(inputStream);
+			return getBitmapOrientation(exifInterface);
+		} finally {
+			inputStream.close();
+		}
+	}
+
+	private static float getBitmapOrientationFromUri(@NonNull Uri uri) throws IOException {
+		ExifInterface exifInterface = new ExifInterface(uri.getPath());
+		return getBitmapOrientation(exifInterface);
+	}
+
+	public static Bitmap getOrientedBitmap(Bitmap bitmap, float angle) {
+		if (bitmap == null) {
+			return null;
+		}
+
+		Matrix matrix = new Matrix();
+		matrix.postRotate(angle);
+		Bitmap rotatedBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+
+		bitmap.recycle();
+		bitmap = null;
+
+		return rotatedBitmap;
+	}
+
+	public static float getBitmapOrientation(ExifInterface exifInterface) {
+		if (exifInterface == null) {
+			return 0f;
+		}
+
+		int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+		float angle = 0;
+		switch (orientation) {
+			case ExifInterface.ORIENTATION_ROTATE_90:
+				angle = 90f;
+				break;
+			case ExifInterface.ORIENTATION_ROTATE_180:
+				angle = 180f;
+				break;
+			case ExifInterface.ORIENTATION_ROTATE_270:
+				angle = 270f;
+				break;
+		}
+
+		return angle;
 	}
 
 	public static void parseFileName(Uri uri, ContentResolver resolver) {


### PR DESCRIPTION
Ticket Solve: [https://jira.catrob.at/browse/PAINTROID-223](https://jira.catrob.at/browse/PAINTROID-223)
* Used ExifInterface to get orientation flag and rotated bitmap accordingly
* Created test for the same  

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
