### PR TITLE
Fix for PAINTROID-314 ora files not always getting saved

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
@@ -120,7 +120,7 @@ interface MainActivityContracts {
 
         fun showToolChangeToast(offset: Int, idRes: Int)
 
-        fun broadcastAddPictureToGallery(file: File)
+        fun broadcastAddPictureToGallery(uri: Uri)
 
         fun rateUsClicked()
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -950,8 +950,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 		}
 
 		if (!model.isOpenedFromCatroid() || saveAsCopy) {
-			File file = new File(getPathFromUri(context, uri));
-			navigator.broadcastAddPictureToGallery(file);
+			navigator.broadcastAddPictureToGallery(uri);
 		}
 
 		switch (requestCode) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.kt
@@ -25,7 +25,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Bitmap
-import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
 import android.provider.OpenableColumns
@@ -72,7 +71,6 @@ import org.catrobat.paintroid.dialog.ScaleImageOnLoadDialog
 import org.catrobat.paintroid.tools.ToolReference
 import org.catrobat.paintroid.ui.fragments.CatroidMediaGalleryFragment
 import org.catrobat.paintroid.ui.fragments.CatroidMediaGalleryFragment.MediaGalleryListener
-import java.io.File
 
 class MainActivityNavigator(
     private val mainActivity: MainActivity,
@@ -477,8 +475,10 @@ class MainActivityNavigator(
         toolNameToast.show()
     }
 
-    override fun broadcastAddPictureToGallery(file: File) {
-        MediaScannerConnection.scanFile(mainActivity, arrayOf(file.toString()), null, null)
+    override fun broadcastAddPictureToGallery(uri: Uri) {
+        val mediaScanIntent = Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE)
+        mediaScanIntent.data = uri
+        mainActivity.sendBroadcast(mediaScanIntent)
     }
 
     override fun restoreFragmentListeners() {

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -1376,8 +1376,7 @@ public class MainActivityPresenterTest {
 
 		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false);
 
-		File file = new File(MainActivityPresenter.getPathFromUri(context, uri));
-		verify(navigator).broadcastAddPictureToGallery(file);
+		verify(navigator).broadcastAddPictureToGallery(uri);
 	}
 
 	@Test
@@ -1386,8 +1385,7 @@ public class MainActivityPresenterTest {
 
 		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, true);
 
-		File file = new File(MainActivityPresenter.getPathFromUri(context, uri));
-		verify(navigator).broadcastAddPictureToGallery(file);
+		verify(navigator).broadcastAddPictureToGallery(uri);
 	}
 
 	@Test
@@ -1397,8 +1395,7 @@ public class MainActivityPresenterTest {
 
 		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, false);
 
-		File file = new File(MainActivityPresenter.getPathFromUri(context, uri));
-		verify(navigator, never()).broadcastAddPictureToGallery(file);
+		verify(navigator, never()).broadcastAddPictureToGallery(uri);
 	}
 
 	@Test
@@ -1408,8 +1405,7 @@ public class MainActivityPresenterTest {
 
 		presenter.onSaveImagePostExecute(SAVE_IMAGE_DEFAULT, uri, true);
 
-		File file = new File(MainActivityPresenter.getPathFromUri(context, uri));
-		verify(navigator).broadcastAddPictureToGallery(file);
+		verify(navigator).broadcastAddPictureToGallery(uri);
 	}
 
 	@Test


### PR DESCRIPTION
This PR is basically a small fix/revert for the crashing `testSaveAndOverrideOraFile`.  The `MediaScannerConnection` doesn't seem to save ora files (octet-streams/zip files). However, there was no crash when saving the ora file the first time (it just didn't get saved), but if you try saving it a second time then the testcase would crash because it would look up an URI to a non existent file.

The newer/refactored code (`MediaScannerConnection`) was used because `Intent.ACTION_MEDIA_SCANNER_SCAN_FILE` was deprecated but there is unfortunately not much information out there why it doesn't work with ora (octet-streams/zip files).

(Not jira ticket)
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
