### PR TITLE
Paintroid-366 Alpha value on the third tab of color picker is ignored

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -60,6 +60,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.pressBack;
 import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasSibling;
@@ -631,5 +632,33 @@ public class ColorDialogIntegrationTest {
 		onView(withId(R.id.color_picker_current_color_view))
 				.check(matches(isDisplayed()))
 				.check(matches(withBackgroundColor(Color.BLACK)));
+	}
+
+	@Test
+	public void alphaValueIsSetInSliderWhenChangedInSeekBar() {
+		onColorPickerView()
+				.performOpenColorPicker();
+		onView(allOf(withId(R.id.color_picker_tab_icon), withBackground(R.drawable.ic_color_picker_tab_rgba))).perform(click());
+
+		// set color to value #7F000000, alpha seekbar 49%
+		onView(withId(R.id.color_picker_color_rgb_seekbar_alpha)).perform(touchCenterMiddle());
+		onView(allOf(withId(R.id.color_picker_tab_icon), withBackground(R.drawable.ic_color_picker_tab_preset))).perform(scrollTo(), click());
+		onToolProperties()
+				.checkMatchesColor(Color.parseColor("#7F000000"));
+	}
+
+	@Test
+	public void alphaValueIsSetInSeekBarWhenChangedInSlider() {
+		onColorPickerView()
+				.performOpenColorPicker();
+		onView(allOf(withId(R.id.color_picker_tab_icon), withBackground(R.drawable.ic_color_picker_tab_preset))).perform(click());
+
+		// set color to value #80000000, alpha seekbar 50%
+		onView(withId(R.id.color_alpha_slider)).perform(scrollTo(), touchCenterMiddle());
+
+		onView(allOf(withId(R.id.color_picker_tab_icon), withBackground(R.drawable.ic_color_picker_tab_rgba))).perform(click());
+		onView(withId(R.id.color_picker_rgb_alpha_value)).check(matches(
+				withText("50")
+		));
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
@@ -53,10 +53,7 @@ class WatercolorTool(
 
     init {
         bitmapPaint.maskFilter = BlurMaskFilter(calcRange(bitmapPaint.alpha), BlurMaskFilter.Blur.INNER)
-        bitmapPaint.alpha = MAX_ALPHA_VALUE
-
         previewPaint.maskFilter = BlurMaskFilter(calcRange(previewPaint.alpha), BlurMaskFilter.Blur.INNER)
-        bitmapPaint.alpha = MAX_ALPHA_VALUE
     }
 
     override fun changePaintColor(color: Int) {
@@ -64,10 +61,7 @@ class WatercolorTool(
 
         brushToolOptionsView.invalidate()
         bitmapPaint.maskFilter = BlurMaskFilter(calcRange(bitmapPaint.alpha), BlurMaskFilter.Blur.INNER)
-        bitmapPaint.alpha = MAX_ALPHA_VALUE
-
         previewPaint.maskFilter = BlurMaskFilter(calcRange(previewPaint.alpha), BlurMaskFilter.Blur.INNER)
-        bitmapPaint.alpha = MAX_ALPHA_VALUE
     }
 
     private fun calcRange(value: Int): Float {

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/AlphaSlider.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/AlphaSlider.kt
@@ -73,7 +73,7 @@ class AlphaSlider(
     }
 
     companion object {
-        private var alphaVal = MAX_ALPHA
+        var alphaValue = MAX_ALPHA
         private lateinit var onColorChangedListener: OnColorChangedListener
         private var selectedColor = 0
         private var currentColor = 0
@@ -133,7 +133,7 @@ class AlphaSlider(
         alphaPaint.shader = alphaShader
         canvas.drawRect(rect, alphaPaint)
         val rectWidth = FOUR * density / SLIDER_PADDING
-        val p = alphaToPoint(alphaVal)
+        val p = alphaToPoint(alphaValue)
         val r = RectF()
         r.left = p.x - rectWidth
         r.right = p.x + rectWidth
@@ -181,7 +181,7 @@ class AlphaSlider(
         val startX = startTouchPoint!!.x
         val startY = startTouchPoint!!.y
         if (alphaRectangle.contains(startX.toFloat(), startY.toFloat())) {
-            alphaVal = pointToAlpha(event.x.toInt())
+            alphaValue = pointToAlpha(event.x.toInt())
         } else {
             update = false
         }
@@ -213,7 +213,7 @@ class AlphaSlider(
     fun getSelectedColor(): Int {
         val hsv = FloatArray(HSV_INITIALIZER)
         Color.colorToHSV(selectedColor, hsv)
-        selectedColor = Color.HSVToColor(alphaVal, hsv)
+        selectedColor = Color.HSVToColor(alphaValue, hsv)
 
         return selectedColor
     }
@@ -225,11 +225,15 @@ class AlphaSlider(
     fun setSelectedColor(color: Int) {
         val hsv = FloatArray(HSV_INITIALIZER)
         Color.colorToHSV(color, hsv)
-        selectedColor = Color.HSVToColor(alphaVal, hsv)
+        selectedColor = Color.HSVToColor(alphaValue, hsv)
         currentColor = color
 
         invalidate()
     }
 
-    fun getAlphaValue(): Int = alphaVal
+    fun getAlphaValue(): Int = alphaValue
+
+    fun setAlphaValue(value: Int) {
+        alphaValue = value
+    }
 }

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
@@ -163,7 +163,7 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
     }
 
     override fun colorChanged(color: Int) {
-        if (alphaSliderView.visibility == GONE) {
+        if (alphaSliderView.visibility == GONE && colorPickerView.rgbSelectorView.seekBarAlpha.visibility == GONE) {
             alphaSliderView.getAlphaSlider()?.invalidate()
             val alpha = alphaSliderView.getAlphaSlider()?.getAlphaValue()
             val hsv = FloatArray(HSV_INITIALIZER)
@@ -174,6 +174,9 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
                 colorToApply = newColor
             }
         } else {
+            if (colorPickerView.rgbSelectorView.seekBarAlpha.visibility != GONE) {
+                alphaSliderView.getAlphaSlider()?.setAlphaValue(Color.alpha(color))
+            }
             setViewColor(newColorView, color)
             colorToApply = color
         }

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.kt
@@ -37,7 +37,7 @@ private const val HSV_TAG = "HSV"
 private const val EXCEPTION = "Invalid TAG"
 
 class ColorPickerView : LinearLayoutCompat {
-    private val rgbSelectorView: RgbSelectorView
+    val rgbSelectorView: RgbSelectorView
     private val preSelectorView: PresetSelectorView
     private val hsvSelectorView: HSVSelectorView
     private var alphaSliderView: AlphaSliderView

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/RgbSelectorView.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/RgbSelectorView.kt
@@ -42,7 +42,7 @@ class RgbSelectorView : LinearLayoutCompat {
     private var seekBarRed: SeekBar
     private var seekBarGreen: SeekBar
     private var seekBarBlue: SeekBar
-    private var seekBarAlpha: SeekBar
+    var seekBarAlpha: SeekBar
     private var textViewRed: AppCompatTextView
     private var textViewGreen: AppCompatTextView
     private var textViewBlue: AppCompatTextView


### PR DESCRIPTION
alpha value of slider is now set when changing value of alpha seekbar in RGBSelectorView;
also fixed wrong alpha value when switching between watercolor tool and other tools
(https://jira.catrob.at/browse/PAINTROID-366)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
