### PR TITLE
Maintenance: Remove no-op method (targetSDK 30)

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityNavigator.kt
@@ -489,7 +489,6 @@ class MainActivityNavigator(
         if (mainActivity.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             offset = 0
         }
-        toolNameToast.setGravity(gravity, 0, offset)
         toolNameToast.show()
     }
 


### PR DESCRIPTION
https://developer.android.com/reference/android/widget/Toast#setGravity(int,%20int,%20int) : Starting from Android Build.VERSION_CODES#R, for apps targeting API level Build.VERSION_CODES#R or higher, this method is a no-op when called on text toasts. It resulted in an error entry in the logs each time the tool is switched.

- [ ] Check that tool change toasts are shown correctly on all supported Android versions
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed