### PR TITLE
PAINTROID-246 Where file was saved not shown when opened from Catroid

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.java
@@ -332,7 +332,9 @@ public class MenuFileActivityIntegrationTest {
 		onView(withText(R.string.save_button_text)).perform(click());
 
 		assertNotNull(activity.model.getSavedPictureUri());
-		assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		if (!activity.model.isOpenedFromCatroid()) {
+			assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		}
 
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());
 	}
@@ -358,7 +360,9 @@ public class MenuFileActivityIntegrationTest {
 		onView(withText(R.string.save_button_text)).perform(click());
 
 		assertNotNull(activity.model.getSavedPictureUri());
-		assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		if (!activity.model.isOpenedFromCatroid()) {
+			assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		}
 
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());
 
@@ -385,7 +389,9 @@ public class MenuFileActivityIntegrationTest {
 		assertNotSame("Changes to saved", oldFile, newFile);
 
 		assertNotNull(activity.model.getSavedPictureUri());
-		assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		if (!activity.model.isOpenedFromCatroid()) {
+			assertNotSame("", MainActivityPresenter.getPathFromUri(this.activity, activity.model.getSavedPictureUri()));
+		}
 
 		addUriToDeletionFileList(activity.model.getSavedPictureUri());
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.java
@@ -59,7 +59,7 @@ public interface MainActivityContracts {
 
 		void showFeedbackDialog();
 
-		void showOverwriteDialog(int permissionCode);
+		void showOverwriteDialog(int permissionCode, boolean isExport);
 
 		void showPngInformationDialog();
 
@@ -192,7 +192,7 @@ public interface MainActivityContracts {
 
 		void showFeedbackDialog();
 
-		void showOverwriteDialog(int permissionCode);
+		void showOverwriteDialog(int permissionCode, boolean isExport);
 
 		void showPngInformationDialog();
 
@@ -204,7 +204,7 @@ public interface MainActivityContracts {
 
 		void onNewImage();
 
-		void switchBetweenVersions(int requestCode);
+		void switchBetweenVersions(int requestCode, boolean isExport);
 
 		void handleActivityResult(int requestCode, int resultCode, Intent data);
 
@@ -214,7 +214,7 @@ public interface MainActivityContracts {
 
 		void saveImageConfirmClicked(int requestCode, Uri uri);
 
-		void saveCopyConfirmClicked(int requestCode);
+		void saveCopyConfirmClicked(int requestCode, boolean isExport);
 
 		void undoClicked();
 
@@ -292,7 +292,7 @@ public interface MainActivityContracts {
 	}
 
 	interface Interactor {
-		void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace);
+		void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, boolean isExport);
 
 		void createFile(CreateFileAsync.CreateFileCallback callback, int requestCode, @Nullable String filename);
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/OverwriteDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/OverwriteDialog.java
@@ -13,12 +13,14 @@ import androidx.appcompat.app.AlertDialog;
 
 public class OverwriteDialog extends MainActivityDialogFragment {
 	private int permission;
+	private boolean isExport;
 
-	public static OverwriteDialog newInstance(int permissionCode) {
+	public static OverwriteDialog newInstance(int permissionCode, boolean isExport) {
 		OverwriteDialog dialog = new OverwriteDialog();
 		Bundle bundle = new Bundle();
 
 		bundle.putInt("permission", permissionCode);
+		bundle.putBoolean("isExport", isExport);
 		dialog.setArguments(bundle);
 
 		return dialog;
@@ -29,6 +31,7 @@ public class OverwriteDialog extends MainActivityDialogFragment {
 		super.onCreate(savedInstanceState);
 		Bundle arguments = getArguments();
 		permission = arguments.getInt("permission");
+		isExport = arguments.getBoolean("isExport");
 	}
 
 	@NonNull
@@ -42,7 +45,7 @@ public class OverwriteDialog extends MainActivityDialogFragment {
 				.setPositiveButton(R.string.overwrite_button_text, new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
-						getPresenter().switchBetweenVersions(permission);
+						getPresenter().switchBetweenVersions(permission, isExport);
 						dismiss();
 					}
 				})

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.java
@@ -60,8 +60,9 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 
 	private int permission;
 	private String setName;
+	private Boolean isExport;
 
-	public static SaveInformationDialog newInstance(int permissionCode, int imageNumber, boolean isStandard) {
+	public static SaveInformationDialog newInstance(int permissionCode, int imageNumber, boolean isStandard, boolean isExport) {
 		if (isStandard) {
 			FileIO.isCatrobatImage = false;
 			FileIO.filename = "image";
@@ -79,6 +80,7 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 		}
 
 		bundle.putInt("permission", permissionCode);
+		bundle.putBoolean("isExport", isExport);
 		dialog.setArguments(bundle);
 
 		return dialog;
@@ -90,6 +92,7 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 		Bundle arguments = getArguments();
 		permission = arguments.getInt("permission");
 		setName = arguments.getString("setName");
+		isExport = arguments.getBoolean("isExport");
 	}
 
 	@Override
@@ -126,9 +129,9 @@ public class SaveInformationDialog extends MainActivityDialogFragment implements
 				FileIO.filename = imageName.getText().toString();
 
 				if (permission != PERMISSION_EXTERNAL_STORAGE_SAVE_COPY && FileIO.checkIfDifferentFile(FileIO.getDefaultFileName()) != Constants.IS_NO_FILE) {
-					getPresenter().showOverwriteDialog(permission);
+					getPresenter().showOverwriteDialog(permission, isExport);
 				} else {
-					getPresenter().switchBetweenVersions(permission);
+					getPresenter().switchBetweenVersions(permission, isExport);
 				}
 
 				dismiss();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImageAsync.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImageAsync.kt
@@ -28,7 +28,7 @@ import org.catrobat.paintroid.tools.Workspace
 import java.io.IOException
 import java.lang.ref.WeakReference
 
-class SaveImageAsync(activity: SaveImageCallback, private val requestCode: Int, workspace: Workspace, uri: Uri?, saveAsCopy: Boolean) : AsyncTask<Void?, Void?, Uri?>() {
+class SaveImageAsync(activity: SaveImageCallback, private val requestCode: Int, workspace: Workspace, uri: Uri?, saveAsCopy: Boolean, val isExport: Boolean = false) : AsyncTask<Void?, Void?, Uri?>() {
 	private val callbackRef: WeakReference<SaveImageCallback> = WeakReference(activity)
 	private var uri: Uri?
 	private val saveAsCopy: Boolean
@@ -106,13 +106,13 @@ class SaveImageAsync(activity: SaveImageCallback, private val requestCode: Int, 
 	override fun onPostExecute(uri: Uri?) {
 		val callback = callbackRef.get()
 		if (callback != null && !callback.isFinishing) {
-			callback.onSaveImagePostExecute(requestCode, uri, saveAsCopy)
+			callback.onSaveImagePostExecute(requestCode, uri, saveAsCopy, isExport)
 		}
 	}
 
 	interface SaveImageCallback {
 		fun onSaveImagePreExecute(requestCode: Int)
-		fun onSaveImagePostExecute(requestCode: Int, uri: Uri?, saveAsCopy: Boolean)
+		fun onSaveImagePostExecute(requestCode: Int, uri: Uri?, saveAsCopy: Boolean, isExport: Boolean = false)
 		val contentResolver: ContentResolver?
 		val isFinishing: Boolean
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -283,8 +283,8 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	}
 
 	@Override
-	public void showOverwriteDialog(int permissionCode) {
-		navigator.showOverwriteDialog(permissionCode);
+	public void showOverwriteDialog(int permissionCode, boolean isExport) {
+		navigator.showOverwriteDialog(permissionCode, isExport);
 	}
 
 	@Override
@@ -327,8 +327,12 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		commandManager.addCommand(commandFactory.createResetCommand());
 	}
 
-	@Override
 	public void switchBetweenVersions(@PermissionRequestCode int requestCode) {
+		switchBetweenVersions(requestCode, false);
+	}
+
+	@Override
+	public void switchBetweenVersions(@PermissionRequestCode int requestCode, boolean isExport) {
 		if (navigator.isSdkAboveOrEqualM()) {
 			switch (requestCode) {
 				case PERMISSION_REQUEST_CODE_LOAD_PICTURE:
@@ -340,7 +344,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 					showLikeUsDialogIfFirstTimeSave();
 					break;
 				case PERMISSION_EXTERNAL_STORAGE_SAVE_COPY:
-					saveCopyConfirmClicked(SAVE_IMAGE_DEFAULT);
+					saveCopyConfirmClicked(SAVE_IMAGE_DEFAULT, isExport);
 					checkforDefaultFilename();
 					break;
 				case PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW:
@@ -508,9 +512,13 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		interactor.saveImage(this, requestCode, workspace, uri);
 	}
 
-	@Override
 	public void saveCopyConfirmClicked(int requestCode) {
-		interactor.saveCopy(this, requestCode, workspace);
+		saveCopyConfirmClicked(requestCode, false);
+	}
+
+	@Override
+	public void saveCopyConfirmClicked(int requestCode, boolean isExport) {
+		interactor.saveCopy(this, requestCode, workspace, isExport);
 	}
 
 	@Override
@@ -870,7 +878,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 	}
 
 	@Override
-	public void onSaveImagePostExecute(@SaveImageRequestCode int requestCode, Uri uri, boolean saveAsCopy) {
+	public void onSaveImagePostExecute(@SaveImageRequestCode int requestCode, Uri uri, boolean saveAsCopy, boolean isExport) {
 		navigator.dismissIndeterminateProgressDialog();
 
 		if (uri == null) {
@@ -879,9 +887,17 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		}
 
 		if (saveAsCopy) {
-			navigator.showToast(context.getString(R.string.copy) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			if (model.isOpenedFromCatroid() && !isExport) {
+				navigator.showToast(R.string.copy, Toast.LENGTH_LONG);
+			} else {
+				navigator.showToast(context.getString(R.string.copy_to) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			}
 		} else {
-			navigator.showToast(context.getString(R.string.saved) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			if (model.isOpenedFromCatroid() && !isExport) {
+				navigator.showToast(R.string.saved, Toast.LENGTH_LONG);
+			} else {
+				navigator.showToast(context.getString(R.string.saved_to) + getPathFromUri(fileActivity, uri), Toast.LENGTH_LONG);
+			}
 			model.setSavedPictureUri(uri);
 			model.setSaved(true);
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
@@ -31,8 +31,8 @@ import org.catrobat.paintroid.tools.Workspace;
 public class MainActivityInteractor implements MainActivityContracts.Interactor {
 
 	@Override
-	public void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace) {
-		new SaveImageAsync(callback, requestCode, workspace, null, true).execute();
+	public void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, boolean isExport) {
+		new SaveImageAsync(callback, requestCode, workspace, null, true, isExport).execute();
 	}
 
 	@Override
@@ -42,7 +42,7 @@ public class MainActivityInteractor implements MainActivityContracts.Interactor 
 
 	@Override
 	public void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, Uri uri) {
-		new SaveImageAsync(callback, requestCode, workspace, uri, false).execute();
+		new SaveImageAsync(callback, requestCode, workspace, uri, false, false).execute();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -247,8 +247,8 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 	}
 
 	@Override
-	public void showOverwriteDialog(int permissionCode) {
-		OverwriteDialog overwriteDialog = OverwriteDialog.newInstance(permissionCode);
+	public void showOverwriteDialog(int permissionCode, boolean isExport) {
+		OverwriteDialog overwriteDialog = OverwriteDialog.newInstance(permissionCode, isExport);
 		overwriteDialog.show(mainActivity.getSupportFragmentManager(), Constants.OVERWRITE_INFORMATION_DIALOG_TAG);
 	}
 
@@ -423,7 +423,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 
 			FileIO.catroidFlag = true;
 			FileIO.isCatrobatImage = false;
-			mainActivity.getPresenter().switchBetweenVersions(permissionCode);
+			mainActivity.getPresenter().switchBetweenVersions(permissionCode, isExport);
 			return;
 		}
 
@@ -432,7 +432,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 			isStandard = true;
 		}
 
-		SaveInformationDialog saveInfodialog = SaveInformationDialog.newInstance(permissionCode, imageNumber, isStandard);
+		SaveInformationDialog saveInfodialog = SaveInformationDialog.newInstance(permissionCode, imageNumber, isStandard, isExport);
 		saveInfodialog.show(mainActivity.getSupportFragmentManager(), Constants.SAVE_INFORMATION_DIALOG_TAG);
 	}
 

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -94,8 +94,10 @@
     <string name="menu_rate_us">Rate us!</string>
     <string name="menu_export">Export</string>
     <string name="menu_feedback">Feedback</string>
-    <string name="saved">Image saved to\n</string>
-    <string name="copy">Copy saved to\n</string>
+    <string name="saved_to">Image saved to\n</string>
+    <string name="saved">Image saved</string>
+    <string name="copy_to">Copy saved to\n</string>
+    <string name="copy">Copy saved</string>
     <string name="menu_quit">Quit</string>
     <string name="save_button_text">Save</string>
     <string name="discard_button_text">Discard</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -259,7 +259,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, false);
 		verifyNoMoreInteractions(interactor);
 	}
 
@@ -489,14 +489,14 @@ public class MainActivityPresenterTest {
 	public void testSaveCopyConfirmCLickedThenSaveImage() {
 		presenter.saveCopyConfirmClicked(0);
 
-		verify(interactor).saveCopy(presenter, 0, workspace);
+		verify(interactor).saveCopy(presenter, 0, workspace, false);
 	}
 
 	@Test
 	public void testSaveCopyConfirmClickedThenUseRequestCode() {
 		presenter.saveCopyConfirmClicked(-1);
 
-		verify(interactor).saveCopy(presenter, -1, workspace);
+		verify(interactor).saveCopy(presenter, -1, workspace, false);
 	}
 
 	@Test
@@ -925,7 +925,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnSaveImagePostExecuteWhenFailedThenShowDialog() {
-		presenter.onSaveImagePostExecute(0, null, false);
+		presenter.onSaveImagePostExecute(0, null, false, false);
 
 		verify(navigator).showSaveErrorDialog();
 	}
@@ -1000,7 +1000,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveCopy(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace));
+		verify(interactor).saveCopy(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace), eq(false));
 	}
 
 	@Test
@@ -1174,7 +1174,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, false);
 	}
 
 	@Test
@@ -1313,7 +1313,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testOnSaveImagePostExecuteThenDismissProgressDialog() {
-		presenter.onSaveImagePostExecute(0, null, false);
+		presenter.onSaveImagePostExecute(0, null, false, false);
 
 		verify(navigator).dismissIndeterminateProgressDialog();
 	}
@@ -1322,18 +1322,21 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenNotSavedAsCopyThenShowSaveToast() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false, false);
 
-		String path = MainActivityPresenter.getPathFromUri(context, uri);
-
-		verify(navigator).showToast(context.getString(R.string.saved) + path, Toast.LENGTH_LONG);
+		if (!model.isOpenedFromCatroid()) {
+			String path = MainActivityPresenter.getPathFromUri(context, uri);
+			verify(navigator).showToast(context.getString(R.string.saved_to) + path, Toast.LENGTH_LONG);
+		} else {
+			verify(navigator).showToast(R.string.saved, Toast.LENGTH_LONG);
+		}
 	}
 
 	@Test
 	public void testOnSaveImagePostExecuteWhenNotSavedAsCopyThenSetModelUri() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false, false);
 
 		verify(model).setSavedPictureUri(uri);
 		verify(model).setSaved(true);
@@ -1343,18 +1346,21 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenSavedAsCopyThenShowCopyToast() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, true);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, true, false);
 
-		String path = MainActivityPresenter.getPathFromUri(context, uri);
-
-		verify(navigator).showToast(context.getString(R.string.copy) + path, Toast.LENGTH_LONG);
+		if (!model.isOpenedFromCatroid()) {
+			String path = MainActivityPresenter.getPathFromUri(context, uri);
+			verify(navigator).showToast(context.getString(R.string.copy_to) + path, Toast.LENGTH_LONG);
+		} else {
+			verify(navigator).showToast(R.string.copy, Toast.LENGTH_LONG);
+		}
 	}
 
 	@Test
 	public void testOnSaveImagePostExecuteWhenSavedAsCopyThenDoNotTouchModel() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, true);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, true, false);
 
 		verify(model, never()).setSavedPictureUri(any(Uri.class));
 		verify(model, never()).setCameraImageUri(any(Uri.class));
@@ -1368,7 +1374,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenSavedThenBroadcastToPictureGallery() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false, false);
 
 		verify(navigator).broadcastAddPictureToGallery(uri);
 	}
@@ -1377,7 +1383,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenSavedAsCopyThenBroadcastToPictureGallery() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, true);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, true, false);
 
 		verify(navigator).broadcastAddPictureToGallery(uri);
 	}
@@ -1387,7 +1393,7 @@ public class MainActivityPresenterTest {
 		Uri uri = mock(Uri.class);
 		when(model.isOpenedFromCatroid()).thenReturn(true);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false, false);
 
 		verify(navigator, never()).broadcastAddPictureToGallery(uri);
 	}
@@ -1397,7 +1403,7 @@ public class MainActivityPresenterTest {
 		Uri uri = mock(Uri.class);
 		when(model.isOpenedFromCatroid()).thenReturn(true);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, true);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, true, false);
 
 		verify(navigator).broadcastAddPictureToGallery(uri);
 	}
@@ -1412,7 +1418,7 @@ public class MainActivityPresenterTest {
 		Command command = mock(Command.class);
 		when(commandFactory.createInitCommand(300, 500)).thenReturn(command);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_NEW_EMPTY, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_NEW_EMPTY, uri, false, false);
 
 		verify(commandManager).setInitialStateCommand(command);
 		verify(commandManager).reset();
@@ -1422,7 +1428,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenDefaultThenDoNotShowDialog() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false, false);
 
 		verify(navigator, never()).startLoadImageActivity(anyInt());
 		verify(navigator, never()).returnToPocketCode(anyString());
@@ -1433,7 +1439,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenFinishThenFinishActivity() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false, false);
 
 		verify(navigator).finishActivity();
 	}
@@ -1442,7 +1448,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenLoadThenStartActivity() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_LOAD_NEW, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_LOAD_NEW, uri, false, false);
 
 		verify(navigator).startLoadImageActivity(REQUEST_CODE_LOAD_PICTURE);
 	}
@@ -1453,7 +1459,7 @@ public class MainActivityPresenterTest {
 		when(uri.getPath()).thenReturn("testPath");
 		when(model.isOpenedFromCatroid()).thenReturn(true);
 
-		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false);
+		presenter.onSaveImagePostExecute(SAVE_IMAGE_FINISH, uri, false, false);
 
 		verify(navigator).returnToPocketCode("testPath");
 	}
@@ -1462,7 +1468,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteWhenInvalidRequestThenThrowException() {
 		Uri uri = mock(Uri.class);
 
-		presenter.onSaveImagePostExecute(0, uri, false);
+		presenter.onSaveImagePostExecute(0, uri, false, false);
 	}
 
 	@Test


### PR DESCRIPTION
Where file was saved is now not shown when when handing back looks from Paintroid to Catroid.

https://jira.catrob.at/browse/PAINTROID-246

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
