### PR TITLE
PAINTROID-246 Feedback on where file was saved should not be shown in detail when handing back looks from Paintroid to Catroid

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
@@ -332,7 +332,9 @@ public class MenuFileActivityIntegrationTest {
 		onView(withText(R.string.save_button_text)).perform(click());
 
 		assertNotNull(activity.model.getSavedPictureUri());
-		assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		if (!activity.model.isOpenedFromCatroid()) {
+			assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		}
 
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());
 	}
@@ -358,7 +360,9 @@ public class MenuFileActivityIntegrationTest {
 		onView(withText(R.string.save_button_text)).perform(click());
 
 		assertNotNull(activity.model.getSavedPictureUri());
-		assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		if (!activity.model.isOpenedFromCatroid()) {
+			assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		}
 
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());
 
@@ -385,7 +389,9 @@ public class MenuFileActivityIntegrationTest {
 		assertNotSame("Changes to saved", oldFile, newFile);
 
 		assertNotNull(activity.model.getSavedPictureUri());
-		assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		if (!activity.model.isOpenedFromCatroid()) {
+			assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		}
 
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -875,9 +875,17 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		}
 
 		if (saveAsCopy) {
-			navigator.showToast(context.getString(R.string.copy) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			if (model.isOpenedFromCatroid()) {
+				navigator.showToast(R.string.copy, Toast.LENGTH_LONG);
+			} else {
+				navigator.showToast(context.getString(R.string.copy_to) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			}
 		} else {
-			navigator.showToast(context.getString(R.string.saved) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			if (model.isOpenedFromCatroid()) {
+				navigator.showToast(R.string.saved, Toast.LENGTH_LONG);
+			} else {
+				navigator.showToast(context.getString(R.string.saved_to) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			}
 			model.setSavedPictureUri(uri);
 			model.setSaved(true);
 		}

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -94,8 +94,10 @@
     <string name="menu_rate_us">Rate us!</string>
     <string name="menu_export">Export</string>
     <string name="menu_feedback">Feedback</string>
-    <string name="saved">Image saved to\n</string>
-    <string name="copy">Copy saved to\n</string>
+    <string name="saved_to">Image saved to\n</string>
+    <string name="saved">Image saved</string>
+    <string name="copy_to">Copy saved to\n</string>
+    <string name="copy">Copy saved</string>
     <string name="menu_quit">Quit</string>
     <string name="save_button_text">Save</string>
     <string name="discard_button_text">Discard</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -1324,9 +1324,12 @@ public class MainActivityPresenterTest {
 
 		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false);
 
-		String path = MainActivityPresenter.getPathFromUri(context, uri);
-
-		verify(navigator).showToast(context.getString(R.string.saved) + path, Toast.LENGTH_LONG);
+		if (!model.isOpenedFromCatroid()) {
+			String path = MainActivityPresenter.getPathFromUri(context, uri);
+			verify(navigator).showToast(context.getString(R.string.saved_to) + path, Toast.LENGTH_LONG);
+		} else {
+			verify(navigator).showToast(R.string.saved, Toast.LENGTH_LONG);
+		}
 	}
 
 	@Test
@@ -1345,9 +1348,12 @@ public class MainActivityPresenterTest {
 
 		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, true);
 
-		String path = MainActivityPresenter.getPathFromUri(context, uri);
-
-		verify(navigator).showToast(context.getString(R.string.copy) + path, Toast.LENGTH_LONG);
+		if (!model.isOpenedFromCatroid()) {
+			String path = MainActivityPresenter.getPathFromUri(context, uri);
+			verify(navigator).showToast(context.getString(R.string.copy_to) + path, Toast.LENGTH_LONG);
+		} else {
+			verify(navigator).showToast(R.string.copy, Toast.LENGTH_LONG);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Where file was saved is now not shown when when handing back looks from Paintroid to Catroid.

https://jira.catrob.at/browse/PAINTROID-246

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
