### PR TITLE
PAINTROID-347 ANR in ColorPickerDialog

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerPreviewActivity.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerPreviewActivity.kt
@@ -30,10 +30,9 @@ import android.view.WindowManager
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import org.catrobat.paintroid.colorpicker.ColorPickerDialog.Companion.BITMAP_Name_EXTRA
-import org.catrobat.paintroid.colorpicker.ColorPickerDialog.Companion.COLOR_EXTRA
 
 class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedListener {
 
@@ -65,12 +64,10 @@ class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedL
             setCurrentColor(it)
         }
 
-        intent?.extras?.getString(BITMAP_Name_EXTRA)?.let {
-            runBlocking {
-                launch {
-                    loadBitmapByName(this@ColorPickerPreviewActivity, it)?.let {
-                        previewSurface.setImageBitmap(it)
-                    }
+        intent?.extras?.getString(BITMAP_NAME_EXTRA)?.let {
+            CoroutineScope(Dispatchers.Main).launch {
+                loadBitmapByName(this@ColorPickerPreviewActivity, it)?.let {
+                    previewSurface.setImageBitmap(it)
                 }
             }
         }
@@ -91,14 +88,19 @@ class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedL
 
     private fun setCurrentColor(color: Int) {
         currentColor = color
-        val checkeredBitmap = BitmapFactory.decodeResource(resources, R.drawable.pocketpaint_checkeredbg)
+        val checkeredBitmap =
+            BitmapFactory.decodeResource(resources, R.drawable.pocketpaint_checkeredbg)
         val shader = BitmapShader(checkeredBitmap, Shader.TileMode.REPEAT, Shader.TileMode.REPEAT)
-        colorPreview.background = ColorPickerDialog.CustomColorDrawable.createDrawable(shader, color)
+        colorPreview.background =
+            ColorPickerDialog.CustomColorDrawable.createDrawable(shader, color)
     }
 
     override fun onStart() {
         super.onStart()
-        window.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_FULLSCREEN,
+            WindowManager.LayoutParams.FLAG_FULLSCREEN
+        )
         window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
     }
 

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/FileOperations.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/FileOperations.kt
@@ -21,6 +21,7 @@ package org.catrobat.paintroid.colorpicker
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.FileInputStream
@@ -29,23 +30,24 @@ import java.io.FileOutputStream
 import java.io.IOException
 
 private const val HUNDRED = 100
+private const val TAG = "FileOperations"
 
-@Suppress("BlockingMethodInNonBlockingContext")
-suspend fun storeBitmapTemporally(bitmap: Bitmap, context: Context, imageName: String) =
-    withContext(Dispatchers.IO) {
-        var outputStream: FileOutputStream? = null
-        try {
-            outputStream = context.openFileOutput(imageName, Context.MODE_PRIVATE)
-            bitmap.compress(Bitmap.CompressFormat.PNG, HUNDRED, outputStream)
-            outputStream.flush()
-        } catch (e: FileNotFoundException) {
-            e.printStackTrace()
-        } catch (e: IOException) {
-            e.printStackTrace()
-        } finally {
-            outputStream?.close()
+@SuppressWarnings("TooGenericExceptionCaught")
+fun storeBitmapTemporally(bitmap: Bitmap, context: Context, imageName: String) {
+    var outputStream: FileOutputStream? = null
+    try {
+        outputStream = context.openFileOutput(imageName, Context.MODE_PRIVATE)
+        bitmap.compress(Bitmap.CompressFormat.PNG, HUNDRED, outputStream)
+        outputStream.flush()
+    } catch (e: Exception) {
+        when (e) {
+            is FileNotFoundException -> Log.e(TAG, "FileNotFoundException: ${e.message}")
+            is IOException -> Log.e(TAG, "IOException: ${e.message}")
         }
+    } finally {
+        outputStream?.close()
     }
+}
 
 @Suppress("BlockingMethodInNonBlockingContext")
 suspend fun loadBitmapByName(context: Context, imageName: String): Bitmap? {


### PR DESCRIPTION
The ANR occurs on clicking the `pipette` button when the image is very large due to the use of `runBlocking` which freezes the UI/main thread till the tasks get completed. `runBlocking` is almost never a tool you use in production. It undoes the asynchronous, non-blocking nature of coroutines. So replaced it with `CoroutineScope` in order to obtain the real asynchronous behaviour. As the `storeBitmapTemporally` method is now properly being performed in a background thread, so now the UI isn't frozen and the user could press the `pipette` button multiple times, so to prevent that I disable the button once the user presses it, so this also gives a hint to the user that the button has been pressed and also prevents the user from clicking the button multiple times(which would lead to the launching of `ColorPickerPreviewActivity` multiple times).
One small problem with the new implementation(which I'm not able to fix as of now) is that if the user changes the orientation while the `storeBitmapTemporally` is still running asynchronously, the app crashes. I've prevented the crash by catching the exception, but the user would need to press the `pipette` button once again in that case.

https://jira.catrob.at/browse/PAINTROID-347

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
