### PR TITLE
Maintenance: Fix colorpicker CrowdIn integration

### DIFF
--- a/crowdin_colorpicker.yml
+++ b/crowdin_colorpicker.yml
@@ -21,13 +21,13 @@ files: [
   # Source files filter
   # e.g. "/resources/en/*.json"
   #
-  "source" : "/colorpicker/src/main/res/values/string.xml",
+  "source" : "/colorpicker/src/main/res/values/strings.xml",
 
   #
   # Where translations will be placed
   # e.g. "/resources/%two_letters_code%/%original_file_name%"
   #
-  "translation" : "/colorpicker/src/main/res/values-%android_code%/string.xml",
+  "translation" : "/colorpicker/src/main/res/values-%android_code%/strings.xml",
 
   #
   # Files or directories for ignore
@@ -39,7 +39,7 @@ files: [
   # The dest allows you to specify a file name in Crowdin
   # e.g. "/messages.json"
   #
-  "dest" : "/paintroid/colorpicker/string.xml",
+  "dest" : "/paintroid/colorpicker/strings.xml",
 
   #
   # File type


### PR DESCRIPTION
Fix incomplete string resource file names for colorpicker CrowdIn action:
- [x] string => strings
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
