### PR TITLE
PAINTROID-401 Watercolor followed by normal brush makes normal brush behave like watercolor

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/WatercolorToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/WatercolorToolIntegrationTest.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,6 +20,7 @@ package org.catrobat.paintroid.test.espresso.tools
 
 import android.graphics.Color
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -59,11 +60,38 @@ class WatercolorToolIntegrationTest {
     }
 
     @Test
+    fun testSwitchingBackToBrushOnBackPressed() {
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+
+        assertTrue(
+            "Paint has maskFilter",
+            launchActivityRule.activity.toolPaint.paint.maskFilter != null
+        )
+
+        pressBack()
+
+        BottomNavigationViewInteraction.onBottomNavigationView()
+            .checkShowsCurrentTool(ToolType.BRUSH)
+
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+
+        assertTrue(
+            "Paint maskFilter has been reset",
+            launchActivityRule.activity.toolPaint.paint.maskFilter == null
+        )
+    }
+
+    @Test
     fun testSwitchingBetweenBrushAndWatercolorAndEraserAndLookForMaskFilter() {
         DrawingSurfaceInteraction.onDrawingSurfaceView()
             .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
 
-        assertTrue("Paint has no maskfilter", launchActivityRule.activity.toolPaint.paint.maskFilter != null)
+        assertTrue(
+            "Paint has no maskFilter",
+            launchActivityRule.activity.toolPaint.paint.maskFilter != null
+        )
 
         ToolBarViewInteraction.onToolBarView()
             .performSelectTool(ToolType.ERASER)
@@ -89,7 +117,10 @@ class WatercolorToolIntegrationTest {
         DrawingSurfaceInteraction.onDrawingSurfaceView()
             .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
 
-        assertTrue("Paint still has maskfilter", launchActivityRule.activity.toolPaint.paint.maskFilter == null)
+        assertTrue(
+            "Paint still has maskFilter",
+            launchActivityRule.activity.toolPaint.paint.maskFilter == null
+        )
     }
 
     @Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -509,8 +509,7 @@ open class MainActivityPresenter(
         } else if (model.isFullscreen) {
             exitFullscreenClicked()
         } else if (!toolController.isDefaultTool) {
-            setTool(ToolType.BRUSH)
-            toolController.switchTool(ToolType.BRUSH, true)
+            switchTool(ToolType.BRUSH, true)
         } else {
             showSecurityQuestionBeforeExit()
         }
@@ -691,9 +690,10 @@ open class MainActivityPresenter(
         }
     }
 
-    private fun switchTool(type: ToolType) {
+    private fun switchTool(type: ToolType, backPressed: Boolean = false) {
+        navigator.setMaskFilterToNull()
         setTool(type)
-        toolController.switchTool(type, false)
+        toolController.switchTool(type, backPressed)
         if (type === ToolType.IMPORTPNG) {
             showImportDialog()
         }


### PR DESCRIPTION
setMaskFilterToNull() method call was somehow missing from the switchTool() method in MainActivityPresenter due to which the maskFilter for the paint was not being reset (i.e. not set to null) after the tool was changed. Added it back.

https://jira.catrob.at/browse/PAINTROID-401

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
