### PR TITLE
PAINTROID-149 better image Better png compression (Research and implementation)

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     debugImplementation 'androidx.multidex:multidex:2.0.0'
 
     implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
-
+    implementation 'id.zelory:compressor:2.1.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.18.3'
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
@@ -27,6 +27,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.net.Uri;
+import android.util.Log;
 
 import org.catrobat.paintroid.FileIO;
 import org.catrobat.paintroid.MainActivity;
@@ -41,8 +42,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.UUID;
@@ -129,7 +128,7 @@ public class SaveCompressImageIntegrationTest {
 		try {
 			compressedBitmap = FileIO.getBitmapFromUri(activity.getContentResolver(), activity.model.getSavedPictureUri(), activity.getApplicationContext());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e("Can't read", "Cant read Bitmap from Uri");
 		}
 		Bitmap testBitmap = FileIO.getBitmapFromFile(testImageFile);
 		assertThat(compressedBitmap.getWidth(), is(equalTo(testBitmap.getWidth())));

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
@@ -41,6 +41,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.UUID;
@@ -123,8 +125,12 @@ public class SaveCompressImageIntegrationTest {
 		onData(allOf(is(instanceOf(String.class)), is("jpg"))).inRoot(isPlatformPopup()).perform(click());
 		onView(withText(R.string.save_button_text)).perform(click());
 
-		File compressedFile = new File(activity.model.getSavedPictureUri().getPath());
-		Bitmap compressedBitmap = FileIO.getBitmapFromFile(compressedFile);
+		Bitmap compressedBitmap = null;
+		try {
+			compressedBitmap = FileIO.getBitmapFromUri(activity.getContentResolver(), activity.model.getSavedPictureUri(), activity.getApplicationContext());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 		Bitmap testBitmap = FileIO.getBitmapFromFile(testImageFile);
 		assertThat(compressedBitmap.getWidth(), is(equalTo(testBitmap.getWidth())));
 		assertThat(compressedBitmap.getHeight(), is(equalTo(testBitmap.getHeight())));

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
@@ -1,0 +1,157 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.test.espresso;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.net.Uri;
+
+import org.catrobat.paintroid.FileIO;
+import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.UUID;
+
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.rule.ActivityTestRule;
+
+import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+public class SaveCompressImageIntegrationTest {
+
+	@Rule
+	public ActivityTestRule<MainActivity> activityTestRule = new IntentsTestRule<>(MainActivity.class);
+
+	@Rule
+	public ScreenshotOnFailRule screenshotOnFailRule = new ScreenshotOnFailRule();
+
+	private File testImageFile;
+	private static ArrayList<File> deletionFileList = null;
+	private MainActivity activity;
+
+	@Before
+	public void setUp() {
+		try {
+			activity = activityTestRule.getActivity();
+			testImageFile = File.createTempFile("PocketPaintTest", ".jpg");
+			deletionFileList = new ArrayList<>();
+			deletionFileList.add(testImageFile);
+			Bitmap bitmap = createTestBitmap();
+			OutputStream outputStream = new FileOutputStream(testImageFile);
+			assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream));
+			outputStream.close();
+		} catch (IOException e) {
+			throw new AssertionError("Could not create temp file", e);
+		}
+
+		Intent intent = new Intent();
+		intent.setData(Uri.fromFile(testImageFile));
+		Instrumentation.ActivityResult resultOK = new Instrumentation.ActivityResult(Activity.RESULT_OK, intent);
+		intending(hasAction(Intent.ACTION_GET_CONTENT)).respondWith(resultOK);
+	}
+
+	@After
+	public void tearDown() {
+		for (File file : deletionFileList) {
+			if (file != null && file.exists()) {
+				assertTrue(file.delete());
+			}
+		}
+	}
+
+	@Test
+	public void testSaveImage() {
+		String testName = UUID.randomUUID().toString();
+		onTopBarView()
+				.performOpenMoreOptions();
+		onView(withText(R.string.menu_load_image)).perform(click());
+
+		onTopBarView()
+				.performOpenMoreOptions();
+		onView(withText(R.string.menu_save_image)).perform(click());
+		onView(withId(R.id.pocketpaint_image_name_save_text)).perform(replaceText(testName));
+		onView(withId(R.id.pocketpaint_save_dialog_spinner)).perform(click());
+		onData(allOf(is(instanceOf(String.class)), is("jpg"))).inRoot(isPlatformPopup()).perform(click());
+		onView(withText(R.string.save_button_text)).perform(click());
+
+		File compressedFile = new File(activity.model.getSavedPictureUri().getPath());
+		Bitmap compressedBitmap = FileIO.getBitmapFromFile(compressedFile);
+		Bitmap testBitmap = FileIO.getBitmapFromFile(testImageFile);
+		assertThat(compressedBitmap.getWidth(), is(equalTo(testBitmap.getWidth())));
+		assertThat(compressedBitmap.getHeight(), is(equalTo(testBitmap.getHeight())));
+	}
+
+	private Bitmap createTestBitmap() {
+		Bitmap bitmap;
+		int width = 1080;
+		int height = 1920;
+		Bitmap.Config bitmapConfig = Bitmap.Config.ARGB_8888;
+		int bytesPerPixel = 4;
+
+		byte[] b = new byte[width * height * bytesPerPixel];
+		Random r = new Random();
+		r.setSeed(0);
+		r.nextBytes(b);
+		bitmap = Bitmap.createBitmap(width, height, bitmapConfig);
+		Canvas canvas = new Canvas(bitmap);
+		int byteIndex = 0;
+		Paint paint = new Paint();
+		for (int i = 0; i < height; i++) {
+			for (int j = 0; j < width; j++) {
+				int color = Color.argb(b[byteIndex++], b[byteIndex++], b[byteIndex++], b[byteIndex++]);
+				paint.setColor(color);
+				canvas.drawPoint(j, i, paint);
+			}
+		}
+		return bitmap;
+	}
+}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeWithImageTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/catroid/OpenedFromPocketCodeWithImageTest.java
@@ -53,6 +53,7 @@ import androidx.test.espresso.Espresso;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.GrantPermissionRule;
+import id.zelory.compressor.Compressor;
 
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
@@ -75,7 +76,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 public class OpenedFromPocketCodeWithImageTest {
 
 	private static final String IMAGE_NAME = "testFile";
-	private static final String IMAGE_TO_LOAD_NAME = "loadFile";
 
 	@Rule
 	public IntentsTestRule<MainActivity> launchActivityRule = new IntentsTestRule<>(MainActivity.class, false, true);
@@ -202,19 +202,30 @@ public class OpenedFromPocketCodeWithImageTest {
 		canvas.drawColor(Color.WHITE);
 		canvas.drawBitmap(bitmap, 0F, 0F, null);
 
-		File imageFile = new File(activity.getExternalFilesDir(null).getAbsolutePath(), IMAGE_TO_LOAD_NAME + ".jpg");
-		Uri imageUri = Uri.fromFile(imageFile);
+		File uncompressedImageFile = new File(activity.getExternalFilesDir(null).getAbsolutePath(), "uncompressed_" + IMAGE_NAME + ".jpg");
+
 		try {
-			OutputStream fos = activity.getContentResolver().openOutputStream(Objects.requireNonNull(imageUri));
-			assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, fos));
+			Uri uncompressedImageUri = Uri.fromFile(uncompressedImageFile);
+			OutputStream fos = activity.getContentResolver().openOutputStream(Objects.requireNonNull(uncompressedImageUri));
+			assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos));
 			assert fos != null;
 			fos.close();
 		} catch (IOException e) {
 			throw new AssertionError("Picture file could not be created.", e);
 		}
