### PR TITLE
PAINTROID-385 Antialiasing incorrectly turned on for stamp tool in Android 11

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/StampCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/StampCommand.kt
@@ -21,7 +21,6 @@ package org.catrobat.paintroid.command.implementation
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
-import android.graphics.Paint
 import android.graphics.Point
 import android.graphics.RectF
 import androidx.annotation.VisibleForTesting
@@ -59,7 +58,7 @@ class StampCommand(bitmap: Bitmap, position: Point, width: Float, height: Float,
             save()
             translate(coordinates.x.toFloat(), coordinates.y.toFloat())
             rotate(boxRotation)
-            drawBitmap(bitmapToDraw, null, rect, Paint(Paint.DITHER_FLAG))
+            drawBitmap(bitmapToDraw, null, rect, null)
             restore()
         }
 


### PR DESCRIPTION
the DITHER_FLAG led to smoothed edges in stamp tool when stamp was enlarged
removed the DITHER_FLAG and tested it on Android 9 and 11; couldn't find any difference between with and without DITHER
except that the "antialiasing" is fixed 

https://jira.catrob.at/browse/PAINTROID-385

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
