### PR TITLE
PAINTROID-228 Checkmark for line tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -317,7 +317,7 @@ public class ColorDialogIntegrationTest {
 		onView(withId(R.id.color_picker_color_rgb_seekbar_blue)).perform(touchCenterRight());
 		onView(withId(R.id.color_picker_color_rgb_seekbar_alpha)).perform(touchCenterRight());
 
-		assertNotEquals("Selected color changed to blue", toolReference.get().getDrawPaint().getColor(), Color.BLUE);
+		assertNotEquals("Selected color changed to blue", toolReference.get().getDrawPaint().getColor(), Color.BLACK);
 
 		onColorPickerView()
 				.onPositiveButton()

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/LineToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/LineToolIntegrationTest.java
@@ -38,12 +38,18 @@ import androidx.test.rule.ActivityTestRule;
 
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.DEFAULT_STROKE_WIDTH;
 import static org.catrobat.paintroid.test.espresso.util.UiInteractions.swipe;
+import static org.catrobat.paintroid.test.espresso.util.UiInteractions.touchAt;
+import static org.catrobat.paintroid.test.espresso.util.UiMatcher.withDrawable;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.DrawingSurfaceInteraction.onDrawingSurfaceView;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction.onToolBarView;
 import static org.catrobat.paintroid.test.espresso.util.wrappers.ToolPropertiesInteraction.onToolProperties;
+import static org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction.onTopBarView;
+import static org.hamcrest.Matchers.allOf;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 @RunWith(AndroidJUnit4.class)
@@ -59,6 +65,7 @@ public class LineToolIntegrationTest {
 	public void setUp() {
 		onToolBarView()
 				.performSelectTool(ToolType.LINE);
+		onTopBarView().performClickCheckmark();
 	}
 
 	@Test
@@ -106,5 +113,144 @@ public class LineToolIntegrationTest {
 		onToolProperties()
 				.checkStrokeWidth(DEFAULT_STROKE_WIDTH)
 				.checkCap(Cap.SQUARE);
+	}
+
+	@Test
+	public void testCheckmarkLineFeature() {
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_LEFT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onTopBarView().onCheckmarkButton()
+				.check(matches(allOf(withDrawable(R.drawable.ic_pocketpaint_checkmark), isEnabled())));
+
+		onTopBarView().performClickCheckmark();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE);
+	}
+
+	@Test
+	public void testCheckmarkLineFeatureChangeColor() {
+		onToolProperties().setColor(Color.BLACK);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_LEFT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onToolProperties().setColor(Color.GREEN);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.GREEN, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.GREEN, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onTopBarView().onCheckmarkButton()
+				.check(matches(allOf(withDrawable(R.drawable.ic_pocketpaint_checkmark), isEnabled())));
+
+		onToolProperties().setColor(Color.RED);
+
+		onTopBarView().performClickCheckmark();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.RED, BitmapLocationProvider.MIDDLE);
+	}
+
+	@Test
+	public void testCheckmarkLineFeatureChangeShape() {
+		onToolProperties().setColor(Color.BLACK);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_LEFT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onToolProperties().setCap(Cap.SQUARE);
+
+		onToolProperties().checkCap(Cap.SQUARE);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onTopBarView().onCheckmarkButton()
+				.check(matches(allOf(withDrawable(R.drawable.ic_pocketpaint_checkmark), isEnabled())));
+
+		onToolProperties().setColor(Color.BLACK);
+
+		onTopBarView().performClickCheckmark();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE);
+	}
+
+	@Test
+	public void testCheckmarkLineFeatureChangeStrokeWidth() {
+		onToolProperties().setColor(Color.BLACK);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_LEFT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_LEFT_MIDDLE);
+
+		onToolProperties().setStrokeWidth(80);
+
+		onToolProperties().checkStrokeWidth(80);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onTopBarView().onCheckmarkButton()
+				.check(matches(allOf(withDrawable(R.drawable.ic_pocketpaint_checkmark), isEnabled())));
+
+		onTopBarView().performClickCheckmark();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE);
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolPropertiesInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolPropertiesInteraction.java
@@ -58,9 +58,19 @@ public final class ToolPropertiesInteraction extends CustomViewInteraction {
 		return this;
 	}
 