+		Compressor compressor = new Compressor(launchActivityRule.getActivity());
+		compressor.setCompressFormat(Bitmap.CompressFormat.JPEG);
+		compressor.setQuality(100);
+		compressor.setDestinationDirectoryPath(activity.getExternalFilesDir(null).getAbsolutePath() + "/Pictures");
+		deletionFileList.add(uncompressedImageFile);
+		try {
+			imageFile = compressor.compressToFile(uncompressedImageFile, IMAGE_NAME + ".png");
+		} catch (IOException e) {
+			throw new AssertionError("Test Picture file could not be created.", e);
+		}
 
 		deletionFileList.add(imageFile);
-		return imageUri;
+		return Uri.fromFile(imageFile);
 	}
 
 	private void verifyImageFile(long lastModifiedBefore, long fileSizeBefore) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/FileIOTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/FileIOTest.java
@@ -17,6 +17,7 @@ public class FileIOTest {
 
 	@Mock
 	Bitmap bitmap;
+
 	@Mock
 	ExifInterface exifInterface;
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -36,22 +36,27 @@ import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.content.FileProvider;
+import androidx.exifinterface.media.ExifInterface;
+
 import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.iotasks.BitmapReturnValue;
 import org.catrobat.paintroid.presenter.MainActivityPresenter;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Random;
+import java.util.UUID;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
-import androidx.core.content.FileProvider;
-import androidx.exifinterface.media.ExifInterface;
+import id.zelory.compressor.Compressor;
 
 import static org.catrobat.paintroid.common.Constants.MAX_LAYERS;
 
@@ -95,23 +100,60 @@ public final class FileIO {
 		}
 	}
 
