### PR TITLE
Maintenance: aar instead of bintray

### DIFF
--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -120,7 +120,7 @@ pipeline {
                             ./gradlew publishToMavenLocal
                     '''
                 }
-                archiveArtifacts artifacts: '**/*.aar'
+                archiveArtifacts artifacts: '**/*-release.aar'
             }
         }
     }

--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -96,33 +96,31 @@ pipeline {
             }
         }
 
-        stage('Approve upload to bintray.com') {
+        stage('Approve generation of AAR file') {
             options {
                 timeout(time: 60, unit: 'MINUTES')
             }
             steps {
                 script {
-                    env.APPROVE_UPLOAD_AAR = input message: 'User input required',
-                            parameters: [choice(name: 'Upload', choices: 'no\nyes',
-                                    description: 'Do you want to upload the AAR files to bintray.com?')]
+                    env.APPROVE_AAR = input message: 'User input required',
+                            parameters: [choice(name: 'Generate', choices: 'no\nyes',
+                                    description: 'Do you want to generate the AAR file?')]
                 }
             }
         }
 
-        stage('Bintray upload') {
+        stage('AAR file') {
             when {
-                environment name: 'APPROVE_UPLOAD_AAR', value: 'yes'
+                environment name: 'APPROVE_AAR', value: 'yes'
             }
             steps {
                 script {
                     sh '''
                             set +x
-                            ./gradlew bintrayUpload \
-                            -PbintrayUser=$bintrayUser \
-                            -PbintrayKey=$bintrayKey \
-                            -PdryRun=false
+                            ./gradlew publishToMavenLocal
                     '''
                 }
+                archiveArtifacts '**/paintroid-signedRelease.aar'
             }
         }
     }

--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -120,7 +120,7 @@ pipeline {
                             ./gradlew publishToMavenLocal
                     '''
                 }
-                archiveArtifacts '**/paintroid-signedRelease.aar'
+                archiveArtifacts artifacts: '**/*.aar'
             }
         }
     }


### PR DESCRIPTION
Bintray/jcenter was sunset. Uploads are not possible anymore since the end of March 2021: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Replacement: Generate aar library files via dedicated Paintroid release build stage, then rename and upload them to
https://github.com/Catrobat/Catroid/[..]/catroid/src/main/libs/ 
https://github.com/Catrobat/Catroid/blob/develop/catroid/src/main/libs/