### PR TITLE
PAINTROID-142: No flashing/blinking of the screen when saving or copying images

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveImageProgressBarTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveImageProgressBarTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.test.espresso
+
+import android.os.SystemClock
+import androidx.core.widget.ContentLoadingProgressBar
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import org.catrobat.paintroid.MainActivity
+import org.catrobat.paintroid.R
+import org.catrobat.paintroid.test.espresso.util.wrappers.TopBarViewInteraction
+import org.hamcrest.Matchers
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SaveImageProgressBarTest {
+
+    @get:Rule
+    val launchActivityRule = ActivityTestRule(MainActivity::class.java)
+
+    private lateinit var activity: MainActivity
+
+    companion object {
+        private const val IMAGE_NAME = "fileName"
+    }
+    @Before
+    fun setUp() {
+        activity = launchActivityRule.activity
+    }
+
+    @Test
+    fun testProgressBarShown() {
+        val progressBar = activity.findViewById<ContentLoadingProgressBar>(R.id.pocketpaint_content_loading_progress_bar)
+        progressBar.show()
+        SystemClock.sleep(501)
+        onView(withId(R.id.pocketpaint_content_loading_progress_bar))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        progressBar.hide()
+    }
+
+    @Test
+    fun testProgressBarNotShown() {
+        val progressBar = activity.findViewById<ContentLoadingProgressBar>(R.id.pocketpaint_content_loading_progress_bar)
+        progressBar.show()
+        onView(withId(R.id.pocketpaint_content_loading_progress_bar))
+            .check(ViewAssertions.matches(Matchers.not(ViewMatchers.isDisplayed())))
+        progressBar.hide()
+    }
+
+    @Test
+    fun testProgressBarNotShownWhenSaving() {
+        TopBarViewInteraction.onTopBarView()
+            .performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image))
+            .perform(ViewActions.click())
+        onView(withId(R.id.pocketpaint_image_name_save_text))
+            .perform(replaceText(IMAGE_NAME))
+        onView(withText(R.string.save_button_text))
+            .perform(ViewActions.click())
+        onView(withId(R.id.pocketpaint_content_loading_progress_bar))
+            .check(ViewAssertions.matches(Matchers.not(ViewMatchers.isDisplayed())))
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.widget.ContentLoadingProgressBar
 import androidx.drawerlayout.widget.DrawerLayout
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import org.catrobat.paintroid.command.CommandFactory
@@ -126,6 +127,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
     private lateinit var bottomNavigationViewHolder: BottomNavigationViewHolder
     private lateinit var commandFactory: CommandFactory
     private var deferredRequestPermissionsResult: Runnable? = null
+    private lateinit var progressBar: ContentLoadingProgressBar
 
     companion object {
         const val TAG = "MainActivity"
@@ -400,6 +402,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         setBottomBarListeners(bottomBarViewHolder)
         setBottomNavigationListeners(bottomNavigationViewHolder)
         setActionBarToolTips(topBarViewHolder, context)
+        progressBar = findViewById(R.id.pocketpaint_content_loading_progress_bar)
     }
 
     private fun onCreateLayerMenu() {
@@ -592,5 +595,13 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             val rootView = window.decorView.rootView
             inputMethodManager.hideSoftInputFromWindow(rootView.windowToken, 0)
         }
+    }
+
+    override fun showContentLoadingProgressBar() {
+        progressBar.show()
+    }
+
+    override fun hideContentLoadingProgressBar() {
+        progressBar.hide()
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
@@ -161,6 +161,10 @@ interface MainActivityContracts {
         fun enterFullscreen()
 
         fun exitFullscreen()
+
+        fun showContentLoadingProgressBar()
+
+        fun hideContentLoadingProgressBar()
     }
 
     interface Presenter {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.java
@@ -867,7 +867,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void onSaveImagePreExecute(@SaveImageRequestCode int requestCode) {
-		navigator.showIndeterminateProgressDialog();
+		view.showContentLoadingProgressBar();
 	}
 
 	public static String getPathFromUri(final Context context, final Uri uri) {
@@ -964,7 +964,7 @@ public class MainActivityPresenter implements Presenter, SaveImageCallback, Load
 
 	@Override
 	public void onSaveImagePostExecute(@SaveImageRequestCode int requestCode, Uri uri, boolean saveAsCopy) {
-		navigator.dismissIndeterminateProgressDialog();
+		view.hideContentLoadingProgressBar();
 
 		if (uri == null) {
 			navigator.showSaveErrorDialog();

--- a/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
@@ -57,6 +57,15 @@
             android:layout_above="@id/pocketpaint_main_bottom_bar"
             android:layout_below="@+id/pocketpaint_layout_top_bar" />
 
+        <androidx.core.widget.ContentLoadingProgressBar
+            android:id="@+id/pocketpaint_content_loading_progress_bar"
+            style="?android:attr/progressBarStyleLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:visibility="gone"
+            />
+
         <LinearLayout
             android:id="@+id/pocketpaint_main_bottom_bar"
             android:layout_width="match_parent"

--- a/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
@@ -52,6 +52,15 @@
                 android:layout_above="@id/pocketpaint_main_bottom_bar"
                 android:layout_below="@+id/pocketpaint_layout_top_bar"/>
 
+            <androidx.core.widget.ContentLoadingProgressBar
+                android:id="@+id/pocketpaint_content_loading_progress_bar"
+                style="?android:attr/progressBarStyleLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:visibility="gone"
+                />
+
             <LinearLayout
                 android:id="@+id/pocketpaint_main_bottom_bar"
                 android:layout_width="match_parent"

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -920,7 +920,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePreExecuteThenShowProgressDialog() {
 		presenter.onSaveImagePreExecute(0);
 
-		verify(navigator).showIndeterminateProgressDialog();
+		verify(view).showContentLoadingProgressBar();
 	}
 
 	@Test
@@ -1315,7 +1315,7 @@ public class MainActivityPresenterTest {
 	public void testOnSaveImagePostExecuteThenDismissProgressDialog() {
 		presenter.onSaveImagePostExecute(0, null, false);
 
-		verify(navigator).dismissIndeterminateProgressDialog();
+		verify(view).hideContentLoadingProgressBar();
 	}
 
 	@Test


### PR DESCRIPTION
Instead of using the IndeterminateProgressDialog a ContentLoadingProgressBar without DialogFrame is used now.

The IndeterminateProgressDialog was shown and almost immediately afterwards dismissed, which led to flashing of the screen.

The ContentLoadingProgressBar is only shown, if action takes longer than 500ms and then for at least 500ms. 
This prevents the screen from flashing.

https://jira.catrob.at/browse/PAINTROID-142

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
