### PR TITLE
PAINTROID-323: Overwrite adds suffix after filetype, it should be before .png

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
@@ -421,7 +421,7 @@ class MenuFileActivityIntegrationTest {
 
     @Test
     fun testCheckSaveImageDialogShowPNGSpinnerText() {
-        FileIO.compressFormat = Bitmap.CompressFormat.PNG
+        FileIO.fileType = FileIO.FileType.PNG
         onDrawingSurfaceView().perform(touchAt(MIDDLE))
         onTopBarView().performOpenMoreOptions()
         onView(withText(R.string.menu_save_image)).perform(click())
@@ -431,7 +431,7 @@ class MenuFileActivityIntegrationTest {
 
     @Test
     fun testCheckSaveImageDialogShowORASpinnerText() {
-        FileIO.isCatrobatImage = true
+        FileIO.fileType = FileIO.FileType.ORA
         onDrawingSurfaceView().perform(touchAt(MIDDLE))
         onTopBarView().performOpenMoreOptions()
         onView(withText(R.string.menu_save_image)).perform(click())
@@ -522,6 +522,138 @@ class MenuFileActivityIntegrationTest {
         onDrawingSurfaceView().checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE)
         onDrawingSurfaceView().perform(touchAt(MIDDLE))
         onDrawingSurfaceView().checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE)
+    }
+
+    @Test
+    fun testSameFileNameAfterOverwritePng() {
+        val name = "testPNG"
+        FileIO.filename = name
+        FileIO.fileType = FileIO.FileType.PNG
+        FileIO.compressFormat = Bitmap.CompressFormat.PNG
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(200))
+        val uri = activity.model.savedPictureUri
+        onDrawingSurfaceView().perform(touchAt(MIDDLE))
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(100))
+        onView(withText(R.string.overwrite_button_text)).check(matches(isDisplayed()))
+        onView(withText(R.string.overwrite_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+
+        val oldFileName = uri?.path?.let { File(it).name }
+        val newFileName = activity.model.savedPictureUri?.path?.let { File(it).name }
+
+        assertEquals(oldFileName, newFileName)
+        addUriToDeletionFileList(activity.model.savedPictureUri)
+    }
+
+    @Test
+    fun testSameFileNameAfterOverwriteJpg() {
+        val name = "testJPG"
+        FileIO.filename = name
+        FileIO.fileType = FileIO.FileType.JPG
+        FileIO.compressFormat = Bitmap.CompressFormat.JPEG
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(200))
+        val uri = activity.model.savedPictureUri
+        onDrawingSurfaceView().perform(touchAt(MIDDLE))
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(100))
+        onView(withText(R.string.overwrite_button_text)).check(matches(isDisplayed()))
+        onView(withText(R.string.overwrite_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+
+        val oldFileName = uri?.path?.let { File(it).name }
+        val newFileName = activity.model.savedPictureUri?.path?.let { File(it).name }
+
+        assertEquals(oldFileName, newFileName)
+        addUriToDeletionFileList(activity.model.savedPictureUri)
+    }
+
+    @Test
+    fun testSameFileNameAfterOverwriteOra() {
+        val name = "testORA"
+        FileIO.filename = name
+        FileIO.fileType = FileIO.FileType.ORA
+        FileIO.compressFormat = Bitmap.CompressFormat.PNG
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+        onDrawingSurfaceView().perform(touchAt(MIDDLE))
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+        onView(withText(R.string.overwrite_button_text)).check(matches(isDisplayed()))
+        onView(withText(R.string.overwrite_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+
+        var newFileName = "new"
+        val uri = activity.model.savedPictureUri
+        if (uri != null) {
+            val cursor = activity.contentResolver.query(
+                uri,
+                arrayOf(MediaStore.Images.ImageColumns.DISPLAY_NAME),
+                null, null, null
+            )
+            cursor?.use {
+                if (cursor.moveToFirst()) {
+                    newFileName =
+                        cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.DISPLAY_NAME))
+                }
+            }
+        }
+
+        assertEquals(newFileName, "testORA.ora")
+        addUriToDeletionFileList(activity.model.savedPictureUri)
+    }
+
+    @Test
+    fun testSameFileNameAfterOverwriteCatrobatImage() {
+        val name = "testCI"
+        FileIO.filename = name
+        FileIO.fileType = FileIO.FileType.CATROBAT
+        FileIO.compressFormat = Bitmap.CompressFormat.PNG
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+        onDrawingSurfaceView().perform(touchAt(MIDDLE))
+        onTopBarView().performOpenMoreOptions()
+        onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withText(R.string.save_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+        onView(withText(R.string.overwrite_button_text)).check(matches(isDisplayed()))
+        onView(withText(R.string.overwrite_button_text)).perform(click())
+        onView(isRoot()).perform(waitFor(500))
+
+        var newFileName = "new"
+        val uri = activity.model.savedPictureUri
+        if (uri != null) {
+            val cursor = activity.contentResolver.query(
+                uri,
+                arrayOf(MediaStore.Images.ImageColumns.DISPLAY_NAME),
+                null, null, null
+            )
+            cursor?.use {
+                if (cursor.moveToFirst()) {
+                    newFileName =
+                        cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.DISPLAY_NAME))
+                }
+            }
+        }
+
+        assertEquals(newFileName, "testCI.catrobat-image")
+        addUriToDeletionFileList(activity.model.savedPictureUri)
     }
 
     private fun addUriToDeletionFileList(uri: Uri?) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
@@ -91,9 +91,6 @@ object FileIO {
     var navigator: MainActivityContracts.Navigator? = null
 
     @JvmField
-    var isCatrobatImage = false
-
-    @JvmField
     var storeImageUri: Uri? = null
 
     var temporaryFilePath: String? = null

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
@@ -248,7 +248,7 @@ interface MainActivityContracts {
 
         fun saveImageConfirmClicked(requestCode: Int, uri: Uri?)
 
-        fun saveCopyConfirmClicked(requestCode: Int)
+        fun saveCopyConfirmClicked(requestCode: Int, uri: Uri?)
 
         fun undoClicked()
 
@@ -311,7 +311,13 @@ interface MainActivityContracts {
     }
 
     interface Interactor {
-        fun saveCopy(callback: SaveImageCallback, requestCode: Int, workspace: Workspace, context: Context)
+        fun saveCopy(
+            callback: SaveImageCallback,
+            requestCode: Int,
+            workspace: Workspace,
+            uri: Uri?,
+            context: Context
+        )
 
         fun createFile(callback: CreateFileCallback, requestCode: Int, filename: String)
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/SaveInformationDialog.kt
@@ -42,7 +42,6 @@ import org.catrobat.paintroid.FileIO.FileType.JPG
 import org.catrobat.paintroid.FileIO.FileType.CATROBAT
 import org.catrobat.paintroid.FileIO.FileType.ORA
 import org.catrobat.paintroid.R
-import org.catrobat.paintroid.common.PERMISSION_EXTERNAL_STORAGE_SAVE_COPY
 import java.util.Locale
 
 private const val STANDARD_FILE_NAME = "image"
@@ -72,7 +71,6 @@ class SaveInformationDialog :
             isExport: Boolean
         ): SaveInformationDialog {
             if (isStandard) {
-                FileIO.isCatrobatImage = false
                 FileIO.filename = STANDARD_FILE_NAME
                 FileIO.compressFormat = Bitmap.CompressFormat.PNG
                 FileIO.fileType = PNG
@@ -118,9 +116,7 @@ class SaveInformationDialog :
             .setPositiveButton(R.string.save_button_text) { _, _ ->
                 FileIO.filename = imageName.text.toString()
                 FileIO.storeImageUri = null
-                if (permission != PERMISSION_EXTERNAL_STORAGE_SAVE_COPY &&
-                    FileIO.checkFileExists(FileIO.fileType, FileIO.defaultFileName, requireContext().contentResolver)
-                ) {
+                if (FileIO.checkFileExists(FileIO.fileType, FileIO.defaultFileName, requireContext().contentResolver)) {
                     presenter.showOverwriteDialog(permission, isExport)
                 } else {
                     presenter.switchBetweenVersions(permission, isExport)
@@ -168,10 +164,10 @@ class SaveInformationDialog :
     private fun initInfoButton(view: View) {
         val infoButton: AppCompatImageButton = view.findViewById(R.id.pocketpaint_btn_save_info)
         infoButton.setOnClickListener {
-            when {
-                FileIO.isCatrobatImage -> presenter.showOraInformationDialog()
-                FileIO.compressFormat == Bitmap.CompressFormat.JPEG -> presenter.showJpgInformationDialog()
-                FileIO.fileType == CATROBAT -> presenter.showCatrobatInformationDialog()
+            when (FileIO.fileType) {
+                JPG -> presenter.showJpgInformationDialog()
+                ORA -> presenter.showOraInformationDialog()
+                CATROBAT -> presenter.showCatrobatInformationDialog()
                 else -> presenter.showPngInformationDialog()
             }
         }
@@ -193,33 +189,31 @@ class SaveInformationDialog :
 
     private fun setFileDetails(
         compressFormat: Bitmap.CompressFormat,
-        isCatrobatImage: Boolean,
-        fileType: FileType,
-        isJpg: Boolean = false
+        fileType: FileType
     ) {
         specificFormatLayout.removeAllViews()
-        if (isJpg) {
+        if (fileType == JPG) {
             specificFormatLayout.addView(jpgView)
         }
         FileIO.compressFormat = compressFormat
-        FileIO.isCatrobatImage = isCatrobatImage
         FileIO.fileType = fileType
     }
 
     private fun setSpinnerSelection() {
-        when {
-            FileIO.isCatrobatImage -> spinner.setSelection(2)
-            FileIO.compressFormat == Bitmap.CompressFormat.PNG -> spinner.setSelection(0)
-            else -> spinner.setSelection(1)
+        when (FileIO.fileType) {
+            JPG -> spinner.setSelection(JPG.ordinal)
+            ORA -> spinner.setSelection(ORA.ordinal)
+            CATROBAT -> spinner.setSelection(CATROBAT.ordinal)
+            else -> spinner.setSelection(PNG.ordinal)
         }
     }
 
     override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
         when (parent?.getItemAtPosition(position).toString().toLowerCase(Locale.getDefault())) {
-            JPG.value -> setFileDetails(Bitmap.CompressFormat.JPEG, false, JPG, true)
-            PNG.value -> setFileDetails(Bitmap.CompressFormat.PNG, false, PNG)
-            ORA.value -> setFileDetails(Bitmap.CompressFormat.PNG, true, ORA)
-            CATROBAT.value -> setFileDetails(Bitmap.CompressFormat.PNG, false, CATROBAT)
+            JPG.value -> setFileDetails(Bitmap.CompressFormat.JPEG, JPG)
+            PNG.value -> setFileDetails(Bitmap.CompressFormat.PNG, PNG)
+            ORA.value -> setFileDetails(Bitmap.CompressFormat.PNG, ORA)
+            CATROBAT.value -> setFileDetails(Bitmap.CompressFormat.PNG, CATROBAT)
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImage.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/SaveImage.kt
@@ -113,7 +113,7 @@ class SaveImage(
                 idlingResource.increment()
                 val bitmap = workspace.bitmapOfAllLayers
                 val filename = FileIO.defaultFileName
-                currentUri = if (FileIO.isCatrobatImage) {
+                currentUri = if (FileIO.fileType == FileIO.FileType.ORA) {
                     val bitmapList = workspace.bitmapLisOfAllLayers
                     if (uri != null && filename.endsWith(FileIO.FileType.ORA.toExtension())) {
                         uri?.let {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -315,7 +315,6 @@ open class MainActivityPresenter(
         FileIO.filename = "image"
         FileIO.compressFormat = Bitmap.CompressFormat.PNG
         FileIO.fileType = FileIO.FileType.PNG
-        FileIO.isCatrobatImage = false
         FileIO.deleteTempFile(internalMemoryPath)
         val initCommand = commandFactory.createInitCommand(metrics.widthPixels, metrics.heightPixels)
         commandManager.setInitialStateCommand(initCommand)
@@ -491,7 +490,10 @@ open class MainActivityPresenter(
                         checkForDefaultFilename()
                     }
                     PERMISSION_EXTERNAL_STORAGE_SAVE_COPY -> {
-                        saveCopyConfirmClicked(SAVE_IMAGE_DEFAULT)
+                        saveCopyConfirmClicked(
+                            SAVE_IMAGE_DEFAULT,
+                            FileIO.storeImageUri
+                        )
                         checkForDefaultFilename()
                     }
                     PERMISSION_REQUEST_CODE_REPLACE_PICTURE ->
@@ -544,10 +546,10 @@ open class MainActivityPresenter(
         interactor.saveImage(this, requestCode, workspace, uri, context)
     }
 
-    override fun saveCopyConfirmClicked(requestCode: Int) {
+    override fun saveCopyConfirmClicked(requestCode: Int, uri: Uri?) {
         checkIfClippingToolNeedsAdjustment()
         view.refreshDrawingSurface()
-        interactor.saveCopy(this, requestCode, workspace, context)
+        interactor.saveCopy(this, requestCode, workspace, uri, context)
     }
 
     override fun undoClicked() {
@@ -833,6 +835,13 @@ open class MainActivityPresenter(
         if (result.model != null) {
             commandManager.loadCommandsCatrobatImage(result.model)
             resetPerspectiveAfterNextCommand = true
+            FileIO.fileType = FileIO.FileType.CATROBAT
+            if (uri != null) {
+                val name = getFileName(uri)
+                if (name != null) {
+                    FileIO.filename = name.substring(0, name.length - FileIO.fileType.toExtension().length)
+                }
+            }
             return
         }
         if (result.toBeScaled) {
@@ -863,15 +872,13 @@ open class MainActivityPresenter(
                         if (name.endsWith(FileIO.FileType.JPG.value) || name.endsWith("jpeg")) {
                             FileIO.compressFormat = Bitmap.CompressFormat.JPEG
                             FileIO.fileType = FileIO.FileType.JPG
-                            FileIO.isCatrobatImage = false
                         } else if (name.endsWith(FileIO.FileType.PNG.value)) {
                             FileIO.compressFormat = Bitmap.CompressFormat.PNG
                             FileIO.fileType = FileIO.FileType.PNG
-                            FileIO.isCatrobatImage = false
                         } else {
                             FileIO.fileType = FileIO.FileType.ORA
-                            FileIO.isCatrobatImage = true
                         }
+                        FileIO.filename = name.substring(0, name.length - FileIO.fileType.toExtension().length)
                     }
                 }
             }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.kt
@@ -39,9 +39,10 @@ class MainActivityInteractor(private val idlingResource: CountingIdlingResource)
         callback: SaveImageCallback,
         requestCode: Int,
         workspace: Workspace,
+        uri: Uri?,
         context: Context
     ) {
-        SaveImage(callback, requestCode, workspace, null, true, context, scopeIO, idlingResource).execute()
+        SaveImage(callback, requestCode, workspace, uri, true, context, scopeIO, idlingResource).execute()
     }
 
     override fun createFile(callback: CreateFileCallback, requestCode: Int, filename: String) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.kt
@@ -478,7 +478,6 @@ class MainActivityNavigator(
             }
             FileIO.filename = "image$imageNumber"
             FileIO.catroidFlag = true
-            FileIO.isCatrobatImage = false
             mainActivity.presenter.switchBetweenVersions(permissionCode, isExport)
             return
         }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -270,7 +270,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, context);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, null, context);
 		verifyNoMoreInteractions(interactor);
 	}
 
@@ -495,16 +495,16 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testSaveCopyConfirmCLickedThenSaveImage() {
-		presenter.saveCopyConfirmClicked(0);
+		presenter.saveCopyConfirmClicked(0, null);
 
-		verify(interactor).saveCopy(presenter, 0, workspace, context);
+		verify(interactor).saveCopy(presenter, 0, workspace, null, context);
 	}
 
 	@Test
 	public void testSaveCopyConfirmClickedThenUseRequestCode() {
-		presenter.saveCopyConfirmClicked(-1);
+		presenter.saveCopyConfirmClicked(-1, null);
 
-		verify(interactor).saveCopy(presenter, -1, workspace, context);
+		verify(interactor).saveCopy(presenter, -1, workspace, null, context);
 	}
 
 	@Test
@@ -1008,7 +1008,7 @@ public class MainActivityPresenterTest {
 				new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 				new int[]{PackageManager.PERMISSION_GRANTED});
 
-		verify(interactor).saveCopy(any(SaveImage.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace), eq(context));
+		verify(interactor).saveCopy(any(SaveImage.SaveImageCallback.class), eq(SAVE_IMAGE_DEFAULT), eq(workspace), eq(null), eq(context));
 	}
 
 	@Test
@@ -1173,7 +1173,7 @@ public class MainActivityPresenterTest {
 		verify(navigator).showSaveImageInformationDialogWhenStandalone(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY, sharedPreferences.getPreferenceImageNumber(), false);
 
 		presenter.switchBetweenVersions(PERMISSION_EXTERNAL_STORAGE_SAVE_COPY);
-		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, context);
+		verify(interactor).saveCopy(presenter, SAVE_IMAGE_DEFAULT, workspace, null, context);
 	}
 
 	@Test


### PR DESCRIPTION
Overwrite adding (1) suffix to file names has been fixed for all file formats. I also implemented tests for it.

Additional changes:
- changed the file info parsing after loading an image and save image dialogue file format selection to use the new FileType values in FileIO.kt.
- removed the now obsolete variable isCatrobatImage in FileIO.kt to avoid confusion with new FileType vlaues.
- the "save image" option now displays the name and format of the currently loaded image

Ticket: https://jira.catrob.at/browse/PAINTROID-323

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x]  Include the name of the Jira ticket in the PR’s title
- [x]  Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (develop)
- [x]  Confirm that the changes follow the project’s coding guidelines
- [x]  Verify that the changes generate no compiler or linter warnings
- [x]  Perform a self-review of the changes
- [x]  Verify to commit no other files than the intentionally changed ones
- [x]  Include reasonable and readable tests verifying the added or changed behavior
- [x]  Confirm that new and existing unit tests pass locally
- [x]  Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x]  Stick to the project’s gitflow workflow
- [x]  Verify that your changes do not have any conflicts with the base branch
- [x]  After the PR, verify that all CI checks have passed
- [x]  Post a message in the #paintroid [Slack channel](https://catrobat.slack.com/) and ask for a code reviewer