### PR TITLE
PAINTROID-101 Correct user intended end position for tools

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -361,7 +361,7 @@ public class BaseToolWithRectangleShapeToolTest {
 	}
 
 	@Test
-	public void testToolClicksOnTouchDownPosition() {
+	public void testToolPreciseMovementTest() {
 		float initialToolPositionX = toolToTest.toolPosition.x;
 		float initialToolPositionY = toolToTest.toolPosition.y;
 
@@ -369,8 +369,8 @@ public class BaseToolWithRectangleShapeToolTest {
 		toolToTest.handleMove(new PointF(initialToolPositionX + 9, initialToolPositionY + 9));
 		toolToTest.handleUp(new PointF(initialToolPositionX + 9, initialToolPositionY + 9));
 
-		assertEquals(toolToTest.toolPosition.x, initialToolPositionX, 0);
-		assertEquals(toolToTest.toolPosition.y, initialToolPositionY, 0);
+		assertEquals(toolToTest.toolPosition.x, initialToolPositionX + 9, 0);
+		assertEquals(toolToTest.toolPosition.y, initialToolPositionY + 9, 0);
 	}
 
 	private class BaseToolWithRectangleShapeImpl extends BaseToolWithRectangleShape {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
@@ -118,7 +118,7 @@ public class StampToolTest {
 	}
 
 	@Test
-	public void testToolClicksOnTouchDownPosition() {
+	public void testToolPreciseMovementTest() {
 		Looper.prepare();
 
 		float initialToolPositionX = tool.toolPosition.x;
@@ -128,7 +128,7 @@ public class StampToolTest {
 		tool.handleMove(new PointF(initialToolPositionX + 9, initialToolPositionY + 9));
 		tool.handleUp(new PointF(initialToolPositionX + 9, initialToolPositionY + 9));
 
-		assertEquals(tool.toolPosition.x, initialToolPositionX, 0);
-		assertEquals(tool.toolPosition.y, initialToolPositionY, 0);
+		assertEquals(tool.toolPosition.x, initialToolPositionX + 9, 0);
+		assertEquals(tool.toolPosition.y, initialToolPositionY + 9, 0);
 	}
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -65,7 +65,6 @@ private const val MAXIMAL_TOOL_STROKE_WIDTH = 8f
 private const val DEFAULT_ROTATION_SYMBOL_DISTANCE = 20
 private const val DEFAULT_ROTATION_SYMBOL_WIDTH = 30
 private const val DEFAULT_MAXIMUM_BOX_RESOLUTION = 0f
-private const val CLICK_IN_BOX_MOVE_TOLERANCE = 10
 private const val DEFAULT_RECTANGLE_SHRINKING = 0
 private const val HIGHLIGHT_RECTANGLE_SHRINKING = 5
 private const val DEFAULT_ROTATION_ENABLED = false
@@ -280,10 +279,6 @@ abstract class BaseToolWithRectangleShape(
         ifNotNull(coordinate, previousEventCoordinate) { (coordinate, previousEventCoordinate) ->
             movedDistance.x += abs(coordinate.x - previousEventCoordinate.x)
             movedDistance.y += abs(coordinate.y - previousEventCoordinate.y)
-        }
-        if (CLICK_IN_BOX_MOVE_TOLERANCE >= movedDistance.x && CLICK_IN_BOX_MOVE_TOLERANCE >= movedDistance.y) {
-            toolPosition.x = touchDownPositionX
-            toolPosition.y = touchDownPositionY
         }
         return true
     }


### PR DESCRIPTION
the end position of tools is not affected anymore by jitter movements of the finger when lifting it
A working implementation from Catroid was used.

In addition, in BaseToolWithRectangleShape a condition was removed, which reset short movements and prohibited precise movements (as shown in the video in the task description).

The jitter movement  in sliders is not being fixed with this pr, there will be a separate ticket.

https://jira.catrob.at/browse/PAINTROID-101

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
