### PR TITLE
Paintroid-375: Show help dialog after install of a release version

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -163,10 +163,11 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         private const val IS_OPENED_FROM_CATROID_KEY = "isOpenedFromCatroid"
         private const val IS_OPENED_FROM_FORMULA_EDITOR_IN_CATROID_KEY =
             "isOpenedFromFormulaEditorInCatroid"
-        private const val WAS_INITIAL_ANIMATION_PLAYED = "wasInitialAnimationPlayed"
         private const val SAVED_PICTURE_URI_KEY = "savedPictureUri"
         private const val CAMERA_IMAGE_URI_KEY = "cameraImageUri"
         private const val APP_FRAGMENT_KEY = "customActivityState"
+        private const val SHARED_PREFS_NAME = "preferences"
+        private const val FIRST_LAUNCH_AFTER_INSTALL = "firstLaunchAfterInstall"
     }
 
     override val presenter: MainActivityContracts.Presenter
@@ -298,13 +299,11 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                 val isOpenedFromFormulaEditorInCatroid = savedInstanceState.getBoolean(
                     IS_OPENED_FROM_FORMULA_EDITOR_IN_CATROID_KEY, false
                 )
-                val wasInitialAnimationPlayed =
-                    savedInstanceState.getBoolean(WAS_INITIAL_ANIMATION_PLAYED, false)
                 val savedPictureUri = savedInstanceState.getParcelable<Uri>(SAVED_PICTURE_URI_KEY)
                 val cameraImageUri = savedInstanceState.getParcelable<Uri>(CAMERA_IMAGE_URI_KEY)
                 presenterMain.restoreState(
                     isFullscreen, isSaved, isOpenedFromCatroid, isOpenedFromFormulaEditorInCatroid,
-                    wasInitialAnimationPlayed, savedPictureUri, cameraImageUri
+                    savedPictureUri, cameraImageUri
                 )
             }
         }
@@ -315,6 +314,15 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             startAutoSaveCoroutine()
         }
         presenterMain.finishInitialize()
+
+        if (!org.catrobat.paintroid.BuildConfig.DEBUG) {
+            val prefs = getSharedPreferences(SHARED_PREFS_NAME, 0)
+
+            if (prefs.getBoolean(FIRST_LAUNCH_AFTER_INSTALL, true)) {
+                prefs.edit().putBoolean(FIRST_LAUNCH_AFTER_INSTALL, false).apply()
+                presenterMain.showHelpClicked()
+            }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -565,7 +573,6 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                 IS_OPENED_FROM_FORMULA_EDITOR_IN_CATROID_KEY,
                 model.isOpenedFromFormulaEditorInCatroid
             )
-            putBoolean(WAS_INITIAL_ANIMATION_PLAYED, model.wasInitialAnimationPlayed())
             putParcelable(SAVED_PICTURE_URI_KEY, model.savedPictureUri)
             putParcelable(CAMERA_IMAGE_URI_KEY, model.cameraImageUri)
         }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
@@ -180,7 +180,6 @@ interface MainActivityContracts {
             isSaved: Boolean,
             isOpenedFromCatroid: Boolean,
             isOpenedFromFormulaEditorInCatroid: Boolean,
-            wasInitialAnimationPlayed: Boolean,
             savedPictureUri: Uri?,
             cameraImageUri: Uri?
         )
@@ -307,10 +306,6 @@ interface MainActivityContracts {
         var isFullscreen: Boolean
         var isOpenedFromCatroid: Boolean
         var isOpenedFromFormulaEditorInCatroid: Boolean
-
-        fun wasInitialAnimationPlayed(): Boolean
-
-        fun setInitialAnimationPlayed(wasInitialAnimationPlayed: Boolean)
     }
 
     interface Interactor {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/MainActivityModel.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/MainActivityModel.kt
@@ -22,17 +22,10 @@ import android.net.Uri
 import org.catrobat.paintroid.contract.MainActivityContracts
 
 class MainActivityModel : MainActivityContracts.Model {
-    private var wasInitialAnimationPlayed = false
     override var isOpenedFromCatroid = false
     override var isOpenedFromFormulaEditorInCatroid = false
     override var isFullscreen = false
     override var isSaved = false
     override var savedPictureUri: Uri? = null
     override var cameraImageUri: Uri? = null
-
-    override fun wasInitialAnimationPlayed(): Boolean = wasInitialAnimationPlayed
-
-    override fun setInitialAnimationPlayed(wasInitialAnimationPlayed: Boolean) {
-        this.wasInitialAnimationPlayed = wasInitialAnimationPlayed
-    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -652,7 +652,6 @@ open class MainActivityPresenter(
         isSaved: Boolean,
         isOpenedFromCatroid: Boolean,
         isOpenedFromFormulaEditorInCatroid: Boolean,
-        wasInitialAnimationPlayed: Boolean,
         savedPictureUri: Uri?,
         cameraImageUri: Uri?
     ) {
@@ -660,7 +659,6 @@ open class MainActivityPresenter(
         model.isSaved = isSaved
         model.isOpenedFromCatroid = isOpenedFromCatroid
         model.isOpenedFromFormulaEditorInCatroid = isOpenedFromFormulaEditorInCatroid
-        model.setInitialAnimationPlayed(wasInitialAnimationPlayed)
         model.savedPictureUri = savedPictureUri
         model.cameraImageUri = cameraImageUri
         navigator.restoreFragmentListeners()


### PR DESCRIPTION
- added code to check the app version when it starts (in MainActivity)
- used SharedPreferences to remember if help menu was already shown after clean install
- removed dead code left over from the previous implementation

https://jira.catrob.at/browse/PAINTROID-375

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ x] Include the name of the Jira ticket in the PR’s title
- [x ] Include a summary of the changes plus the relevant context
- [ x] Choose the proper base branch (*develop*)
- [x ] Confirm that the changes follow the project’s coding guidelines
- [x ] Verify that the changes generate no compiler or linter warnings
- [x ] Perform a self-review of the changes
- [x ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x ] Stick to the project’s gitflow workflow
- [x ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
