### PR TITLE
PAINTROID-351 Catrobat-image smoothed lines not getting displayed after loading

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
@@ -64,8 +64,8 @@ import org.catrobat.paintroid.tools.implementation.DefaultToolPaint
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import kotlin.collections.ArrayList
 
 class CommandSerializationTest {
@@ -210,6 +210,7 @@ class CommandSerializationTest {
             moveTo(20f, 30f)
             lineTo(30f, 10f)
             quadTo(10f, 20f, 30f, 40f)
+            cubicTo(10f, 20f, 30f, 3f, 19f, 20f)
         }
         expectedModel.commands.add(commandFactory.createPathCommand(paint, path))
         assertSerializeAndDeserialize()
@@ -434,6 +435,7 @@ class CommandSerializationTest {
             is SerializablePath.Move -> return equalsActionMove(expectedAction, actualAction as SerializablePath.Move)
             is SerializablePath.Line -> return equalsActionLine(expectedAction, actualAction as SerializablePath.Line)
             is SerializablePath.Quad -> return equalsActionQuad(expectedAction, actualAction as SerializablePath.Quad)
+            is SerializablePath.Cube -> return equalsActionCube(expectedAction, actualAction as SerializablePath.Cube)
             is SerializablePath.Rewind -> return true
         }
         return false
@@ -448,4 +450,9 @@ class CommandSerializationTest {
     private fun equalsActionQuad(expectedAction: SerializablePath.Quad, actualAction: SerializablePath.Quad) =
         expectedAction.x1 == actualAction.x1 && expectedAction.y1 == actualAction.y1 &&
             expectedAction.x2 == actualAction.x2 && expectedAction.y2 == actualAction.y2
+
+    private fun equalsActionCube(expectedAction: SerializablePath.Cube, actualAction: SerializablePath.Cube) =
+        expectedAction.x1 == actualAction.x1 && expectedAction.y1 == actualAction.y1 &&
+            expectedAction.x2 == actualAction.x2 && expectedAction.y2 == actualAction.y2 &&
+            expectedAction.x3 == actualAction.x3 && expectedAction.y3 == actualAction.y3
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -87,7 +87,6 @@ import org.catrobat.paintroid.ui.viewholder.DrawerLayoutViewHolder
 import org.catrobat.paintroid.ui.viewholder.LayerMenuViewHolder
 import org.catrobat.paintroid.ui.viewholder.TopBarViewHolder
 import java.io.File
-import java.io.IOException
 import java.util.Locale
 
 class MainActivity : AppCompatActivity(), MainView, CommandListener {
@@ -162,6 +161,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         }
     }
 
+    @SuppressWarnings("TooGenericExceptionCaught")
     private fun handleIntent(receivedIntent: Intent): Boolean {
         var receivedUri = receivedIntent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
 
@@ -208,7 +208,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                         )
                     }
             }
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             Log.e("Can not read", "Unable to retrieve Bitmap from Uri")
         }
         return true

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializationUtilities.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializationUtilities.kt
@@ -128,6 +128,7 @@ class CommandSerializationUtilities(private val activityContext: Context, privat
             put(StampCommand::class.java, StampCommandSerializer(version))
             put(SerializableTypeface::class.java, SerializableTypeface.TypefaceSerializer(version))
             put(PointCommand::class.java, PointCommandSerializer(version))
+            put(SerializablePath.Cube::class.java, SerializablePath.PathActionCubeSerializer(version))
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/SerializablePath.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/SerializablePath.kt
@@ -54,6 +54,11 @@ open class SerializablePath : Path {
         super.quadTo(x1, y1, x2, y2)
     }
 
+    override fun cubicTo(x1: Float, y1: Float, x2: Float, y2: Float, x3: Float, y3: Float) {
+        serializableActions.add(Cube(x1, y1, x2, y2, x3, y3))
+        super.cubicTo(x1, y1, x2, y2, x3, y3)
+    }
+
     override fun rewind() {
         serializableActions.clear()
         super.rewind()
@@ -78,6 +83,12 @@ open class SerializablePath : Path {
     class Quad(val x1: Float, val y1: Float, val x2: Float, val y2: Float) : SerializableAction {
         override fun perform(path: Path) {
             path.quadTo(x1, y1, x2, y2)
+        }
+    }
+
+    class Cube(val x1: Float, val y1: Float, val x2: Float, val y2: Float, val x3: Float, val y3: Float) : SerializableAction {
+        override fun perform(path: Path) {
+            path.cubicTo(x1, y1, x2, y2, x3, y3)
         }
     }
 
@@ -162,6 +173,27 @@ open class SerializablePath : Path {
                 Quad(readFloat(), readFloat(), readFloat(), readFloat())
             }
         }
+    }
+
+    class PathActionCubeSerializer(version: Int) : VersionSerializer<Cube>(version) {
+        override fun write(kryo: Kryo, output: Output, action: Cube) {
+            with(output) {
+                writeFloat(action.x1)
+                writeFloat(action.y1)
+                writeFloat(action.x2)
+                writeFloat(action.y2)
+                writeFloat(action.x3)
+                writeFloat(action.y3)
+            }
+        }
+
+        override fun read(kryo: Kryo, input: Input, type: Class<out Cube>): Cube =
+            super.handleVersions(this, kryo, input, type)
+
+        override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out Cube>) =
+            with(input) {
+                Cube(readFloat(), readFloat(), readFloat(), readFloat(), readFloat(), readFloat())
+            }
     }
 
     class PathActionRewindSerializer(version: Int) : VersionSerializer<Rewind>(version) {


### PR DESCRIPTION
In order to smooth the lines the function `cubicTo` was called which wasn't specified for the `SerializePath`.

Also when an  ora-image/catrobat-image/octet-stream is to be opened with Pocket Paint, I think its best to catch every exception, if the user sends a malformed image/etc. This would also catch the crash for https://jira.catrob.at/browse/PAINTROID-321 (but obviously the cause would remain unknown).

https://jira.catrob.at/browse/PAINTROID-351

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
