### PR TITLE
Paintroid-298 adding fullscreen when drawing

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -408,7 +408,8 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             layerModel,
             perspective,
             toolReference,
-            toolOptionsViewController
+            toolOptionsViewController,
+            presenterMain
         )
         layerPresenter.setDrawingSurface(drawingSurface)
         appFragment.perspective = perspective

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
@@ -24,6 +24,8 @@ import android.os.Handler
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnTouchListener
+import org.catrobat.paintroid.contract.MainActivityContracts
+import org.catrobat.paintroid.presenter.MainActivityPresenter
 import org.catrobat.paintroid.tools.Tool
 import org.catrobat.paintroid.tools.Tool.StateChange
 import org.catrobat.paintroid.tools.ToolType
@@ -36,9 +38,10 @@ private const val DRAWER_EDGE_SIZE = 20f
 private const val CONSTANT_1 = 0.5f
 
 open class DrawingSurfaceListener(
-    private val autoScrollTask: AutoScrollTask,
-    private val callback: DrawingSurfaceListenerCallback,
-    displayDensity: Float
+        private val autoScrollTask: AutoScrollTask,
+        private val callback: DrawingSurfaceListenerCallback,
+        displayDensity: Float,
+        val presenter: MainActivityContracts.Presenter
 ) : OnTouchListener {
     private var touchMode: TouchMode
     private var pointerDistance = 0f
@@ -153,6 +156,7 @@ open class DrawingSurfaceListener(
                 if (eventTouchPoint.x < drawerEdgeSize || view.getWidth() - eventTouchPoint.x < drawerEdgeSize) {
                     return false
                 }
+                presenter.enterFullscreenClicked()
                 timerStartDraw = System.currentTimeMillis()
                 currentTool.handleDown(canvasTouchPoint)
                 if (autoScroll) {
@@ -178,6 +182,7 @@ open class DrawingSurfaceListener(
                 eventX = 0f
                 eventY = 0f
                 touchMode = TouchMode.DRAW
+                presenter.exitFullscreenClicked()
             }
         }
         drawingSurface.refreshDrawingSurface()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
@@ -25,7 +25,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnTouchListener
 import org.catrobat.paintroid.contract.MainActivityContracts
-import org.catrobat.paintroid.presenter.MainActivityPresenter
 import org.catrobat.paintroid.tools.Tool
 import org.catrobat.paintroid.tools.Tool.StateChange
 import org.catrobat.paintroid.tools.ToolType
@@ -38,10 +37,9 @@ private const val DRAWER_EDGE_SIZE = 20f
 private const val CONSTANT_1 = 0.5f
 
 open class DrawingSurfaceListener(
-        private val autoScrollTask: AutoScrollTask,
-        private val callback: DrawingSurfaceListenerCallback,
-        displayDensity: Float,
-        val presenter: MainActivityContracts.Presenter
+    private val autoScrollTask: AutoScrollTask,
+    private val callback: DrawingSurfaceListenerCallback,
+    displayDensity: Float
 ) : OnTouchListener {
     private var touchMode: TouchMode
     private var pointerDistance = 0f
@@ -54,6 +52,7 @@ open class DrawingSurfaceListener(
     private val drawerEdgeSize: Int = (DRAWER_EDGE_SIZE * displayDensity + CONSTANT_1).toInt()
     private var autoScroll = true
     private var timerStartDraw = 0.toLong()
+    var presenter: MainActivityContracts.Presenter? = null
 
     internal enum class TouchMode {
         DRAW, PINCH
@@ -156,7 +155,7 @@ open class DrawingSurfaceListener(
                 if (eventTouchPoint.x < drawerEdgeSize || view.getWidth() - eventTouchPoint.x < drawerEdgeSize) {
                     return false
                 }
-                presenter.enterFullscreenClicked()
+                presenter?.enterFullscreenClicked()
                 timerStartDraw = System.currentTimeMillis()
                 currentTool.handleDown(canvasTouchPoint)
                 if (autoScroll) {
@@ -182,7 +181,7 @@ open class DrawingSurfaceListener(
                 eventX = 0f
                 eventY = 0f
                 touchMode = TouchMode.DRAW
-                presenter.exitFullscreenClicked()
+                presenter?.exitFullscreenClicked()
             }
         }
         drawingSurface.refreshDrawingSurface()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
@@ -41,6 +41,7 @@ import android.view.SurfaceView
 import androidx.core.content.ContextCompat
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.contract.LayerContracts
+import org.catrobat.paintroid.contract.MainActivityContracts
 import org.catrobat.paintroid.listener.DrawingSurfaceListener
 import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTask
 import org.catrobat.paintroid.listener.DrawingSurfaceListener.AutoScrollTaskCallback
@@ -64,6 +65,7 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
     private lateinit var perspective: Perspective
     private lateinit var toolReference: ToolReference
     private lateinit var toolOptionsViewController: ToolOptionsViewController
+    private lateinit var presenter: MainActivityContracts.Presenter
 
     constructor(context: Context?, attrSet: AttributeSet?) : super(context, attrSet)
 
@@ -104,20 +106,22 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
             override fun getToolOptionsViewController(): ToolOptionsViewController =
                 toolOptionsViewController
         }
-        drawingSurfaceListener = DrawingSurfaceListener(autoScrollTask, callback, density)
+        drawingSurfaceListener = DrawingSurfaceListener(autoScrollTask, callback, density, presenter)
         setOnTouchListener(drawingSurfaceListener)
     }
 
     fun setArguments(
-        layerModel: LayerContracts.Model,
-        perspective: Perspective,
-        toolReference: ToolReference,
-        toolOptionsViewController: ToolOptionsViewController
+            layerModel: LayerContracts.Model,
+            perspective: Perspective,
+            toolReference: ToolReference,
+            toolOptionsViewController: ToolOptionsViewController,
+            presenter: MainActivityContracts.Presenter,
     ) {
         this.layerModel = layerModel
         this.perspective = perspective
         this.toolReference = toolReference
         this.toolOptionsViewController = toolOptionsViewController
+        this.presenter = presenter
     }
 
     @Synchronized

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
@@ -65,11 +65,24 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
     private lateinit var perspective: Perspective
     private lateinit var toolReference: ToolReference
     private lateinit var toolOptionsViewController: ToolOptionsViewController
-    private lateinit var presenter: MainActivityContracts.Presenter
 
     constructor(context: Context?, attrSet: AttributeSet?) : super(context, attrSet)
 
     constructor(context: Context?) : super(context)
+
+    fun setArguments(
+        layerModel: LayerContracts.Model,
+        perspective: Perspective,
+        toolReference: ToolReference,
+        toolOptionsViewController: ToolOptionsViewController,
+        presenter: MainActivityContracts.Presenter?,
+    ) {
+        this.layerModel = layerModel
+        this.perspective = perspective
+        this.toolReference = toolReference
+        this.toolOptionsViewController = toolOptionsViewController
+        drawingSurfaceListener.presenter = presenter
+    }
 
     init {
         surfaceLock = Object()
@@ -106,22 +119,24 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
             override fun getToolOptionsViewController(): ToolOptionsViewController =
                 toolOptionsViewController
         }
-        drawingSurfaceListener = DrawingSurfaceListener(autoScrollTask, callback, density, presenter)
+        drawingSurfaceListener = DrawingSurfaceListener(autoScrollTask, callback, density)
         setOnTouchListener(drawingSurfaceListener)
     }
 
+    companion object {
+        private val TAG = DrawingSurface::class.java.name
+    }
+
     fun setArguments(
-            layerModel: LayerContracts.Model,
-            perspective: Perspective,
-            toolReference: ToolReference,
-            toolOptionsViewController: ToolOptionsViewController,
-            presenter: MainActivityContracts.Presenter,
+        layerModel: LayerContracts.Model,
+        perspective: Perspective,
+        toolReference: ToolReference,
+        toolOptionsViewController: ToolOptionsViewController
     ) {
         this.layerModel = layerModel
         this.perspective = perspective
         this.toolReference = toolReference
         this.toolOptionsViewController = toolOptionsViewController
-        this.presenter = presenter
     }
 
     @Synchronized

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.java
@@ -73,7 +73,7 @@ public class DrawingSurfaceListenerTest {
 		when(callback.getToolOptionsViewController())
 				.thenReturn(toolOptionsViewController);
 
-		drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask, callback, DISPLAY_DENSITY);
+		drawingSurfaceListener = new DrawingSurfaceListener(autoScrollTask, callback, DISPLAY_DENSITY, presenter);
 	}
 
 	@Test


### PR DESCRIPTION
Paintroid-298 implement automatic hiding of menu bars

switches to fullscreen mode on touch_down event and back on touch_up event


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