-	public static Uri saveBitmapToUri(Uri uri, ContentResolver resolver, Bitmap bitmap) throws IOException {
-		OutputStream outputStream = resolver.openOutputStream(uri);
+	public static Uri saveBitmapToUri(Uri uri, ContentResolver resolver, Bitmap bitmap, Context context) throws IOException {
+		Random random = new Random();
+		random.setSeed(System.currentTimeMillis());
+		Uri cachedImageUri = saveBitmapToCache(bitmap, context, Long.toString(random.nextLong()));
+		File cachedFile = new File(MainActivityPresenter.getPathFromUri(context, cachedImageUri));
 
-		if (outputStream == null) {
-			throw new IllegalArgumentException("Can not open uri.");
-		}
 		try {
-			saveBitmapToStream(outputStream, bitmap);
+			if (!compress(context, cachedFile, uri)) {
+				throw new IOException("Can not compress image file.");
+			}
 		} finally {
-			outputStream.close();
+			if (cachedFile.exists()) {
+				cachedFile.delete();
+			}
 		}
-
 		return uri;
 	}
 
-	public static Uri saveBitmapToFile(String fileName, Bitmap bitmap, ContentResolver resolver) throws IOException {
-		OutputStream fos;
+	public static boolean compress(Context context, File fileToCompress, Uri destination) {
+		Compressor compressor = new Compressor(context);
+		compressor.setQuality(compressQuality);
+		compressor.setCompressFormat(compressFormat);
+		String tempFileName = "tmp";
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+			File compressed = null;
+			try {
+				File cachePath = new File(context.getCacheDir(), "images");
+				cachePath.mkdirs();
+				compressor.setDestinationDirectoryPath(cachePath.getPath());
+				compressed = compressor.compressToFile(fileToCompress, tempFileName + ending);
+				OutputStream os = context.getContentResolver().openOutputStream(destination);
+				copyStreams(new FileInputStream(compressed), os);
+				return true;
+			} catch (IOException e) {
+				Log.e("Can not compress", "Can not compress image file.", e);
+				return false;
+			} finally {
+				if (compressed != null && compressed.exists()) {
+					compressed.delete();
+				}
+			}
+		} else {
+			try {
+				compressor.setDestinationDirectoryPath(Objects.requireNonNull(new File(destination.getPath()).getParentFile()).getPath());
+				compressor.compressToFile(fileToCompress, destination.getLastPathSegment());
+				return true;
+			} catch (IOException e) {
+				Log.e("Can not compress", "Can not compress image file.", e);
+				return false;
+			}
+		}
+	}
+
+	public static Uri saveBitmapToFile(String fileName, Bitmap bitmap, ContentResolver resolver, Context context) throws IOException {
 		Uri imageUri;
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -121,47 +163,51 @@ public final class FileIO {
 			contentValues.put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES);
 
 			imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues);
-			fos = resolver.openOutputStream(Objects.requireNonNull(imageUri));
+			Uri cachedImageUri = saveBitmapToCache(bitmap, context, UUID.randomUUID().toString());
+			File cachedFile = new File(MainActivityPresenter.getPathFromUri(context, cachedImageUri));
 
 			try {
-				saveBitmapToStream(fos, bitmap);
-
-				Objects.requireNonNull(fos, "Can't create fileoutputstream!");
+				if (!compress(context, cachedFile, imageUri)) {
+					throw new IOException("Can not compress image file.");
+				}
 			} finally {
-				fos.close();
+				if (cachedFile.exists()) {
+					cachedFile.delete();
+				}
 			}
 		} else {
 			if (!(Constants.MEDIA_DIRECTORY.exists() || Constants.MEDIA_DIRECTORY.mkdirs())) {
 				throw new IOException("Can not create media directory.");
 			}
 
-			File file = new File(Constants.MEDIA_DIRECTORY, fileName);
-			OutputStream outputStream = new FileOutputStream(file);
-
+			imageUri = Uri.fromFile(new File(Constants.MEDIA_DIRECTORY, fileName));
+			Uri cachedImageUri = saveBitmapToCache(bitmap, context, UUID.randomUUID().toString());
+			File cachedFile = new File(MainActivityPresenter.getPathFromUri(context, cachedImageUri));
 			try {
-				saveBitmapToStream(outputStream, bitmap);
+				if (!compress(context, cachedFile, imageUri)) {
+					throw new IOException("Can not compress image file.");
+				}
 			} finally {
-				outputStream.close();
+				if (cachedFile.exists()) {
+					cachedFile.delete();
+				}
 			}
-
-			imageUri = Uri.fromFile(file);
 		}
