### PR TITLE
PAINTRIOD-352 : fixed the stroke slider width

### DIFF
--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_stroke.xml
@@ -56,12 +56,13 @@
         android:id="@+id/pocketpaint_stroke_width_seek_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:max="100"
-        android:minHeight="30dip"
         android:layout_alignTop="@id/pocketpaint_stroke_width_width_text_layout"
-        android:layout_toEndOf="@+id/pocketpaint_stroke_width_width_text_layout"
         android:layout_alignBottom="@id/pocketpaint_stroke_width_width_text_layout"
-        android:layout_alignParentEnd="true"/>
+        android:layout_alignParentEnd="true"
+        android:layout_marginRight="10dp"
+        android:layout_toEndOf="@+id/pocketpaint_stroke_width_width_text_layout"
+        android:max="100"
+        android:minHeight="30dip" />
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
https://jira.catrob.at/browse/PAINTROID-352?jql=project%20%3D%20PAINTROID

added layout_marginRight of 10dp to the pocketpaint_stroke_width_seek_bar.


#![Before](https://user-images.githubusercontent.com/81173749/134683014-7d7e5587-92ed-40be-99df-7fa357a2449f.jpg)

![After](https://user-images.githubusercontent.com/81173749/134683048-077b2fc1-cc8a-40d9-b257-926293238009.jpg)


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behaviour
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
