### PR TITLE
PAINTROID-250 Crash when using the "Import image" tool without file system access permission on Android 6.0

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/common/MainActivityConstants.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/common/MainActivityConstants.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -46,6 +46,7 @@ public final class MainActivityConstants {
 	public static final int PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY = 4;
 	public static final int PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH = 5;
 	public static final int PERMISSION_REQUEST_CODE_LOAD_PICTURE = 6;
+	public static final int PERMISSION_REQUEST_CODE_IMPORT_PICTURE = 7;
 
 	public static final int RESULT_INTRO_MW_NOT_SUPPORTED = 10;
 
@@ -74,7 +75,8 @@ public final class MainActivityConstants {
 			PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW,
 			PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY,
 			PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH,
-			PERMISSION_REQUEST_CODE_LOAD_PICTURE})
+			PERMISSION_REQUEST_CODE_LOAD_PICTURE,
+			PERMISSION_REQUEST_CODE_IMPORT_PICTURE})
 	@Retention(RetentionPolicy.SOURCE)
 	public @interface PermissionRequestCode {
 	}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -85,6 +85,7 @@ import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXT
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW;
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY;
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_EXTERNAL_STORAGE_SAVE_COPY;
+import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_REQUEST_CODE_IMPORT_PICTURE;
 import static org.catrobat.paintroid.common.MainActivityConstants.PERMISSION_REQUEST_CODE_LOAD_PICTURE;
 import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_IMPORTPNG;
 import static org.catrobat.paintroid.common.MainActivityConstants.REQUEST_CODE_INTRO;
@@ -341,6 +342,8 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 			switch (requestCode) {
 				case PERMISSION_REQUEST_CODE_LOAD_PICTURE:
 					break;
+				case PERMISSION_REQUEST_CODE_IMPORT_PICTURE:
+					break;
 				case PERMISSION_EXTERNAL_STORAGE_SAVE:
 					checkforDefaultFilename();
 					showLikeUsDialogIfFirstTimeSave();
@@ -469,6 +472,9 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 						} else {
 							navigator.showSaveBeforeLoadImageDialog();
 						}
+						break;
+					case PERMISSION_REQUEST_CODE_IMPORT_PICTURE:
+						navigator.startImportImageActivity(REQUEST_CODE_IMPORTPNG);
 						break;
 					default:
 						view.superHandleRequestPermissionsResult(requestCode, permissions, grantResults);
@@ -982,7 +988,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void importFromGalleryClicked() {
-		navigator.startImportImageActivity(REQUEST_CODE_IMPORTPNG);
+		switchBetweenVersions(PERMISSION_REQUEST_CODE_IMPORT_PICTURE);
 	}
 
 	@Override


### PR DESCRIPTION
Fixed crash when using import image tool without file system access permission on Android 6.0.

https://jira.catrob.at/browse/PAINTROID-250

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
