### PR TITLE
PAINTROID-320 Very high frequency crash in paintroid.[...].DefaultCommandManager.undo and .redo

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
@@ -66,7 +66,11 @@ class AsyncCommandManager(
         CoroutineScope(Dispatchers.Default).launch {
             mutex.withLock {
                 if (!shuttingDown) {
-                    synchronized(layerModel) { commandManager.undo() }
+                    synchronized(layerModel) {
+                        if (isUndoAvailable) {
+                            commandManager.undo()
+                        }
+                    }
                 }
                 withContext(Dispatchers.Main) {
                     notifyCommandPostExecute()
@@ -79,7 +83,11 @@ class AsyncCommandManager(
         CoroutineScope(Dispatchers.Default).launch {
             mutex.withLock {
                 if (!shuttingDown) {
-                    synchronized(layerModel) { commandManager.redo() }
+                    synchronized(layerModel) {
+                        if (isRedoAvailable) {
+                            commandManager.redo()
+                        }
+                    }
                 }
                 withContext(Dispatchers.Main) {
                     notifyCommandPostExecute()


### PR DESCRIPTION
Tried and fix the crash due to `java.util.NoSuchElementException` when calling `DefaultCommandManager.undo` and `.redo`.
`java.util.NoSuchElementException` is due to popping from the ArrayDeque even after it's empty, so before performing the undo/redo operations, added condition for checking the empty ArrayDeque.

https://jira.catrob.at/browse/PAINTROID-320

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