-
 		return imageUri;
 	}
 
-	public static Uri saveBitmapToCache(Bitmap bitmap, MainActivity mainActivity) {
+	public static Uri saveBitmapToCache(Bitmap bitmap, Context context, String fileName) {
 		Uri uri = null;
 		try {
-			File cachePath = new File(mainActivity.getCacheDir(), "images");
+			File cachePath = new File(context.getCacheDir(), "images");
 			cachePath.mkdirs();
-			FileOutputStream stream = new FileOutputStream(cachePath + "/image.png");
+			FileOutputStream stream = new FileOutputStream(cachePath + "/" + fileName + ending);
 			saveBitmapToStream(stream, bitmap);
 			stream.close();
-			File imagePath = new File(mainActivity.getCacheDir(), "images");
-			File newFile = new File(imagePath, "image.png");
-			String fileProviderString = mainActivity.getApplicationContext().getPackageName() + ".fileprovider";
-			uri = FileProvider.getUriForFile(mainActivity.getApplicationContext(), fileProviderString, newFile);
+			File imagePath = new File(context.getCacheDir(), "images");
+			File newFile = new File(imagePath, fileName + ending);
+			String fileProviderString = context.getApplicationContext().getPackageName() + ".fileprovider";
+			uri = FileProvider.getUriForFile(context.getApplicationContext(), fileProviderString, newFile);
 		} catch (IOException e) {
 			Log.e("Can not write", "Can not write png to stream.", e);
 		}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.java
@@ -36,11 +36,6 @@ import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
-import androidx.core.content.FileProvider;
-import androidx.exifinterface.media.ExifInterface;
-
 import org.catrobat.paintroid.common.Constants;
 import org.catrobat.paintroid.iotasks.BitmapReturnValue;
 import org.catrobat.paintroid.presenter.MainActivityPresenter;
@@ -56,9 +51,14 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 
-import id.zelory.compressor.Compressor;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.content.FileProvider;
+import androidx.exifinterface.media.ExifInterface;
 
 import static org.catrobat.paintroid.common.Constants.MAX_LAYERS;
+
+import id.zelory.compressor.Compressor;
 
 public final class FileIO {
 	public static String filename = "image";

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
@@ -31,7 +31,6 @@ import org.catrobat.paintroid.common.MainActivityConstants.ActivityRequestCode
 import org.catrobat.paintroid.dialog.PermissionInfoDialog.PermissionType
 import org.catrobat.paintroid.iotasks.CreateFileAsync.CreateFileCallback
 import org.catrobat.paintroid.iotasks.LoadImageAsync.LoadImageCallback
-import org.catrobat.paintroid.iotasks.SaveImageAsync
 import org.catrobat.paintroid.iotasks.SaveImageAsync.SaveImageCallback
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
@@ -288,16 +287,16 @@ interface MainActivityContracts {
     }
 
     interface Interactor {
-        fun saveCopy(callback: SaveImageAsync.SaveImageAsync.SaveImageCallback, requestCode: Int, workspace: Workspace, context: Context)
+        fun saveCopy(callback: SaveImageCallback, requestCode: Int, workspace: Workspace, context: Context)
 
         fun createFile(callback: CreateFileCallback, requestCode: Int, filename: String)
 
         fun saveImage(
-                callback: SaveImageAsync.SaveImageAsync.SaveImageCallback,
-                requestCode: Int,
-                workspace: Workspace,
-                uri: Uri?,
-                context: Context
+            callback: SaveImageCallback,
+            requestCode: Int,
+            workspace: Workspace,
+            uri: Uri?,
+            context: Context
         )
 
         fun loadFile(

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
@@ -31,6 +31,7 @@ import org.catrobat.paintroid.common.MainActivityConstants.ActivityRequestCode
 import org.catrobat.paintroid.dialog.PermissionInfoDialog.PermissionType
 import org.catrobat.paintroid.iotasks.CreateFileAsync.CreateFileCallback
 import org.catrobat.paintroid.iotasks.LoadImageAsync.LoadImageCallback
+import org.catrobat.paintroid.iotasks.SaveImageAsync
 import org.catrobat.paintroid.iotasks.SaveImageAsync.SaveImageCallback
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
@@ -287,15 +288,16 @@ interface MainActivityContracts {
     }
 
     interface Interactor {
-        fun saveCopy(callback: SaveImageCallback, requestCode: Int, workspace: Workspace)
+        fun saveCopy(callback: SaveImageAsync.SaveImageAsync.SaveImageCallback, requestCode: Int, workspace: Workspace, context: Context)
 
         fun createFile(callback: CreateFileCallback, requestCode: Int, filename: String)
 
         fun saveImage(
-            callback: SaveImageCallback,
-            requestCode: Int,
-            workspace: Workspace,
-            uri: Uri?
+                callback: SaveImageAsync.SaveImageAsync.SaveImageCallback,
+                requestCode: Int,
+                workspace: Workspace,
+                uri: Uri?,
+                context: Context
         )
 
         fun loadFile(

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImageAsync.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImageAsync.kt
@@ -186,10 +186,10 @@ class SaveImageAsync(
         private val TAG = SaveImageAsync::class.java.simpleName
     }
 
-	init {
-		this.uri = uri
-		this.saveAsCopy = saveAsCopy
-		this.workspace = workspace
-		this.context = context
-	}
+    init {
+        this.uri = uri
+        this.saveAsCopy = saveAsCopy
+        this.workspace = workspace
+        this.context = context
+    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImageAsync.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImageAsync.kt
@@ -20,6 +20,7 @@ package org.catrobat.paintroid.iotasks
 
 import android.content.ContentResolver
 import android.graphics.Bitmap
+import android.content.Context
 import android.net.Uri
 import android.os.AsyncTask
 import android.util.Log
@@ -35,12 +36,14 @@ class SaveImageAsync(
     private val requestCode: Int,
     workspace: Workspace,
     uri: Uri?,
-    saveAsCopy: Boolean
+    saveAsCopy: Boolean,
+    context: Context
 ) : AsyncTask<Void?, Void?, Uri?>() {
     private val callbackRef: WeakReference<SaveImageCallback> = WeakReference(activity)
     private var uri: Uri?
     private val saveAsCopy: Boolean
     private val workspace: Workspace
+    private val context: Context
     override fun onPreExecute() {
         val callback = callbackRef.get()
         if (callback == null || callback.isFinishing) {
@@ -57,7 +60,7 @@ class SaveImageAsync(
         val fileName = FileIO.getDefaultFileName()
         val fileExistsValue = FileIO.checkIfDifferentFile(fileName)
         return if (uri == null) {
-            val imageUri = FileIO.saveBitmapToFile(fileName, bitmap, callback.contentResolver)
+            val imageUri = FileIO.saveBitmapToFile(fileName, bitmap, callback.contentResolver, context)
             if (FileIO.ending == ".png") {
                 FileIO.currentFileNamePng = fileName
                 FileIO.uriFilePng = imageUri
@@ -70,7 +73,7 @@ class SaveImageAsync(
             if (!FileIO.catroidFlag) {
                 setUriToFormatUri(fileExistsValue)
             }
-            FileIO.saveBitmapToUri(uri, callback.contentResolver, bitmap)
+            FileIO.saveBitmapToUri(uri, callback.contentResolver, bitmap, context)
         }
     }
 
@@ -183,9 +186,10 @@ class SaveImageAsync(
         private val TAG = SaveImageAsync::class.java.simpleName
     }
 
-    init {
-        this.uri = uri
-        this.saveAsCopy = saveAsCopy
-        this.workspace = workspace
-    }
+	init {
+		this.uri = uri
+		this.saveAsCopy = saveAsCopy
+		this.workspace = workspace
+		this.context = context
+	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -517,12 +517,12 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void saveImageConfirmClicked(int requestCode, Uri uri) {
-		interactor.saveImage(this, requestCode, workspace, uri);
+		interactor.saveImage(this, requestCode, workspace, uri, context);
 	}
 
 	@Override
 	public void saveCopyConfirmClicked(int requestCode) {
-		interactor.saveCopy(this, requestCode, workspace);
+		interactor.saveCopy(this, requestCode, workspace, context);
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.java
@@ -31,8 +31,8 @@ import org.catrobat.paintroid.tools.Workspace;
 public class MainActivityInteractor implements MainActivityContracts.Interactor {
 
 	@Override
-	public void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace) {
-		new SaveImageAsync(callback, requestCode, workspace, null, true).execute();
+	public void saveCopy(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, Context context) {
+		new SaveImageAsync(callback, requestCode, workspace, null, true, context).execute();
 	}
 
 	@Override
@@ -41,8 +41,8 @@ public class MainActivityInteractor implements MainActivityContracts.Interactor 
 	}
 
 	@Override
-	public void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, Uri uri) {
-		new SaveImageAsync(callback, requestCode, workspace, uri, false).execute();
+	public void saveImage(SaveImageAsync.SaveImageCallback callback, int requestCode, Workspace workspace, Uri uri, Context context) {
+		new SaveImageAsync(callback, requestCode, workspace, uri, false, context).execute();
 	}
 
 	@Override

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.java
@@ -214,7 +214,7 @@ public class MainActivityNavigator implements MainActivityContracts.Navigator {
 
 	@Override
 	public void startShareImageActivity(Bitmap bitmap) {
-		Uri uri = FileIO.saveBitmapToCache(bitmap, mainActivity);
+		Uri uri = FileIO.saveBitmapToCache(bitmap, mainActivity, "image");
 		if (uri != null) {
 			Intent shareIntent = new Intent();
 			shareIntent.putExtra(Intent.EXTRA_STREAM, uri);

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -259,7 +259,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, context);
 		verifyNoMoreInteractions(interactor);
 	}
 
@@ -272,7 +272,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, workspace, uri, context);
 
 		verifyNoMoreInteractions(interactor);
 	}
@@ -473,7 +473,7 @@ public class MainActivityPresenterTest {
 
 		presenter.saveImageConfirmClicked(0, uri);
 
-		verify(interactor).saveImage(presenter, 0, workspace, uri);
+		verify(interactor).saveImage(presenter, 0, workspace, uri, context);
 	}
 
 	@Test
@@ -482,21 +482,21 @@ public class MainActivityPresenterTest {
 
 		presenter.saveImageConfirmClicked(-1, uri);
 
-		verify(interactor).saveImage(presenter, -1, workspace, uri);
+		verify(interactor).saveImage(presenter, -1, workspace, uri, context);
 	}
 
 	@Test
 	public void testSaveCopyConfirmCLickedThenSaveImage() {
 		presenter.saveCopyConfirmClicked(0);
 
-		verify(interactor).saveCopy(presenter, 0, workspace);
+		verify(interactor).saveCopy(presenter, 0, workspace, context);
 	}
 
 	@Test
 	public void testSaveCopyConfirmClickedThenUseRequestCode() {
 		presenter.saveCopyConfirmClicked(-1);
 
-		verify(interactor).saveCopy(presenter, -1, workspace);
+		verify(interactor).saveCopy(presenter, -1, workspace, context);
 	}
 
 	@Test
@@ -969,7 +969,7 @@ public class MainActivityPresenterTest {
 
 		Uri uri = model.getSavedPictureUri();
 
-		verify(interactor).saveImage(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace), eq(uri));
+		verify(interactor).saveImage(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace), eq(uri), eq(context));
 	}
 
 	@Test
@@ -1000,7 +1000,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveCopy(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace));
+		verify(interactor).saveCopy(any(SaveImageAsync.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace), eq(context));
 	}
 
 	@Test
@@ -1036,7 +1036,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, workspace, uri, context);
 	}
 
 	@Test
@@ -1096,7 +1096,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, workspace, uri, context);
 	}
 
 	@Test
@@ -1132,7 +1132,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, workspace, uri, context);
 	}
 
 	@Test
@@ -1174,7 +1174,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, context);
 	}
 
 	@Test
@@ -1199,7 +1199,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH);
-		verify(interactor).saveImage(any(MainActivityPresenter.class), anyInt(), any(Workspace.class), eq((Uri) null));
+		verify(interactor).saveImage(any(MainActivityPresenter.class), anyInt(), any(Workspace.class), eq((Uri) null), any(Context.class));
 	}
 
 	@Test
@@ -1224,7 +1224,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_DEFAULT, workspace, uri, context);
 	}
 
 	@Test
@@ -1248,7 +1248,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_FINISH, workspace, uri, context);
 	}
 
 	@Test
@@ -1272,7 +1272,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_NEW_EMPTY);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_NEW_EMPTY, workspace, uri, context);
 	}
 
 	@Test
@@ -1296,7 +1296,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW);
-		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, workspace, uri);
+		verify(interactor).saveImage(presenter, SAVE_IMAGE_LOAD_NEW, workspace, uri, context);
 	}
 
 	@Test


### PR DESCRIPTION
[PAINTROID-149 Better png compression](https://jira.catrob.at/browse/PAINTROID-149)

- added id.zelory.compressor.Compressor library for compression
- saving images temporary in the cache if needed for compression
- added support for Android Q (files are handled differently)
- added compression test

### Your checklist for this pull request

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
