### PR TITLE
PAINTROID-363 Rotations clear images in layer preview

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.kt
@@ -21,6 +21,7 @@ package org.catrobat.paintroid.test.espresso
 import android.app.Activity
 import android.app.Instrumentation.ActivityResult
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -74,10 +75,12 @@ class LayerIntegrationTest {
 
     private var bitmapHeight = 0
     private var bitmapWidth = 0
+    private lateinit var activity: Activity
     private lateinit var deletionFileList: ArrayList<File?>
 
     @Before
     fun setUp() {
+        activity = launchActivityRule.activity
         deletionFileList = ArrayList()
         val workspace = launchActivityRule.activity.workspace
         bitmapHeight = workspace.height
@@ -538,6 +541,22 @@ class LayerIntegrationTest {
             .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
         ToolPropertiesInteraction.onToolProperties()
             .checkMatchesColorResource(R.color.pocketpaint_color_picker_green1)
+    }
+
+    @Test
+    fun testLayerPreviewKeepsBitmapAfterOrientationChange() {
+        ToolBarViewInteraction.onToolBarView()
+            .performSelectTool(ToolType.FILL)
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+        LayerMenuViewInteraction.onLayerMenuView()
+            .performOpen()
+            .checkLayerAtPositionHasTopLeftPixelWithColor(0, Color.BLACK)
+
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+
+        LayerMenuViewInteraction.onLayerMenuView()
+            .checkLayerAtPositionHasTopLeftPixelWithColor(0, Color.BLACK)
     }
 
     @Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
@@ -19,8 +19,12 @@
 
 package org.catrobat.paintroid.test.espresso.util.wrappers;
 
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.view.Gravity;
 import android.view.View;
+import android.widget.ImageView;
 
 import org.catrobat.paintroid.R;
 import org.catrobat.paintroid.model.Layer;
@@ -28,6 +32,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import androidx.annotation.ColorInt;
 import androidx.test.espresso.DataInteraction;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.contrib.DrawerActions;
@@ -87,7 +92,7 @@ public final class LayerMenuViewInteraction extends CustomViewInteraction {
 	public LayerMenuViewInteraction performClose() {
 		check(matches(isDisplayed()));
 		onView(withId(R.id.pocketpaint_drawer_layout))
-			.perform(DrawerActions.close(Gravity.END));
+				.perform(DrawerActions.close(Gravity.END));
 		return this;
 	}
 
@@ -141,5 +146,35 @@ public final class LayerMenuViewInteraction extends CustomViewInteraction {
 				return matcher.matches(view) && currentIndex++ == index;
 			}
 		};
+	}
+
+	public LayerMenuViewInteraction checkLayerAtPositionHasTopLeftPixelWithColor(int listPosition, @ColorInt final int expectedColor) {
+		onData(instanceOf(Layer.class))
+				.inAdapterView(withId(R.id.pocketpaint_layer_side_nav_list))
+				.atPosition(listPosition)
+				.onChildView(withId(R.id.pocketpaint_item_layer_image))
+				.check(matches(new TypeSafeMatcher<View>() {
+					@Override
+					public void describeTo(Description description) {
+						description.appendText("Color at coordinates is " + Integer.toHexString(expectedColor));
+					}
+
+					@Override
+					protected boolean matchesSafely(View view) {
+						Bitmap bitmap = getBitmap(((ImageView) view).getDrawable());
+						int actualColor = bitmap.getPixel(0, 0);
+						return actualColor == expectedColor;
+					}
+				}));
+
+		return this;
+	}
+
+	private Bitmap getBitmap(Drawable drawable) {
+		Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+		Canvas canvas = new Canvas(bitmap);
+		drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+		drawable.draw(canvas);
+		return bitmap;
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -41,6 +41,7 @@ import androidx.appcompat.widget.TooltipCompat
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.drawerlayout.widget.DrawerLayout
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationView
 import org.catrobat.paintroid.command.CommandFactory
 import org.catrobat.paintroid.command.CommandManager
 import org.catrobat.paintroid.command.CommandManager.CommandListener
@@ -406,7 +407,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
     }
 
     private fun onCreateLayerMenu() {
-        val layerLayout = findViewById<ViewGroup>(R.id.pocketpaint_layer_side_nav_menu)
+        val layerLayout = findViewById<NavigationView>(R.id.pocketpaint_nav_view_layer)
         val layerListView = findViewById<DragAndDropListView>(R.id.pocketpaint_layer_side_nav_list)
         val layerMenuViewHolder = LayerMenuViewHolder(layerLayout)
         val layerNavigator = LayerNavigator(applicationContext)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
@@ -30,8 +30,6 @@ interface LayerContracts {
         fun notifyDataSetChanged()
 
         fun getViewHolderAt(position: Int): LayerViewHolder?
-
-        fun setDrawerLayoutOpen(isOpen: Boolean)
     }
 
     interface Presenter {
@@ -67,6 +65,8 @@ interface LayerContracts {
         fun setDefaultToolController(defaultToolController: DefaultToolController)
 
         fun setBottomNavigationViewHolder(bottomNavigationViewHolder: BottomNavigationViewHolder)
+
+        fun isShown(): Boolean
     }
 
     interface LayerViewHolder {
@@ -98,6 +98,8 @@ interface LayerContracts {
         fun disableRemoveLayerButton()
 
         fun enableRemoveLayerButton()
+
+        fun isShown(): Boolean
     }
 
     interface Layer {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawerLayoutListener.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawerLayoutListener.kt
@@ -10,13 +10,10 @@ class DrawerLayoutListener(private val view: DrawerLayout, private val adapter: 
 
     override fun onDrawerOpened(drawerView: View) = Unit
 
-    override fun onDrawerClosed(drawerView: View) {
-        adapter.setDrawerLayoutOpen(false)
-    }
+    override fun onDrawerClosed(drawerView: View) = Unit
 
     override fun onDrawerStateChanged(newState: Int) {
         if (newState == DrawerLayout.STATE_DRAGGING && !view.isDrawerOpen(GravityCompat.END)) {
-            adapter.setDrawerLayoutOpen(true)
             for (i in 0 until adapter.count) {
                 adapter.getViewHolderAt(i)?.let { holder ->
                     holder.bitmap?.let { bitmapImageView ->

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
@@ -133,6 +133,8 @@ class LayerPresenter(
         }
     }
 
+    override fun isShown(): Boolean = layerMenuViewHolder.isShown()
+
     override fun getLayerItem(position: Int): LayerContracts.Layer = layers[position]
 
     override fun getLayerItemId(position: Int): Long = position.toLong()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -546,7 +546,6 @@ open class MainActivityPresenter(
 
     override fun showLayerMenuClicked() {
         layerAdapter?.apply {
-            setDrawerLayoutOpen(true)
             for (i in 0 until count) {
                 val currentHolder = getViewHolderAt(i)
                 currentHolder?.let {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -38,7 +38,6 @@ import org.catrobat.paintroid.ui.viewholder.BottomNavigationViewHolder
 
 class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), LayerContracts.Adapter {
     private val viewHolders: SparseArray<LayerContracts.LayerViewHolder> = SparseArray()
-    private var isDrawerLayoutOpen = false
 
     override fun getCount() = presenter.layerCount
 
@@ -49,10 +48,6 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
     override fun notifyDataSetChanged() {
         viewHolders.clear()
         super.notifyDataSetChanged()
-    }
-
-    override fun setDrawerLayoutOpen(isOpen: Boolean) {
-        isDrawerLayoutOpen = isOpen
     }
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup): View? {
@@ -67,7 +62,8 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
             viewHolder = localConvertView.tag as LayerContracts.LayerViewHolder
         }
         viewHolders.put(position, viewHolder)
-        presenter.onBindLayerViewHolderAtPosition(position, viewHolder, isDrawerLayoutOpen)
+        val isShown = presenter.isShown()
+        presenter.onBindLayerViewHolderAtPosition(position, viewHolder, isShown)
         val checkBox = localConvertView?.findViewById<CheckBox>(R.id.pocketpaint_checkbox_layer)
         checkBox?.setOnClickListener {
             with(presenter) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/viewholder/LayerMenuViewHolder.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/viewholder/LayerMenuViewHolder.kt
@@ -19,13 +19,15 @@
 package org.catrobat.paintroid.ui.viewholder
 
 import android.view.View
-import android.view.ViewGroup
+import com.google.android.material.navigation.NavigationView
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.contract.LayerContracts
 
-class LayerMenuViewHolder(layerLayout: ViewGroup) : LayerContracts.LayerMenuViewHolder {
+class LayerMenuViewHolder(val layerLayout: NavigationView) : LayerContracts.LayerMenuViewHolder {
     val layerAddButton: View = layerLayout.findViewById(R.id.pocketpaint_layer_side_nav_button_add)
     val layerDeleteButton: View = layerLayout.findViewById(R.id.pocketpaint_layer_side_nav_button_delete)
+
+    override fun isShown(): Boolean = layerLayout.isShown
 
     override fun disableAddLayerButton() {
         layerAddButton.isEnabled = false

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
@@ -70,8 +70,8 @@
         android:layout_height="wrap_content"
         android:layout_below="@id/pocketpaint_layer_side_nav_button_add"
         android:background="@color/pocketpaint_colorPrimary"
-        tools:listitem="@layout/pocketpaint_item_layer"
-        android:splitMotionEvents="true">
+        android:splitMotionEvents="true"
+        tools:listitem="@layout/pocketpaint_item_layer">
 
     </org.catrobat.paintroid.ui.dragndrop.DragAndDropListView>
 


### PR DESCRIPTION
Layer preview lost images after configuration change since `isDrawerLayoutOpen` was not set/restored properly.
So after configuration change the Previews have not been updated because the logic stated that it was not displayed.

[https://jira.catrob.at/browse/PAINTROID-363](https://jira.catrob.at/browse/PAINTROID-363)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
