### PR TITLE
PAINTROID-350 Color of bottom bar icons is wrong in landscape mode

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomNavigationLandscape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/BottomNavigationLandscape.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import com.google.android.material.bottomnavigation.BottomNavigationItemView
 import com.google.android.material.bottomnavigation.BottomNavigationMenuView
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -53,6 +54,7 @@ class BottomNavigationLandscape(context: Context, private val bottomNavigationVi
             val icon = itemBottomNavigation.findViewById<ImageView>(R.id.icon)
             val text = itemBottomNavigation.findViewById<TextView>(R.id.title)
             icon.setImageDrawable(menu.getItem(i).icon)
+            icon.setColorFilter(ContextCompat.getColor(context, R.color.pocketpaint_welcome_dot_active))
             text.text = menu.getItem(i).title
             item.removeAllViews()
             item.addView(itemBottomNavigation)


### PR DESCRIPTION
Added Icon.setColorFilter(white) to the setAppearance in the BottomNavigationLandscape.kt file. https://jira.catrob.at/browse/PAINTROID-350

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
