### PR TITLE
PAINTROID-256 fixed NPE when image couldn't be decoded

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -153,25 +153,19 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             }
 
             if (receivedUri != null) {
-
-                if(mimeType.equals("application/zip") || mimeType.equals("application/octet-stream")){
-
-                    val returnValue : BitmapReturnValue = OpenRasterFileFormatConversion.importOraFile(contentResolver,receivedUri,applicationContext)
-                    if(returnValue.bitmap != null){
-                        commandManager.setInitialStateCommand(commandFactory.createInitCommand(returnValue.bitmap))
-                    }
-                    else{
-                        commandManager.setInitialStateCommand(commandFactory.createInitCommand(returnValue.bitmapList))
-                    }
-                }
-                else {
-                    try {
+                try {
+                    if (mimeType.equals("application/zip") || mimeType.equals("application/octet-stream")) {
+                        OpenRasterFileFormatConversion.importOraFile(contentResolver, receivedUri, applicationContext).bitmapList?.let { bitmapList ->
+                            commandManager.setInitialStateCommand(commandFactory.createInitCommand(bitmapList))
+                        }
+                    } else {
                         FileIO.filename = "image"
-                        val receivedBitmap = FileIO.getBitmapFromUri(contentResolver, receivedUri, applicationContext)
-                        commandManager.setInitialStateCommand(commandFactory.createInitCommand(receivedBitmap))
-                    } catch (e: IOException) {
-                        Log.e("Can not read", "Unable to retrieve Bitmap from Uri")
+                        FileIO.getBitmapFromUri(contentResolver, receivedUri, applicationContext)?.let { receivedBitmap ->
+                            commandManager.setInitialStateCommand(commandFactory.createInitCommand(receivedBitmap))
+                        }
                     }
+                } catch (e: IOException) {
+                    Log.e("Can not read", "Unable to retrieve Bitmap from Uri")
                 }
             }
             commandManager.reset()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
+org.gradle.jvmargs=-XX:MaxPermSize=1024m -Xmx4096m


### PR DESCRIPTION
`FileIO.getBitmapFromUri` might return null or throw `IOException`, also checked for null now.

There was also a bug from the ticket with register intent, when you open an octet-stream/binary file/zip file which is not in the ora file format. Therefore catched the potential `IOException` too, and `importOra()` always returns a `BitmapReturnValue` where the bitmap is null. 

I also increased the jvm heap size, since the statical analysis sometimes goes of of memory when doing the lint checks. 

https://jira.catrob.at/browse/PAINTROID-256

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
