### PR TITLE
PAINTROID-369: Crash NullPointerException: colorpicker.ZoomableImageView

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ZoomableImageView.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ZoomableImageView.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -38,6 +38,8 @@ import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.view.View
+import android.view.WindowInsets
+import android.view.WindowManager
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat
 import androidx.core.view.updateLayoutParams
@@ -310,11 +312,24 @@ class ZoomableImageView :
 
     private fun updateLP() {
         updateLayoutParams {
-            val point = Point()
             post {
-                display.getSize(point)
-                height = point.y
-                width = point.x
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+                    val windowMetrics = windowManager.currentWindowMetrics
+                    val windowInsets = windowMetrics.windowInsets.getInsetsIgnoringVisibility(
+                        WindowInsets.Type.navigationBars() or WindowInsets.Type.displayCutout()
+                    )
+                    val insetsWidth = windowInsets.right + windowInsets.left
+                    val insetsHeight = windowInsets.top + windowInsets.bottom
+                    val b = windowMetrics.bounds
+                    width = b.width() - insetsWidth
+                    height = b.height() - insetsHeight
+                } else {
+                    val point = Point()
+                    display?.getSize(point)
+                    height = point.y
+                    width = point.x
+                }
             }
         }
     }


### PR DESCRIPTION
display variable in ZoomableImageView could be null; null check added

(https://jira.catrob.at/browse/PAINTROID-369)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
