### PR TITLE
PAINTROID-382: "+" icon not appearing in line tool after drawing the first line segment

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/LineToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/LineToolIntegrationTest.java
@@ -290,6 +290,65 @@ public class LineToolIntegrationTest {
 	}
 
 	@Test
+	public void testConnectedLinesFeatureDrawingLine() {
+		onToolProperties().setColor(Color.BLACK);
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT, DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onTopBarView().performClickPlus();
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_BOTTOM_MIDDLE);
+
+		onTopBarView().performClickPlus();
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_LEFT_MIDDLE, DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_TOP_LEFT);
+
+		onTopBarView().performClickCheckmark();
+	}
+
+	@Test
+	public void testConnectedLinesFeatureRedrawingLine() {
+		onToolProperties().setColor(Color.BLACK);
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT, DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_RIGHT, DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_LEFT));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_BOTTOM_RIGHT);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_RIGHT_MIDDLE);
+
+		onTopBarView().performClickPlus();
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_LEFT_MIDDLE, DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_TOP_LEFT);
+
+		onTopBarView().performClickCheckmark();
+	}
+
+	@Test
 	public void testClickingUndoOnceOnConnectedLines() {
 		onToolProperties().setColor(Color.BLACK);
 
@@ -372,6 +431,57 @@ public class LineToolIntegrationTest {
 
 		onDrawingSurfaceView()
 				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE);
+
+		onTopBarView().performClickCheckmark();
+	}
+
+	@Test
+	public void testUndoWithDrawingConnectedLines() {
+		onToolProperties().setColor(Color.BLACK);
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_LEFT_MIDDLE));
+
+		onDrawingSurfaceView()
+				.perform(touchAt(DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE));
+
+		onTopBarView().performClickPlus();
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT, DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_RIGHT));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_BOTTOM_RIGHT);
+
+		onTopBarView().performUndo();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_BOTTOM_RIGHT);
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT, DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_RIGHT));
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT, DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_LEFT));
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_BOTTOM_RIGHT);
+
+		onTopBarView().performClickPlus();
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_RIGHT, DrawingSurfaceLocationProvider.HALFWAY_TOP_MIDDLE));
+
+		onDrawingSurfaceView()
+				.perform(swipe(DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT, DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_RIGHT));
+
+		onTopBarView().performUndo();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_BOTTOM_RIGHT);
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_BOTTOM_LEFT);
 
 		onTopBarView().performClickCheckmark();
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/BitmapLocationProvider.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/BitmapLocationProvider.java
@@ -82,6 +82,12 @@ public enum BitmapLocationProvider implements CoordinatesProvider{
 		public float[] calculateCoordinates(View view) {
 			return calculatePercentageOffset(view, .75f, .75f);
 		}
+	},
+	HALFWAY_BOTTOM_LEFT {
+		@Override
+		public float[] calculateCoordinates(View view) {
+			return calculatePercentageOffset(view, .25f, .75f);
+		}
 	};
 
 	private static float[] calculatePercentageOffset(View view, float percentageX, float percentageY) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
@@ -153,4 +153,21 @@ class LineToolTest {
         Assert.assertEquals(tool.connectedLines, true)
         Assert.assertEquals(tool.undoRecentlyClicked, false)
     }
