### PR TITLE
PAINTROID-325 Crash due to java.lang.IllegalArgumentException in DrawingSurface

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
@@ -36,6 +36,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
+import android.util.Log
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import androidx.core.content.ContextCompat
@@ -108,6 +109,10 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
         setOnTouchListener(drawingSurfaceListener)
     }
 
+    companion object {
+        private val TAG = DrawingSurface::class.java.name
+    }
+
     fun setArguments(
         layerModel: LayerContracts.Model,
         perspective: Perspective,
@@ -142,7 +147,9 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
                 val iterator = layerModel.listIterator(layerModel.layerCount)
 
                 while (iterator.hasPrevious()) {
-                    iterator.previous().bitmap?.let { surfaceViewCanvas.drawBitmap(it, 0f, 0f, null) }
+                    iterator.previous().bitmap?.let {
+                        surfaceViewCanvas.drawBitmap(it, 0f, 0f, null)
+                    }
                 }
 
                 val tool = toolReference.get()
@@ -268,6 +275,8 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
                     canvas?.let {
                         doDraw(it)
                     }
+                } catch (e: IllegalArgumentException) {
+                    Log.e(TAG, "run: ", e)
                 } finally {
                     canvas?.let {
                         holder.unlockCanvasAndPost(it)


### PR DESCRIPTION
The crash was most probably due to the missing `catch` block after the `try` in line number 273, so added the `catch` block in the `DrawingSurface` class to possibly fix that crash.

https://jira.catrob.at/browse/PAINTROID-325

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
