### PR TITLE
PAINTROID-338 URGENT: Webview for Import image of Catrobat stickers should not allow to navigate to projects on share

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/web/MediaGalleryWebViewClient.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/web/MediaGalleryWebViewClient.java
@@ -44,7 +44,7 @@ public class MediaGalleryWebViewClient extends WebViewClient {
 
 	@Override
 	public void onPageStarted(WebView view, String urlClient, Bitmap favicon) {
-		if (webViewLoadingDialog == null) {
+		if (webViewLoadingDialog == null && !urlClient.matches("https://share.catrob.at/pocketcode/")) {
 			webViewLoadingDialog = new ProgressDialog(view.getContext(), R.style.WebViewLoadingCircle);
 			webViewLoadingDialog.setCancelable(true);
 			webViewLoadingDialog.setCanceledOnTouchOutside(false);


### PR DESCRIPTION
Fixed unexpected behavior with import stickers when clicking on catrobat logo in menu or on "Catrobat community" in the top bar. Now when clicking on one of those two sections, the import interaction will be canceled instead of allowing the user to explore other projects.

Fixed it by regex matching the desired url and in case of the catrobat logo or "catrobat community" in the top bar, the url always is "https://share.catrob.at/pocketcode/" and if that URL is passed to the onPageStarted() function as the "urlClient" parameter, we just call callback.finish().

https://jira.catrob.at/browse/PAINTROID-338

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
