### PR TITLE
PAINTROID-293 Color picker forgets color when exiting the picker via the back button

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -210,8 +210,8 @@ public class ColorDialogIntegrationTest {
 	}
 
 	@Test
-	public void testColorPickerDialogOnBackPressedSelectedColorShouldNotChange() {
-		int expectedSelectedColor = toolReference.get().getDrawPaint().getColor();
+	public void testColorPickerDialogOnBackPressedSelectedColorShouldChange() {
+		int initialColor = toolReference.get().getDrawPaint().getColor();
 
 		onColorPickerView()
 				.performOpenColorPicker();
@@ -224,7 +224,7 @@ public class ColorDialogIntegrationTest {
 		int colorToSelect = presetColors.getColor(colorToSelectIndex, Color.WHITE);
 		presetColors.recycle();
 
-		assertNotEquals("Selected color should not be the same as the color to select", colorToSelect, expectedSelectedColor);
+		assertNotEquals("Selected color should not be the same as the initial color", colorToSelect, initialColor);
 
 		onColorPickerView()
 				.performClickColorPickerPresetSelectorButton(colorToSelectIndex);
@@ -233,7 +233,7 @@ public class ColorDialogIntegrationTest {
 		onView(isRoot()).perform(pressBack());
 
 		int currentSelectedColor = toolReference.get().getDrawPaint().getColor();
-		assertEquals("Selected color has not changed", expectedSelectedColor, currentSelectedColor);
+		assertEquals("Selected color has not changed", colorToSelect, currentSelectedColor);
 	}
 
 	@Test

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
@@ -114,10 +114,10 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
         colorToApply = colorPickerView.initialColor
         val materialDialog = MaterialAlertDialogBuilder(requireContext(), R.style.AlertDialogTheme)
             .setNegativeButton(R.string.color_picker_cancel) { dialogInterface: DialogInterface, _: Int ->
+                updateColorChange(colorPickerView.initialColor)
                 dialogInterface.dismiss()
             }
             .setPositiveButton(R.string.color_picker_apply) { _: DialogInterface, _: Int ->
-                updateColorChange(colorToApply)
                 deleteBitmapFile(requireContext(), bitmapName)
                 dismiss()
             }
@@ -142,6 +142,7 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
     override fun colorChanged(color: Int) {
         setViewColor(newColorView, color)
         colorToApply = color
+        updateColorChange(colorToApply)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
Now it always updates the color when its changed, and when the cancel button is pressed the color gets changed to its initial color. 
https://jira.catrob.at/browse/PAINTROID-293

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
