### PR TITLE
PAINTROID-236 Frequent crash in kotlin.UninitializedPropertyAccessException

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ZoomableImageView.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ZoomableImageView.kt
@@ -210,22 +210,24 @@ class ZoomableImageView : AppCompatImageView, View.OnTouchListener, GestureDetec
         super.onDraw(canvas)
         canvas.setMatrix(mMatrix)
 
-        canvasRect.set(0, 0, mBitmap.width, mBitmap.height)
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            canvas.drawColor(backgroundSurfaceColor, PorterDuff.Mode.SRC)
-        } else {
-            canvas.apply {
-                save()
-                clipOutRect(canvasRect)
-                drawColor(backgroundSurfaceColor, PorterDuff.Mode.SRC)
-                restore()
+        if (this::mBitmap.isInitialized) {
+            canvasRect.set(0, 0, mBitmap.width, mBitmap.height)
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                canvas.drawColor(backgroundSurfaceColor, PorterDuff.Mode.SRC)
+            } else {
+                canvas.apply {
+                    save()
+                    clipOutRect(canvasRect)
+                    drawColor(backgroundSurfaceColor, PorterDuff.Mode.SRC)
+                    restore()
+                }
             }
-        }
 
-        canvas.apply {
-            drawRect(canvasRect, checkeredPattern)
-            drawRect(canvasRect, boarderPaint)
-            drawBitmap(mBitmap, 0f, 0f, null)
+            canvas.apply {
+                drawRect(canvasRect, checkeredPattern)
+                drawRect(canvasRect, boarderPaint)
+                drawBitmap(mBitmap, 0f, 0f, null)
+            }
         }
     }
 


### PR DESCRIPTION
Fixed crash in ZoomableImageView.kt file due to kotlin.UninitializedPropertyAccessException.

https://jira.catrob.at/browse/PAINTROID-236

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
