### PR TITLE
PAINTROID-324 When you load an image and select colour pipette app hangs for a while

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
@@ -56,7 +56,8 @@ private const val INITIAL_COLOR = "InitialColor"
 private const val REQUEST_CODE = 1
 private const val BITMAP_NAME = "temp.png"
 const val COLOR_EXTRA = "colorExtra"
-const val BITMAP_NAME_EXTRA = "bitmapNameExtra"
+const val BITMAP_HEIGHT_EXTRA = "bitmapHeightNameExtra"
+const val BITMAP_WIDTH_EXTRA = "bitmapWidthNameExtra"
 
 class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
     @VisibleForTesting
@@ -92,15 +93,17 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
             .inflate(R.layout.color_picker_dialog_view, null)
         currentColorView = dialogView.findViewById(R.id.color_picker_current_color_view)
         pipetteBtn = dialogView.findViewById(R.id.color_picker_pipette_btn)
+
         pipetteBtn.setOnClickListener {
             pipetteBtn.isEnabled = false
             CoroutineScope(Dispatchers.IO).launch {
-                storeBitmapTemporally(currentBitmap, requireContext(), BITMAP_NAME)
+                ColorPickerPreviewActivity.pickableImage = currentBitmap
                 withContext(Dispatchers.Main) {
                     pipetteBtn.isEnabled = true
                     val intent = Intent(it.context, ColorPickerPreviewActivity::class.java).apply {
                         putExtra(COLOR_EXTRA, colorToApply)
-                        putExtra(BITMAP_NAME_EXTRA, BITMAP_NAME)
+                        putExtra(BITMAP_HEIGHT_EXTRA, currentBitmap.height)
+                        putExtra(BITMAP_WIDTH_EXTRA, currentBitmap.width)
                     }
                     try {
                         startActivityForResult(intent, REQUEST_CODE)

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerPreviewActivity.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerPreviewActivity.kt
@@ -32,6 +32,9 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
+const val BITMAP_FALLBACK_HEIGHT = 512
+const val BITMAP_FALLBACK_WIDTH = 512
+
 class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedListener {
 
     private lateinit var backAction: ImageView
@@ -41,9 +44,6 @@ class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedL
 
     private var currentColor = 0
     private var oldChosenColor = 0
-
-    private var bitmapDefaultHeight = 512
-    private var bitmapDefaultWidth = 512
 
     companion object {
         var pickableImage: Bitmap? = null
@@ -78,7 +78,7 @@ class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedL
                     Bitmap.createBitmap(it1, it, Bitmap.Config.ARGB_8888)
                 }
             } ?: run {
-                Bitmap.createBitmap(bitmapDefaultWidth, bitmapDefaultHeight, Bitmap.Config.ARGB_8888)
+                Bitmap.createBitmap(BITMAP_FALLBACK_WIDTH, BITMAP_FALLBACK_HEIGHT, Bitmap.Config.ARGB_8888)
             }
             previewSurface.setImageBitmap(bitmap)
         }

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerPreviewActivity.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerPreviewActivity.kt
@@ -20,6 +20,7 @@ package org.catrobat.paintroid.colorpicker
 
 import android.content.DialogInterface
 import android.content.Intent
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.BitmapShader
 import android.graphics.Color
@@ -30,9 +31,6 @@ import android.view.WindowManager
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedListener {
 
@@ -43,6 +41,13 @@ class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedL
 
     private var currentColor = 0
     private var oldChosenColor = 0
+
+    private var bitmapDefaultHeight = 512
+    private var bitmapDefaultWidth = 512
+
+    companion object {
+        var pickableImage: Bitmap? = null
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -64,12 +69,18 @@ class ColorPickerPreviewActivity : AppCompatActivity(), OnImageViewPointClickedL
             setCurrentColor(it)
         }
 
-        intent?.extras?.getString(BITMAP_NAME_EXTRA)?.let {
-            CoroutineScope(Dispatchers.Main).launch {
-                loadBitmapByName(this@ColorPickerPreviewActivity, it)?.let {
-                    previewSurface.setImageBitmap(it)
+        pickableImage?.let { previewSurface.setImageBitmap(it) } ?: run {
+
+            val height = intent.extras?.getInt(BITMAP_HEIGHT_EXTRA)
+            val width = intent.extras?.getInt(BITMAP_WIDTH_EXTRA)
+            val bitmap = width?.let {
+                height?.let { it1 ->
+                    Bitmap.createBitmap(it1, it, Bitmap.Config.ARGB_8888)
                 }
+            } ?: run {
+                Bitmap.createBitmap(bitmapDefaultWidth, bitmapDefaultHeight, Bitmap.Config.ARGB_8888)
             }
+            previewSurface.setImageBitmap(bitmap)
         }
 
         doneAction.setOnClickListener {


### PR DESCRIPTION
removing coroutines that save and load the image, resulting in freeze.

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

Previously coroutines were used to temporarily save and restore an image to pass it to the new intent which is started when we click the pipette inside the color picker. The reason most likely was the byte-limitation for extras for new intents.
A static variable was introduced where a bitmap can be passed to the class. If no bitmap is set it will fall back to a colorless 512x512 bitmap to keep the current behavior.

The freeze is now completely removed.