### PR TITLE
PAINTROID-361 Colorpicker permanently sends color to catroid

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/SaveCompressImageIntegrationTest.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -42,6 +43,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 
@@ -109,7 +111,7 @@ public class SaveCompressImageIntegrationTest {
 	}
 
 	@Test
-	public void testSaveImage() {
+	public void testSaveImage() throws IOException {
 		String testName = UUID.randomUUID().toString();
 		onTopBarView()
 				.performOpenMoreOptions();
@@ -122,8 +124,9 @@ public class SaveCompressImageIntegrationTest {
 		onView(withId(R.id.pocketpaint_save_dialog_spinner)).perform(click());
 		onData(allOf(is(instanceOf(String.class)), is("jpg"))).inRoot(isPlatformPopup()).perform(click());
 		onView(withText(R.string.save_button_text)).perform(click());
-		File compressedFile = new File(activity.model.getSavedPictureUri().getPath());
-		Bitmap compressedBitmap = FileIO.INSTANCE.getBitmapFromFile(compressedFile);
+		BitmapFactory.Options options = new BitmapFactory.Options();
+		options.inMutable = true;
+		Bitmap compressedBitmap = FileIO.INSTANCE.decodeBitmapFromUri(this.activity.getContentResolver(), Objects.requireNonNull(activity.model.getSavedPictureUri()), options, this.activity.getApplicationContext());
 		Bitmap testBitmap = FileIO.INSTANCE.getBitmapFromFile(testImageFile);
 		assertThat(compressedBitmap.getWidth(), is(equalTo(testBitmap.getWidth())));
 		assertThat(compressedBitmap.getHeight(), is(equalTo(testBitmap.getHeight())));

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -38,6 +38,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.test.espresso.action.ViewActions;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
 
@@ -375,12 +376,11 @@ public class ColorDialogIntegrationTest {
 		onView(withId(R.id.color_picker_color_rgb_seekbar_blue)).perform(touchCenterRight());
 		onView(withId(R.id.color_picker_color_rgb_seekbar_alpha)).perform(touchCenterRight());
 
-		assertNotEquals("Selected color changed to blue", toolReference.getTool().getDrawPaint().getColor(), Color.BLACK);
-
 		onColorPickerView()
 				.onPositiveButton()
 				.perform(click());
 
+		assertNotEquals("Selected color changed to blue from black", toolReference.getTool().getDrawPaint().getColor(), Color.BLACK);
 		assertEquals("Selected color is not blue", toolReference.getTool().getDrawPaint().getColor(), Color.BLUE);
 	}
 
@@ -530,7 +530,7 @@ public class ColorDialogIntegrationTest {
 	}
 
 	@Test
-	public void testStandardColorDoesNotChangeOnCancel() {
+	public void testStandardColorDoesNotChangeOnCancelButtonPress() {
 		int initialColor = toolReference.getTool().getDrawPaint().getColor();
 
 		onColorPickerView()
@@ -545,6 +545,45 @@ public class ColorDialogIntegrationTest {
 
 		onToolProperties()
 				.checkMatchesColor(initialColor);
+	}
+
+	@Test
+	public void testStandardColorDoesChangeOnCancel() {
+		int initialColor = toolReference.getTool().getDrawPaint().getColor();
+
+		onColorPickerView()
+				.performOpenColorPicker();
+		onColorPickerView()
+				.performClickColorPickerPresetSelectorButton(0);
+		onColorPickerView()
+				.perform(ViewActions.pressBack());
+		onToolProperties()
+				.checkDoesNotMatchColor(initialColor);
+	}
+
+	@Test
+	public void testColorOnlyUpdatesOncePerColorPickerIntent() {
+		int initialColor = toolReference.getTool().getDrawPaint().getColor();
+
+		onColorPickerView()
+				.performOpenColorPicker();
+		onColorPickerView()
+				.performClickColorPickerPresetSelectorButton(0);
+		onToolProperties()
+				.checkMatchesColor(initialColor);
+		onColorPickerView()
+				.performClickColorPickerPresetSelectorButton(1);
+		onToolProperties()
+				.checkMatchesColor(initialColor);
+		onColorPickerView()
+				.performClickColorPickerPresetSelectorButton(2);
+		onToolProperties()
+				.checkMatchesColor(initialColor);
+
+		onColorPickerView()
+				.perform(ViewActions.pressBack());
+		onToolProperties()
+				.checkDoesNotMatchColor(initialColor);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolPropertiesInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolPropertiesInteraction.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -33,6 +33,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import static org.catrobat.paintroid.test.espresso.util.EspressoUtils.getMainActivity;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public final class ToolPropertiesInteraction extends CustomViewInteraction {
 	private ToolPropertiesInteraction() {
@@ -44,6 +45,11 @@ public final class ToolPropertiesInteraction extends CustomViewInteraction {
 
 	public ToolPropertiesInteraction checkMatchesColor(@ColorInt int expectedColor) {
 		assertEquals(expectedColor, getCurrentTool().getDrawPaint().getColor());
+		return this;
+	}
+
+	public ToolPropertiesInteraction checkDoesNotMatchColor(@ColorInt int color) {
+		assertNotEquals(color, getCurrentTool().getDrawPaint().getColor());
 		return this;
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -254,7 +254,7 @@ object FileIO {
     }
 
     @Throws(IOException::class)
-    private fun decodeBitmapFromUri(
+    fun decodeBitmapFromUri(
         resolver: ContentResolver,
         uri: Uri,
         options: BitmapFactory.Options,

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerDialog.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -57,7 +57,6 @@ private const val INITIAL_CATROID_FLAG = "InitialCatroidFlag"
 private const val CURRENT_COLOR = "CurrentColor"
 private const val INITIAL_COLOR = "InitialColor"
 private const val REQUEST_CODE = 1
-private const val BITMAP_NAME = "temp.png"
 const val COLOR_EXTRA = "colorExtra"
 const val BITMAP_HEIGHT_EXTRA = "bitmapHeightNameExtra"
 const val BITMAP_WIDTH_EXTRA = "bitmapWidthNameExtra"
@@ -65,14 +64,14 @@ const val BITMAP_WIDTH_EXTRA = "bitmapWidthNameExtra"
 class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
     @VisibleForTesting
     var onColorPickedListener = mutableListOf<OnColorPickedListener>()
+    private var colorToApply = 0
+
     private lateinit var colorPickerView: ColorPickerView
     private lateinit var currentColorView: View
     private lateinit var newColorView: View
     private lateinit var pipetteBtn: MaterialButton
     private lateinit var checkeredShader: Shader
     private lateinit var currentBitmap: Bitmap
-
-    private var colorToApply = 0
 
     companion object {
         private lateinit var alphaSliderView: AlphaSliderView
@@ -137,11 +136,11 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
         colorToApply = colorPickerView.initialColor
         val materialDialog = MaterialAlertDialogBuilder(requireContext(), R.style.AlertDialogTheme)
             .setNegativeButton(R.string.color_picker_cancel) { dialogInterface: DialogInterface, _: Int ->
-                updateColorChange(colorPickerView.initialColor)
+                // updateColorChange(colorToApply)
                 dialogInterface.dismiss()
             }
             .setPositiveButton(R.string.color_picker_apply) { _: DialogInterface, _: Int ->
-                deleteBitmapFile(requireContext(), BITMAP_NAME)
+                updateColorChange(colorToApply)
                 dismiss()
             }
             .setView(dialogView)
@@ -151,8 +150,12 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
             materialDialog.window?.clearFlags(FLAG_NOT_FOCUSABLE or FLAG_ALT_FOCUSABLE_IM)
             materialDialog.window?.setSoftInputMode(SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         }
-
         return materialDialog
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        updateColorChange(colorToApply)
+        super.onCancel(dialog)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -177,8 +180,6 @@ class ColorPickerDialog : AppCompatDialogFragment(), OnColorChangedListener {
             setViewColor(newColorView, color)
             colorToApply = color
         }
-
-        updateColorChange(colorToApply)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
Following behaviour was discussed and implemented:

- Apply color changes when the "Apply button" is clicked
- Apply color changes when the "Back button" is clicked
- Apply color changes when the _onCancel_-cethod is called e.g. the user clicks outside the ColorPickerView
- Colors **are not applied** when the "Cancel button" is clicked.
- Color changes should be applied once and only once when the color picker is dismissed and a change has accured.

Older tests have been adjusted to follow the defined behaviour. 
A new test was added to checks the "only apply once"-rule!


One test is currently failing in the pipeline, sadly i can not pinpoint the cause right now.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer