### PR TITLE
PAINTROID-362 advanced settings layout

### DIFF
--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_advanced_settings.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_advanced_settings.xml
@@ -18,42 +18,31 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:padding="?dialogPreferredPadding">
 
-    <LinearLayout
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/pocketpaint_antialiasing"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:orientation="vertical"
-        android:padding="10dp"
-        style="@style/AlertDialogTheme">
+        android:layout_height="match_parent"
+        android:checked="true"
+        android:text="@string/dialog_antialiasing"
+        android:textColor="@color/design_default_color_on_secondary"
+        android:theme="@style/CustomSwitchTheme" />
 
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:checked="true"
-            android:text="@string/dialog_antialiasing"
-            android:id="@+id/pocketpaint_antialiasing"
-            android:textColor="@color/design_default_color_on_secondary"/>
-    </LinearLayout>
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="16dp" />
 
-    <LinearLayout
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/pocketpaint_smoothing"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:orientation="vertical"
-        android:padding="10dp"
-        style="@style/AlertDialogTheme">
-
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:checked="true"
-            android:text="@string/dialog_smoothing"
-            android:id="@+id/pocketpaint_smoothing"
-            android:textColor="@color/design_default_color_on_secondary"/>
-    </LinearLayout>
+        android:layout_height="match_parent"
+        android:checked="true"
+        android:text="@string/dialog_smoothing"
+        android:textColor="@color/design_default_color_on_secondary"
+        android:theme="@style/CustomSwitchTheme" />
 
 </LinearLayout>

--- a/Paintroid/src/main/res/values/style.xml
+++ b/Paintroid/src/main/res/values/style.xml
@@ -89,6 +89,12 @@
         <item name="hintEnabled">false</item>
     </style>
 
+    <style name="CustomSwitchTheme" parent="@style/ThemeOverlay.MaterialComponents">
+        <item name="colorSwitchThumbNormal">@color/pocketpaint_lighter_gray</item>
+        <item name="android:colorForeground">@android:color/darker_gray</item>
+    </style>
+
+
     <style name="PocketPaintTheme.Base" parent="Theme.MaterialComponents.NoActionBar.Bridge">
         <item name="android:windowBackground">@color/pocketpaint_colorPrimary</item>
         <item name="dialogTheme">@style/PocketPaintAlertDialog</item>


### PR DESCRIPTION
Updated the layout of the advanced settings dialog such that the switches are aligned to the right side of the dialog.
[https://jira.catrob.at/browse/PAINTROID-362](https://jira.catrob.at/browse/PAINTROID-362)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
