### PR TITLE
PAINTROID-237 fixed ActivityNotFound when rating the app

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -22,6 +22,7 @@ package org.catrobat.paintroid.ui;
 import android.annotation.SuppressLint;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -181,7 +182,10 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 		} catch (ActivityNotFoundException e) {
 			Uri uriNoPlayStore = Uri.parse("http://play.google.com/store/apps/details?id=" + applicationId);
 			Intent noPlayStoreInstalled = new Intent(Intent.ACTION_VIEW, uriNoPlayStore);
-			mainActivity.startActivity(noPlayStoreInstalled);
+			ActivityInfo activityInfo = noPlayStoreInstalled.resolveActivityInfo(mainActivity.getPackageManager(), noPlayStoreInstalled.getFlags());
+			if (activityInfo.exported) {
+				mainActivity.startActivity(noPlayStoreInstalled);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixed ActivityNotFoundException when the user tries to rate this app but no app is registered for handling the intent.

https://jira.catrob.at/browse/PAINTROID-237

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