+
+    @Test
+    @UiThreadTest
+    fun testIfPlusIsDisplayedAfterDrawingLine() {
+        tool.handleDown(PointF(1f, 1f))
+        tool.handleMove(PointF(500f, 500f))
+        tool.handleUp(PointF(500f, 500f))
+        Assert.assertEquals(tool.currentCoordinate, null)
+        Assert.assertEquals(tool.initialEventCoordinate, null)
+        Assert.assertEquals(tool.startpointSet, true)
+        Assert.assertNotEquals(tool.startPointToDraw, null)
+        val plusButtonVisibility = LineTool.topBarViewHolder?.plusButton?.visibility
+        Assert.assertEquals(plusButtonVisibility, View.VISIBLE)
+        tool.onClickOnPlus()
+        Assert.assertEquals(tool.connectedLines, true)
+        Assert.assertEquals(tool.undoRecentlyClicked, false)
+    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/Constants.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/common/Constants.kt
@@ -20,4 +20,3 @@ package org.catrobat.paintroid.tools.common
 
 const val SCROLL_TOLERANCE_PERCENTAGE = 0.1f
 const val MOVE_TOLERANCE = 5f
-const val LINE_THRESHOLD = 100f

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
@@ -32,12 +32,9 @@ import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.common.CommonBrushChangedListener
 import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener
-import org.catrobat.paintroid.tools.common.LINE_THRESHOLD
-import org.catrobat.paintroid.tools.implementation.LineTool.Companion.topBarViewHolder
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
 import org.catrobat.paintroid.ui.viewholder.TopBarViewHolder
-import kotlin.math.abs
 
 class LineTool(
     private val brushToolOptionsView: BrushToolOptionsView,
@@ -84,6 +81,10 @@ class LineTool(
     var connectedLines = false
 
     var undoRecentlyClicked = false
+
+    var undoPreviousLineForConnectedLines = true
+
+    var changeInitialCoordinateForHandleNormalLine = false
 
     companion object {
         var topBarViewHolder: TopBarViewHolder? = null
@@ -146,9 +147,9 @@ class LineTool(
 
     fun onClickOnPlus() {
         if (startpointSet && endpointSet) {
-            val newStartCoordinate = endPointToDraw
-            initialEventCoordinate = endPointToDraw
-            previousEventCoordinate = endPointToDraw
+            val newStartCoordinate = endPointToDraw?.let { PointF(it.x, it.y) }
+            initialEventCoordinate = endPointToDraw?.let { PointF(it.x, it.y) }
+            previousEventCoordinate = endPointToDraw?.let { PointF(it.x, it.y) }
             startPointToDraw = null
             endPointToDraw = null
             startpointSet = false
@@ -204,14 +205,25 @@ class LineTool(
 
     override fun handleMove(coordinate: PointF?): Boolean {
         coordinate ?: return false
+        changeInitialCoordinateForHandleNormalLine = true
+        if (startpointSet) {
+            initialEventCoordinate = startPointToDraw?.let { PointF(it.x, it.y) }
+            previousEventCoordinate = startPointToDraw?.let { PointF(it.x, it.y) }
+            if (undoPreviousLineForConnectedLines && commandManager.isUndoAvailable && !undoRecentlyClicked) {
+                undoRecentlyClicked = false
+                commandManager.undo()
+            }
+            undoPreviousLineForConnectedLines = false
+            undoRecentlyClicked = false
+        }
         currentCoordinate = PointF(coordinate.x, coordinate.y)
         return true
     }
 
     fun handleStartPoint(xDistance: Float, yDistance: Float): Boolean {
-        startPointToDraw = previousEventCoordinate
-        startPointToDraw?.x = xDistance.let { startPointToDraw?.x?.minus(it) }
-        startPointToDraw?.y = yDistance.let { startPointToDraw?.y?.minus(it) }
+        startPointToDraw = previousEventCoordinate?.let { PointF(it.x, it.y) }
+        startPointToDraw?.x = startPointToDraw?.x?.minus(xDistance)
+        startPointToDraw?.y = startPointToDraw?.y?.minus(yDistance)
 
         if (startPointToDraw?.let { workspace.contains(it) } == true) {
             startpointSet = true
@@ -227,23 +239,25 @@ class LineTool(
         return true
     }
 
-    fun handleEndPoint(xDistance: Float, yDistance: Float): Boolean {
+    fun handleEndPoint(xDistance: Float, yDistance: Float, fromHandleLine: Boolean = false): Boolean {
         if (previousEventCoordinate?.let { workspace.contains(it) } == false) {
             return false
         }
-        endPointToDraw = previousEventCoordinate
-        endPointToDraw?.x = xDistance.let { endPointToDraw?.x?.minus(it) }
-        endPointToDraw?.y = yDistance.let { endPointToDraw?.y?.minus(it) }
+        endPointToDraw = previousEventCoordinate?.let { PointF(it.x, it.y) }
+        endPointToDraw?.x = endPointToDraw?.x?.minus(xDistance)
+        endPointToDraw?.y = endPointToDraw?.y?.minus(yDistance)
         endpointSet = true
         val startX = startPointToDraw?.x
         val startY = startPointToDraw?.y
         val endX = endPointToDraw?.x
         val endY = endPointToDraw?.y
-        if (commandManager.isUndoAvailable && !undoRecentlyClicked) {
-            commandManager.undo()
-        }
-        if (undoRecentlyClicked) {
-            undoRecentlyClicked = false
+        if (!fromHandleLine) {
+            if (commandManager.isUndoAvailable && !undoRecentlyClicked) {
+                commandManager.undo()
+            }
+            if (undoRecentlyClicked) {
+                undoRecentlyClicked = false
+            }
         }
 
         val finalPath = SerializablePath().apply {
@@ -261,11 +275,10 @@ class LineTool(
         return true
     }
 
-    fun handleNormalLine(coordinate: PointF): Boolean {
+    fun handleNormalLine(coordinate: PointF, xDistance: Float, yDistance: Float): Boolean {
         val bounds = RectF()
         if (startpointSet) {
-            resetInternalState()
-            return true
+            return handleEndPoint(xDistance, yDistance, true)
         }
         val finalPath = SerializablePath().apply {
             moveTo(
@@ -277,6 +290,18 @@ class LineTool(
         }
         bounds.inset(-toolPaint.strokeWidth, -toolPaint.strokeWidth)
 
+        previousEventCoordinate?.x = previousEventCoordinate?.x?.minus(xDistance)
+        previousEventCoordinate?.y = previousEventCoordinate?.y?.minus(yDistance)
+        startPointToDraw = initialEventCoordinate?.let { PointF(it.x, it.y) }
+        endPointToDraw = previousEventCoordinate?.let { PointF(it.x, it.y) }
+
+        endpointSet = true
+        startpointSet = true
+
+        if (topBarViewHolder != null && topBarViewHolder?.plusButton?.visibility != View.VISIBLE) {
+            topBarViewHolder?.showPlusButton()
+        }
+
         if (workspace.intersectsWith(bounds)) {
             val command = commandFactory.createPathCommand(toolPaint.paint, finalPath)
             commandManager.addCommand(command)
@@ -286,20 +311,27 @@ class LineTool(
     }
 
     override fun handleUp(coordinate: PointF?): Boolean {
+        undoPreviousLineForConnectedLines = true
+        if (changeInitialCoordinateForHandleNormalLine && initialEventCoordinate == null) {
+            initialEventCoordinate = startPointToDraw?.let { PointF(it.x, it.y) }
+        }
         if (initialEventCoordinate == null || previousEventCoordinate == null || coordinate == null) {
+            changeInitialCoordinateForHandleNormalLine = false
             return false
         }
         val xDistance = initialEventCoordinate?.x?.minus(coordinate.x)
         val yDistance = initialEventCoordinate?.y?.minus(coordinate.y)
         if (xDistance != null && yDistance != null) {
-            if (abs(xDistance) > LINE_THRESHOLD || abs(yDistance) > LINE_THRESHOLD) {
-                return handleNormalLine(coordinate)
+            if (changeInitialCoordinateForHandleNormalLine) {
+                changeInitialCoordinateForHandleNormalLine = false
+                return handleNormalLine(coordinate, xDistance, yDistance)
             } else if (!startpointSet) {
                 return handleStartPoint(xDistance, yDistance)
             } else {
                 return handleEndPoint(xDistance, yDistance)
             }
         }
+        changeInitialCoordinateForHandleNormalLine = false
         return true
     }
 


### PR DESCRIPTION
"+" didn't not appear when line was drawn in one swipe
(https://jira.catrob.at/browse/PAINTROID-382)

* setting startpoint plus endpoint and drawing a line was handled differently
* drawing a line in one swipe behaves now like setting startpoint and endpoint separately
* also fixes:
   PAINTROID-383: Line tool does not allow to correctly reposition end point of first segment
   (https://jira.catrob.at/browse/PAINTROID-383)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
