### PR TITLE
PAINTROID-252 nullptr bugfix in superHandleActivityResult

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MainActivityIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MainActivityIntegrationTest.java
@@ -19,20 +19,27 @@
 
 package org.catrobat.paintroid.test.espresso;
 
+import android.app.Activity;
 import android.content.Context;
 
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.contract.MainActivityContracts;
+import org.catrobat.paintroid.presenter.MainActivityPresenter;
 import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 
 import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
+import static org.mockito.Mockito.verify;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
@@ -44,6 +51,12 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class MainActivityIntegrationTest {
+
+	@Mock
+	private MainActivityContracts.MainView view;
+
+	@InjectMocks
+	private MainActivityPresenter presenter;
 
 	@Rule
 	public ActivityTestRule<MainActivity> launchActivityRule = new ActivityTestRule<>(MainActivity.class);
@@ -80,5 +93,13 @@ public class MainActivityIntegrationTest {
 
 		onView(withText(R.string.pocketpaint_menu_about))
 				.check(doesNotExist());
+	}
+
+	@Test
+	public void testHandleActivityResultWhenIntentIsNull() {
+		launchActivityRule.getActivity().onActivityResult(0, Activity.RESULT_OK, null);
+		MockitoAnnotations.initMocks(this);
+		presenter.handleActivityResult(0, Activity.RESULT_OK, null);
+		verify(view).superHandleActivityResult(0, Activity.RESULT_OK, null);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -406,7 +406,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         presenter.handleActivityResult(requestCode, resultCode, data)
     }
 
-    override fun superHandleActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
+    override fun superHandleActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
     }
 


### PR DESCRIPTION
Changed parameter `data` in `superHandleActivityResult()` to be nullable. 

https://jira.catrob.at/browse/PAINTROID-252

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