+	public ToolPropertiesInteraction setCap(Cap expectedCap) {
+		getCurrentTool().changePaintStrokeCap(expectedCap);
+		return this;
+	}
+
 	public ToolPropertiesInteraction checkStrokeWidth(float expectedStrokeWidth) {
 		Paint strokePaint = getCurrentTool().getDrawPaint();
 		assertEquals(expectedStrokeWidth, strokePaint.getStrokeWidth(), Float.MIN_VALUE);
+		return this;
+	}
+
+	public ToolPropertiesInteraction setStrokeWidth(float expectedStrokeWidth) {
+		getCurrentTool().changePaintStrokeWidth((int) expectedStrokeWidth);
 		return this;
 	}
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
@@ -18,6 +18,7 @@
  */
 package org.catrobat.paintroid.test.junit.tools
 
+import android.graphics.Paint
 import android.graphics.PointF
 import org.catrobat.paintroid.command.CommandManager
 import org.catrobat.paintroid.tools.ContextCallback
@@ -26,6 +27,7 @@ import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.implementation.LineTool
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.ui.Perspective
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -34,14 +36,35 @@ import org.mockito.Mockito
 class LineToolTest {
     private val toolPaint = Mockito.mock(ToolPaint::class.java)
     private val commandManager = Mockito.mock(CommandManager::class.java)
-    private val workspace = Mockito.mock(Workspace::class.java)
+    private var workspace = Mockito.mock(Workspace::class.java)
     private val brushToolOptions = Mockito.mock(BrushToolOptionsView::class.java)
     private val toolOptionsController = Mockito.mock(ToolOptionsVisibilityController::class.java)
     private val contextCallback = Mockito.mock(ContextCallback::class.java)
     private lateinit var tool: LineTool
+    private var screenWidth = 1920
+    private var screenHeight = 1080
+
+    object MockitoHelper {
+        fun <T> anyObject(): T {
+            Mockito.any<T>()
+            return uninitialized()
+        }
+        @Suppress("UNCHECKED_CAST")
+        fun <T> uninitialized(): T = null as T
+    }
 
     @Before
     fun setUp() {
+        Mockito.`when`(workspace.perspective).thenReturn(Perspective(screenWidth, screenHeight))
+        Mockito.`when`(workspace.width).thenReturn(screenWidth)
+        Mockito.`when`(workspace.height).thenReturn(screenHeight)
+        Mockito.`when`(workspace.contains(MockitoHelper.anyObject()))
+            .thenAnswer { invocation ->
+                val point = invocation.getArgument<PointF>(0)
+                point.x >= 0 && point.y >= 0 && point.x < screenWidth && point.y < screenHeight
+            }
+        val paint = Paint()
+        Mockito.`when`(toolPaint.paint).thenReturn(paint)
         tool = LineTool(
             brushToolOptions,
             contextCallback,
@@ -56,6 +79,7 @@ class LineToolTest {
     fun testInternalStateGetsResetWithPathOuterWorkspace() {
         tool.handleDown(PointF(-1f, -1f))
         tool.handleUp(PointF(-2f, -2f))
+
         Assert.assertEquals(tool.currentCoordinate, null)
         Assert.assertEquals(tool.initialEventCoordinate, null)
     }
@@ -76,5 +100,21 @@ class LineToolTest {
         val point = PointF(2f, 2f)
         tool.handleMove(point)
         Assert.assertEquals(tool.currentCoordinate, point)
+    }
+
+    @Test
+    fun testIfCheckmarkFeatureWorks() {
+        tool.handleDown(PointF(1f, 1f))
+        tool.handleUp(PointF(2f, 2f))
+        Assert.assertEquals(tool.currentCoordinate, null)
+        Assert.assertEquals(tool.initialEventCoordinate, null)
+        Assert.assertEquals(tool.startpointSet, true)
+        Assert.assertNotEquals(tool.startPointToDraw, null)
+        tool.handleDown(PointF(5f, 5f))
+        tool.handleUp(PointF(10f, 10f))
+        Assert.assertEquals(tool.endpointSet, true)
+        Assert.assertNotEquals(tool.endPointToDraw, null)
+        tool.onClickOnButton()
+        Assert.assertEquals(tool.lineFinalized, false)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.java
@@ -105,12 +105,18 @@ public class DefaultToolController implements ToolController {
 		return toolReference.get().getDrawPaint().getColor();
 	}
 
+	@Override
+	public Tool getCurrentTool() {
+		return toolReference.get();
+	}
+
 	private void switchTool(Tool tool, boolean backPressed) {
 		Tool currentTool = toolReference.get();
 		ToolType currentToolType = currentTool.getToolType();
 
 		if ((currentToolType == ToolType.TEXT || currentToolType == ToolType.TRANSFORM
-				|| currentToolType == ToolType.IMPORTPNG || currentToolType == ToolType.SHAPE) && !backPressed) {
+				|| currentToolType == ToolType.IMPORTPNG || currentToolType == ToolType.SHAPE
+				|| currentToolType == ToolType.LINE) && !backPressed) {
 			BaseToolWithShape toolToApply = (BaseToolWithShape) currentTool;
 			toolToApply.onClickOnButton();
 		}
@@ -160,7 +166,8 @@ public class DefaultToolController implements ToolController {
 		if (toolType == ToolType.TEXT
 				|| toolType == ToolType.TRANSFORM
 				|| toolType == ToolType.SHAPE
-				|| toolType == ToolType.IMPORTPNG) {
+				|| toolType == ToolType.IMPORTPNG
+				|| toolType == ToolType.LINE) {
 			toolOptionsViewController.showCheckmark();
 		} else {
 			toolOptionsViewController.hideCheckmark();

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.java
@@ -22,6 +22,7 @@ package org.catrobat.paintroid.controller;
 import android.graphics.Bitmap;
 
 import org.catrobat.paintroid.colorpicker.OnColorPickedListener;
+import org.catrobat.paintroid.tools.Tool;
 import org.catrobat.paintroid.tools.ToolType;
 
 public interface ToolController {
@@ -42,6 +43,8 @@ public interface ToolController {
 	void resetToolInternalStateOnImageLoaded();
 
 	int getToolColor();
+
+	Tool getCurrentTool();
 
 	ToolType getToolType();
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/Constants.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/Constants.kt
@@ -20,3 +20,4 @@ package org.catrobat.paintroid.tools.common
 
 const val SCROLL_TOLERANCE_PERCENTAGE = 0.1f
 const val MOVE_TOLERANCE = 5f
+const val LINE_THRESHOLD = 100f

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
@@ -19,6 +19,7 @@
 package org.catrobat.paintroid.tools.implementation
 
 import android.graphics.Canvas
+import android.graphics.Paint
 import android.graphics.PointF
 import android.graphics.RectF
 import androidx.annotation.VisibleForTesting
@@ -30,8 +31,10 @@ import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.common.CommonBrushChangedListener
 import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener
+import org.catrobat.paintroid.tools.common.LINE_THRESHOLD
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import kotlin.math.abs
 
 class LineTool(
     private val brushToolOptionsView: BrushToolOptionsView,
@@ -40,15 +43,41 @@ class LineTool(
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager
-) : BaseTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager) {
+) : BaseToolWithShape(
+    contextCallback,
+    toolOptionsViewController,
+    toolPaint,
+    workspace,
+    commandManager
+) {
+    @VisibleForTesting
+    var lineFinalized: Boolean = false
+
+    @VisibleForTesting
+    var endpointSet: Boolean = false
+
+    @VisibleForTesting
+    var startpointSet: Boolean = false
 
     @VisibleForTesting
     var initialEventCoordinate: PointF? = null
 
     @VisibleForTesting
+    var startPointToDraw: PointF? = null
+
+    @VisibleForTesting
+    var endPointToDraw: PointF? = null
+
+    @VisibleForTesting
     var currentCoordinate: PointF? = null
 
     override var toolType: ToolType = ToolType.LINE
+
+    var pointToDelete: PointF? = null
+
+    var toolSwitched: Boolean = false
+
+    var lastSetStrokeWidth: Int = 0
 
     init {
         brushToolOptionsView.setBrushChangedListener(CommonBrushChangedListener(this))
@@ -78,6 +107,41 @@ class LineTool(
         }
     }
 
+    override fun drawShape(canvas: Canvas) {
+        // This should never be invoked
+    }
+
+    override fun onClickOnButton() {
+        if (startpointSet && endpointSet) {
+            if (toolSwitched) {
+                val startX = startPointToDraw?.x
+                val startY = startPointToDraw?.y
+                val endX = endPointToDraw?.x
+                val endY = endPointToDraw?.y
+                val finalPath = SerializablePath().apply {
+                    if (startX != null && startY != null && endX != null && endY != null) {
+                        moveTo(startX, startY)
+                        lineTo(endX, endY)
+                    }
+                }
+                lineFinalized = true
+                toolSwitched = false
+                val command = commandFactory.createPathCommand(toolPaint.paint, finalPath)
+                commandManager.addCommand(command)
+            }
+            lineFinalized = true
+            resetInternalState()
+        } else if (startpointSet && !endpointSet) {
+            if (commandManager.isUndoAvailable) {
+                commandManager.undo()
+            }
+            lineFinalized = true
+            resetInternalState()
+        } else {
+            resetInternalState()
+        }
+    }
+
     override fun handleDown(coordinate: PointF?): Boolean {
         coordinate ?: return false
         initialEventCoordinate = PointF(coordinate.x, coordinate.y)
@@ -91,11 +155,54 @@ class LineTool(
         return true
     }
 
-    override fun handleUp(coordinate: PointF?): Boolean {
-        if (initialEventCoordinate == null || previousEventCoordinate == null || coordinate == null) {
-            return false
+    fun handleStartPoint(xDistance: Float, yDistance: Float): Boolean {
+        startPointToDraw = previousEventCoordinate
+        startPointToDraw?.x = xDistance.let { startPointToDraw?.x?.minus(it) }
+        startPointToDraw?.y = yDistance.let { startPointToDraw?.y?.minus(it) }
+
+        if (startPointToDraw?.let { workspace.contains(it) } == true) {
+            startpointSet = true
+            resetInternalState()
+            startPointToDraw?.let {
+                return addPointCommand(it)
+            }
+        } else {
+            lineFinalized = true
+            resetInternalState()
         }
+        return true
+    }
+
+    fun handleEndPoint(xDistance: Float, yDistance: Float): Boolean {
+        endPointToDraw = previousEventCoordinate
+        endPointToDraw?.x = xDistance.let { endPointToDraw?.x?.minus(it) }
+        endPointToDraw?.y = yDistance.let { endPointToDraw?.y?.minus(it) }
+        endpointSet = true
+        val startX = startPointToDraw?.x
+        val startY = startPointToDraw?.y
+        val endX = endPointToDraw?.x
+        val endY = endPointToDraw?.y
+        if (commandManager.isUndoAvailable) {
+            commandManager.undo()
+        }
+        val finalPath = SerializablePath().apply {
+            if (startX != null && startY != null && endX != null && endY != null) {
+                moveTo(startX, startY)
+                lineTo(endX, endY)
+            }
+        }
+        val command = commandFactory.createPathCommand(toolPaint.paint, finalPath)
+        commandManager.addCommand(command)
+        resetInternalState()
+        return true
+    }
+
+    fun handleNormalLine(coordinate: PointF): Boolean {
         val bounds = RectF()
+        if (startpointSet) {
+            resetInternalState()
+            return true
+        }
         val finalPath = SerializablePath().apply {
             moveTo(
                 initialEventCoordinate?.x ?: return false,
@@ -114,13 +221,122 @@ class LineTool(
         return true
     }
 
+    override fun handleUp(coordinate: PointF?): Boolean {
+        if (initialEventCoordinate == null || previousEventCoordinate == null || coordinate == null) {
+            return false
+        }
+        val xDistance = initialEventCoordinate?.x?.minus(coordinate.x)
+        val yDistance = initialEventCoordinate?.y?.minus(coordinate.y)
+        if (xDistance != null && yDistance != null) {
+            if (abs(xDistance) > LINE_THRESHOLD || abs(yDistance) > LINE_THRESHOLD) {
+                return handleNormalLine(coordinate)
+            } else if (!startpointSet) {
+                return handleStartPoint(xDistance, yDistance)
+            } else {
+                return handleEndPoint(xDistance, yDistance)
+            }
+        }
+        return true
+    }
+
     override fun resetInternalState() {
         initialEventCoordinate = null
         currentCoordinate = null
+        if (lineFinalized) {
+            startPointToDraw = null
+            endPointToDraw = null
+            startpointSet = false
+            endpointSet = false
+            lineFinalized = false
+        }
     }
 
     override fun changePaintColor(color: Int) {
         super.changePaintColor(color)
+        if (startpointSet && endpointSet) {
+            val startX = startPointToDraw?.x
+            val startY = startPointToDraw?.y
+            val endX = endPointToDraw?.x
+            val endY = endPointToDraw?.y
+            if (commandManager.isUndoAvailable) {
+                commandManager.undo()
+                val finalPath = SerializablePath().apply {
+                    if (startX != null && startY != null && endX != null && endY != null) {
+                        moveTo(startX, startY)
+                        lineTo(endX, endY)
+                    }
+                }
+                val command = commandFactory.createPathCommand(toolPaint.paint, finalPath)
+                commandManager.addCommand(command)
+            }
+        } else if (startpointSet && !endpointSet && !lineFinalized) {
+            if (commandManager.isUndoAvailable) {
+                commandManager.undo()
+                startPointToDraw?.let { addPointCommand(it) }
+            }
+        }
         brushToolOptionsView.invalidate()
+    }
+
+    override fun changePaintStrokeWidth(strokeWidth: Int) {
+        super.changePaintStrokeWidth(strokeWidth)
+        val noNewLine = lastSetStrokeWidth == strokeWidth
+        if (startpointSet && endpointSet && !noNewLine) {
+            val startX = startPointToDraw?.x
+            val startY = startPointToDraw?.y
+            val endX = endPointToDraw?.x
+            val endY = endPointToDraw?.y
+            if (commandManager.isUndoAvailable) {
+                commandManager.undo()
+                val finalPath = SerializablePath().apply {
+                    if (startX != null && startY != null && endX != null && endY != null) {
+                        moveTo(startX, startY)
+                        lineTo(endX, endY)
+                    }
+                }
+                val command = commandFactory.createPathCommand(toolPaint.paint, finalPath)
+                commandManager.addCommand(command)
+            }
+        } else if (startpointSet && !endpointSet && !lineFinalized && !noNewLine) {
+            if (commandManager.isUndoAvailable) {
+                commandManager.undo()
+                startPointToDraw?.let { addPointCommand(it) }
+            }
+        }
+        lastSetStrokeWidth = strokeWidth
+        brushToolOptionsView.invalidate()
+    }
+
+    override fun changePaintStrokeCap(cap: Paint.Cap) {
+        super.changePaintStrokeCap(cap)
+        if (startpointSet && endpointSet) {
+            val startX = startPointToDraw?.x
+            val startY = startPointToDraw?.y
+            val endX = endPointToDraw?.x
+            val endY = endPointToDraw?.y
+            if (commandManager.isUndoAvailable) {
+                commandManager.undo()
+                val finalPath = SerializablePath().apply {
+                    if (startX != null && startY != null && endX != null && endY != null) {
+                        moveTo(startX, startY)
+                        lineTo(endX, endY)
+                    }
+                }
+                val command = commandFactory.createPathCommand(toolPaint.paint, finalPath)
+                commandManager.addCommand(command)
+            }
+        } else if (startpointSet && !endpointSet && !lineFinalized) {
+            if (commandManager.isUndoAvailable) {
+                commandManager.undo()
+                startPointToDraw?.let { addPointCommand(it) }
+            }
+        }
+        brushToolOptionsView.invalidate()
+    }
+
+    private fun addPointCommand(coordinate: PointF): Boolean {
+        val command = commandFactory.createPointCommand(this.drawPaint, coordinate)
+        commandManager.addCommand(command)
+        return true
     }
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/PAINTROID-228

The new line tool has a checkmark on the right of the top bar. There are several different use cases when the line tool is active:
1. The user can draw a normal line --> I've implemented a threshold and as long as the line is bigger than this threshold, the app detects that the user just wants to draw a normal line and allows that. When finger gets released within the threshold, the line will not be drawn and the last point is set to the starting point. 

2. The user can first declare a start point via a tap, the start point gets marked on the canvas. In order to correctly place the start point the user has the option to correct the initial start point via moving it around until the finger leaves the screen for the first time. When start point is set there are again a few different scenarios:
                                
      2.1. User draws line while start point is set -> line just gets ignored (matter of definition I thought it's the best solution)
      
      2.2. User clicks on the checkbox -> tool gets reset and user can again draw normal lines or choose a start point.
      
      2.2. User clicks anywhere on the canvas -> end point is set and line will be drawn from startpoint to endpoint, user can then again click on the canvas as often as he wants and the end point always gets modified to the last point clicked. As long as the checkmark is not clicked, the user can change color, size and form (square or round) as often as he wants. Currently I've implemented the option when the user draws a really small line when declaring the endpoint (currently same threshold as starting point), the last point of the small line gets chosen as the end point, basically same as starting point but user can change position of end point even after releasing the finger. 

3. When the user just clicks the checkmark with no start point chosen, nothing happens.
4. One bug that is introduced in this ticket is due to the fact, that I have to call undo() internally to properly show the current starting point or line/path with the newly chosen color/cap/stroke width. This causes hidden layers to be shown again because the current implementation of undo() resets the layermodel and therefore resets all checkboxes, I already created a ticket for that problem that has to be fixed before this ticket can be merged. Not a huge bug in my opinion but obviously not perfect and should be corrected soonish. 

I've also created 1 demo GIF for the normal behavior and two GIFS for the bug/unwanted behavior (which is also present in the current version of our app).

I also thought about using a toast to indicate that start/end point is set but not sure if it's needed.

<details><summary>Click for demo normal behaviour:</summary>
<p>

<img src="https://user-images.githubusercontent.com/56889304/126619503-d1079c36-71ce-4767-a060-67fa95c02e18.gif" width="500">

</p>
</details>

<details><summary>Click for demo internal undo bug with new line tool feature:</summary>
<p>

<img src="https://user-images.githubusercontent.com/56889304/126620479-e14818fd-82c6-49c0-bad4-82fc9e29df76.gif" width="500">

</p>
</details>

<details><summary>Click for demo overall undo bug:</summary>
<p>

<img src="https://user-images.githubusercontent.com/56889304/126620487-fb1c41ff-4c95-4aba-80dd-ff30d3870051.gif" width="500">

</p>
</details>

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
