### PR TITLE
PAINTROID-371 IndexOutOfBoundsException paintroid.model.LayerModel.getLayerAt and similar crashes with layers (#3 in Crashes and ANRs)

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/LoadBitmapListCommandTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/LoadBitmapListCommandTest.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -53,8 +53,8 @@ class LoadBitmapListCommandTest {
     fun testRunCopiesImage() {
         commandUnderTest.run(canvas, layerModel)
         Assert.assertTrue(layerModel.currentLayer!!.bitmap!!.sameAs(bitmapList[0]))
-        Assert.assertTrue(layerModel.getLayerAt(1).bitmap!!.sameAs(bitmapList[1]))
-        Assert.assertTrue(layerModel.getLayerAt(2).bitmap!!.sameAs(bitmapList[2]))
+        Assert.assertTrue(layerModel.getLayerAt(1)!!.bitmap!!.sameAs(bitmapList[1]))
+        Assert.assertTrue(layerModel.getLayerAt(2)!!.bitmap!!.sameAs(bitmapList[2]))
     }
 
     @Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/MergeLayersCommandTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/MergeLayersCommandTest.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -74,10 +74,10 @@ class MergeLayersCommandTest {
     @Test
     fun testRun() {
         commandUnderTest.run(canvasUnderTest, layerModel)
-        Assert.assertEquals(layerModel.getLayerAt(0).bitmap!!.getPixel(5, 5), PAINT_BASE_COLOR)
-        Assert.assertEquals(layerModel.getLayerAt(0).bitmap!!.getPixel(8, 8), PAINT_BASE_COLOR)
-        Assert.assertEquals(layerModel.getLayerAt(0).bitmap!!.getPixel(3, 3), 0)
-        Assert.assertEquals(layerModel.getLayerAt(0).bitmap!!.getPixel(0, 0), 0)
+        Assert.assertEquals(layerModel.getLayerAt(0)!!.bitmap!!.getPixel(5, 5), PAINT_BASE_COLOR)
+        Assert.assertEquals(layerModel.getLayerAt(0)!!.bitmap!!.getPixel(8, 8), PAINT_BASE_COLOR)
+        Assert.assertEquals(layerModel.getLayerAt(0)!!.bitmap!!.getPixel(3, 3), 0)
+        Assert.assertEquals(layerModel.getLayerAt(0)!!.bitmap!!.getPixel(0, 0), 0)
     }
 
     @Test
@@ -96,6 +96,6 @@ class MergeLayersCommandTest {
         Assert.assertEquals(layerModel.currentLayer!!.bitmap!!.getPixel(8, 8), PAINT_BASE_COLOR)
         Assert.assertEquals(layerModel.currentLayer!!.bitmap!!.getPixel(3, 3), 0)
         Assert.assertEquals(layerModel.currentLayer!!.bitmap!!.getPixel(5, 5), 0)
-        Assert.assertEquals(layerModel.getLayerAt(1).bitmap!!.getPixel(5, 5), PAINT_BASE_COLOR)
+        Assert.assertEquals(layerModel.getLayerAt(1)!!.bitmap!!.getPixel(5, 5), PAINT_BASE_COLOR)
     }
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/model/LayerTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/model/LayerTest.java
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -39,7 +39,11 @@ import org.junit.runner.RunWith;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
@@ -50,14 +54,16 @@ public class LayerTest {
 	private CommandFactory commandFactory;
 	private CommandManager commandManager;
 	private LayerContracts.Model layerModel;
+	private final int layerHeight = 200;
+	private final int layerWidth = 200;
 
 	@Before
 	public void setUp() {
 		commandFactory = new DefaultCommandFactory();
 		layerModel = new LayerModel();
-		layerModel.setWidth(200);
-		layerModel.setHeight(200);
-		Layer layer = new Layer(Bitmap.createBitmap(200, 200, Bitmap.Config.ARGB_8888));
+		layerModel.setWidth(layerWidth);
+		layerModel.setHeight(layerHeight);
+		Layer layer = new Layer(Bitmap.createBitmap(layerWidth, layerHeight, Bitmap.Config.ARGB_8888));
 		layerModel.addLayerAt(0, layer);
 		layerModel.setCurrentLayer(layer);
 
@@ -154,5 +160,33 @@ public class LayerTest {
 		assertThat(layerToHide.getBitmap().getPixel(2, 1), is(Color.BLACK));
 		assertThat(layerToHide.getBitmap().getPixel(3, 1), is(Color.BLACK));
 		assertThat(layerToHide.getBitmap().getPixel(4, 1), is(Color.BLACK));
+	}
+
+	@Test
+	public void testGetLayerAt() {
+		for (int i = 0; i < layerModel.getLayerCount(); i++) {
+			assertNotNull(layerModel.getLayerAt(i));
+		}
+
+		assertNull(layerModel.getLayerAt(-1));
+		assertNull(layerModel.getLayerAt(layerModel.getLayerCount()));
+	}
+
+	@Test
+	public void testAddLayerAt() {
+		Layer layer = new Layer(Bitmap.createBitmap(layerWidth, layerHeight, Bitmap.Config.ARGB_8888));
+		assertTrue(layerModel.addLayerAt(0, layer));
+		assertTrue(layerModel.addLayerAt(layerModel.getLayerCount(), layer));
+		assertFalse(layerModel.addLayerAt(-1, layer));
+		assertFalse(layerModel.addLayerAt(layerModel.getLayerCount() + 1, layer));
+	}
+
+	@Test
+	public void testRemoveLayerAt() {
+		assertFalse(layerModel.removeLayerAt(-1));
+		assertTrue(layerModel.removeLayerAt(0));
+		Layer layer = new Layer(Bitmap.createBitmap(layerWidth, layerHeight, Bitmap.Config.ARGB_8888));
+		layerModel.addLayerAt(0, layer);
+		assertFalse(layerModel.removeLayerAt(layerModel.getLayerCount()));
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -90,23 +90,37 @@ class DefaultCommandManager(
     }
 
     override fun undo() {
+        var success = true
         val command = undoCommandList.pop()
         redoCommandList.addFirst(command)
-
         var layerCount = layerModel.layerCount
         val currentCommandName = command.javaClass.simpleName
         val addLayerCommandRegex = AddLayerCommand::class.java.simpleName.toRegex()
         val mergeLayerCommandRegex = MergeLayersCommand::class.java.simpleName.toRegex()
 
+        var backupLayer: LayerContracts.Layer? = null
         if (currentCommandName.matches(addLayerCommandRegex)) {
             layerCount--
-            layerModel.removeLayerAt(0)
+            backupLayer = layerModel.getLayerAt(0)
+            success = layerModel.removeLayerAt(0)
         }
 
         val checkBoxes: MutableList<Boolean> = ArrayList(Collections.nCopies(layerCount, true))
 
         if (!currentCommandName.matches(mergeLayerCommandRegex)) {
-            backUpCheckBoxes(layerCount, checkBoxes)
+            success = if (!backUpCheckBoxes(layerCount, checkBoxes)) false else success
+        }
+
+        if (!success) {
+            backupLayer?.apply {
+                if (layerModel.getLayerIndexOf(this) == -1) {
+                    layerModel.addLayerAt(0, this)
+                }
+            }
+            val commandToRestore = redoCommandList.pop()
+            undoCommandList.addFirst(commandToRestore)
+
+            return
         }
 
         layerModel.reset()
@@ -172,14 +186,21 @@ class DefaultCommandManager(
         }
     }
 
-    private fun backUpCheckBoxes(layerCount: Int, checkBoxes: MutableList<Boolean>) {
+    private fun backUpCheckBoxes(layerCount: Int, checkBoxes: MutableList<Boolean>): Boolean {
+        var success = true
         if (layerCount > 1) {
             for (index in layerCount - 1 downTo 0) {
-                checkBoxes[index] = layerModel.getLayerAt(index).checkBox
+                layerModel.getLayerAt(index)?.let {
+                    checkBoxes[index] = it.checkBox
+                } ?: run { success = false }
             }
         } else {
-            checkBoxes[0] = layerModel.getLayerAt(0).checkBox
+            layerModel.getLayerAt(0)?.let {
+                checkBoxes[0] = it.checkBox
+            } ?: run { success = false }
         }
+
+        return success
     }
 
     private fun fetchBackCheckBoxes(layerCount: Int, checkBoxes: List<Boolean>) {
@@ -187,8 +208,10 @@ class DefaultCommandManager(
             for (index in layerCount - 1 downTo 0) {
                 val destinationLayer = layerModel.getLayerAt(index)
                 if (!checkBoxes[index]) {
-                    destinationLayer.switchBitmaps(false)
-                    destinationLayer.checkBox = false
+                    destinationLayer?.let {
+                        it.switchBitmaps(false)
+                        it.checkBox = false
+                    }
                 }
             }
         } else {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/RemoveLayerCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/RemoveLayerCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -28,8 +28,9 @@ class RemoveLayerCommand(position: Int) : Command {
     var position = position; private set
 
     override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
-        layerModel.removeLayerAt(position)
-        layerModel.currentLayer = layerModel.layers[0]
+        if (layerModel.removeLayerAt(position)) {
+            layerModel.getLayerAt(0)?.let { layerModel.currentLayer = it }
+        }
     }
 
     override fun freeResources() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ReorderLayersCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ReorderLayersCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@
 package org.catrobat.paintroid.command.implementation
 
 import android.graphics.Canvas
+import android.util.Log
 import org.catrobat.paintroid.command.Command
 import org.catrobat.paintroid.contract.LayerContracts
 
@@ -28,11 +29,22 @@ class ReorderLayersCommand(position: Int, destination: Int) : Command {
     var position = position; private set
     var destination = destination; private set
 
+    companion object {
+        private val TAG = ReorderLayersCommand::class.java.simpleName
+    }
+
     override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
         layerModel.run {
-            val tempLayer = getLayerAt(position)
-            removeLayerAt(position)
-            addLayerAt(destination, tempLayer)
+            var success = false
+            getLayerAt(position)?.let { layer ->
+                if (removeLayerAt(position)) {
+                    success = addLayerAt(destination, layer)
+                }
+            }
+
+            if (!success) {
+                Log.e(TAG, "Could not retrieve layer to reorder!")
+            }
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -117,17 +117,17 @@ interface LayerContracts {
 
         fun reset()
 
-        fun getLayerAt(index: Int): Layer
+        fun getLayerAt(index: Int): Layer?
 
         fun getLayerIndexOf(layer: Layer): Int
 
-        fun addLayerAt(index: Int, layer: Layer)
+        fun addLayerAt(index: Int, layer: Layer): Boolean
 
         fun listIterator(index: Int): ListIterator<Layer>
 
         fun setLayerAt(position: Int, layer: Layer)
 
-        fun removeLayerAt(position: Int)
+        fun removeLayerAt(position: Int): Boolean
     }
 
     interface Navigator {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -22,12 +22,13 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import org.catrobat.paintroid.contract.LayerContracts
 import java.util.ArrayList
+import kotlin.IndexOutOfBoundsException
 
 class LayerModel : LayerContracts.Model {
     override var currentLayer: LayerContracts.Layer? = null
     override var width = 0
     override var height = 0
-    override val layers: ArrayList<LayerContracts.Layer> = ArrayList()
+    override val layers: ArrayList<LayerContracts.Layer> = arrayListOf()
     override val layerCount: Int
         get() = layers.size
 
@@ -35,12 +36,16 @@ class LayerModel : LayerContracts.Model {
         layers.clear()
     }
 
-    override fun getLayerAt(index: Int): LayerContracts.Layer = layers[index]
+    override fun getLayerAt(index: Int): LayerContracts.Layer? = layers.getOrNull(index)
 
     override fun getLayerIndexOf(layer: LayerContracts.Layer): Int = layers.indexOf(layer)
 
-    override fun addLayerAt(index: Int, layer: LayerContracts.Layer) {
+    @SuppressWarnings("SwallowedException", "TooGenericExceptionCaught")
+    override fun addLayerAt(index: Int, layer: LayerContracts.Layer): Boolean = try {
         layers.add(index, layer)
+        true
+    } catch (e: IndexOutOfBoundsException) {
+        false
     }
 
     override fun listIterator(index: Int): ListIterator<LayerContracts.Layer> =
@@ -50,12 +55,15 @@ class LayerModel : LayerContracts.Model {
         layers[position] = layer
     }
 
-    override fun removeLayerAt(position: Int) {
+    @SuppressWarnings("SwallowedException", "TooGenericExceptionCaught")
+    override fun removeLayerAt(position: Int): Boolean = try {
         layers.removeAt(position)
+        true
+    } catch (e: IndexOutOfBoundsException) {
+        false
     }
 
     companion object {
-        @JvmStatic
         fun getBitmapOfAllLayersToSave(layers: List<LayerContracts.Layer>): Bitmap? {
             if (layers.isEmpty()) {
                 return null
@@ -73,7 +81,6 @@ class LayerModel : LayerContracts.Model {
             return bitmap
         }
 
-        @JvmStatic
         fun getBitmapListOfAllLayers(layers: List<LayerContracts.Layer>): List<Bitmap?> {
             val bitmapList: MutableList<Bitmap?> = ArrayList()
             for (layer in layers) {


### PR DESCRIPTION
Added error handling to the LayerModel for invalid index accesses. Errors occured due to concurrency issues - now null types are returned instead of crashing.  All major occurences now have null type handling in place, resulting in silent fails for the relevant commands, leaving a valid state behind.  Command undo's are no handled. Missing tests for the LayerModel have been added.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
