### PR TITLE
PAINTROID-82 Text tool has high memory usage

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.java
@@ -20,8 +20,6 @@
 package org.catrobat.paintroid.test.espresso.tools;
 
 import android.content.pm.ActivityInfo;
-import android.content.res.TypedArray;
-import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PointF;
@@ -36,6 +34,7 @@ import org.catrobat.paintroid.contract.LayerContracts;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.MainActivityHelper;
 import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
+import org.catrobat.paintroid.tools.FontType;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.implementation.TextTool;
@@ -47,8 +46,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import androidx.core.content.res.ResourcesCompat;
 import androidx.recyclerview.widget.RecyclerView;
@@ -71,7 +68,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
@@ -88,16 +84,9 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class TextToolIntegrationTest {
-	private static final String TEST_TEXT = "testing 123";
+	private static final String TEST_TEXT = "123 www 123";
 	private static final String TEST_TEXT_ADVANCED = "testing 123 new";
-	private static final String TEST_ARABIC_TEXT = "السلام عليكم 123";
 	private static final String TEST_TEXT_MULTILINE = "testing\nmultiline\ntext\n\n123";
-
-	private static final String FONT_MONOSPACE = "Monospace";
-	private static final String FONT_SERIF = "Serif";
-	private static final String FONT_SANS_SERIF = "Sans Serif";
-	private static final String FONT_STC = "STC";
-	private static final String FONT_DUBAI = "Dubai";
 
 	private static final double EQUALS_DELTA = 0.25d;
 	@Rule
@@ -194,45 +183,46 @@ public class TextToolIntegrationTest {
 		enterTestText();
 		assertEquals(TEST_TEXT, textTool.text);
 
-		selectFormatting(FormattingOptions.SERIF);
-		assertEquals(FONT_SERIF, textTool.font);
-		assertEquals(FONT_SERIF, ((FontListAdapter) fontList.getAdapter()).getSelectedItem());
+		selectFontType(FontType.SERIF);
+		assertEquals(FontType.SERIF, textTool.font);
+		assertEquals(FontType.SERIF, ((FontListAdapter) fontList.getAdapter()).getSelectedItem());
 
 		selectFormatting(FormattingOptions.UNDERLINE);
 		assertTrue(textTool.underlined);
 		assertTrue(underlinedToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.UNDERLINE), underlinedToggleButton.getText().toString());
+		assertEquals(getFormattingOptionAsString(FormattingOptions.UNDERLINE), underlinedToggleButton.getText().toString());
 
 		selectFormatting(FormattingOptions.UNDERLINE);
 		assertFalse(textTool.underlined);
 		assertFalse(underlinedToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.UNDERLINE), underlinedToggleButton.getText().toString());
+		assertEquals(getFormattingOptionAsString(FormattingOptions.UNDERLINE), underlinedToggleButton.getText().toString());
 
 		selectFormatting(FormattingOptions.ITALIC);
 		assertTrue(getToolMemberItalic());
 		assertTrue(italicToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.ITALIC), italicToggleButton.getText().toString());
+		assertEquals(getFormattingOptionAsString(FormattingOptions.ITALIC), italicToggleButton.getText().toString());
 
 		selectFormatting(FormattingOptions.ITALIC);
 		assertFalse(getToolMemberItalic());
 		assertFalse(italicToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.ITALIC), italicToggleButton.getText().toString());
+		assertEquals(getFormattingOptionAsString(FormattingOptions.ITALIC), italicToggleButton.getText().toString());
 
 		selectFormatting(FormattingOptions.BOLD);
 		assertTrue(getToolMemberBold());
 		assertTrue(boldToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.BOLD), boldToggleButton.getText().toString());
+		assertEquals(getFormattingOptionAsString(FormattingOptions.BOLD), boldToggleButton.getText().toString());
 
 		selectFormatting(FormattingOptions.BOLD);
 		assertFalse(getToolMemberBold());
 		assertFalse(boldToggleButton.isChecked());
-		assertEquals(getFontString(FormattingOptions.BOLD), boldToggleButton.getText().toString());
+		assertEquals(getFormattingOptionAsString(FormattingOptions.BOLD), boldToggleButton.getText().toString());
 	}
 
 	@Test
 	public void testDialogAndTextBoxAfterReopenDialog() {
 		enterTestText();
-		selectFormatting(FormattingOptions.SANS_SERIF);
+		selectFontType(FontType.SANS_SERIF);
+
 		selectFormatting(FormattingOptions.UNDERLINE);
 		selectFormatting(FormattingOptions.ITALIC);
 		selectFormatting(FormattingOptions.BOLD);
@@ -243,14 +233,12 @@ public class TextToolIntegrationTest {
 		PointF boxPosition = getToolMemberBoxPosition();
 		PointF newBoxPosition = new PointF(boxPosition.x + 100, boxPosition.y + 200);
 		setToolMemberBoxPosition(newBoxPosition);
-		setToolMemberBoxHeight(50.0f);
-		setToolMemberBoxWidth(50.0f);
 
 		onToolBarView()
 				.performOpenToolOptionsView();
 
 		assertEquals(TEST_TEXT, textEditText.getText().toString());
-		assertEquals(FONT_SANS_SERIF, ((FontListAdapter) fontList.getAdapter()).getSelectedItem());
+		assertEquals(FontType.SANS_SERIF, ((FontListAdapter) fontList.getAdapter()).getSelectedItem());
 		assertTrue(underlinedToggleButton.isChecked());
 		assertTrue(italicToggleButton.isChecked());
 		assertTrue(boldToggleButton.isChecked());
@@ -260,7 +248,7 @@ public class TextToolIntegrationTest {
 	@Test
 	public void testStateRestoredAfterOrientationChange() {
 		enterTestText();
-		selectFormatting(FormattingOptions.SANS_SERIF);
+		selectFontType(FontType.SANS_SERIF);
 		selectFormatting(FormattingOptions.UNDERLINE);
 		selectFormatting(FormattingOptions.ITALIC);
 		selectFormatting(FormattingOptions.BOLD);
@@ -273,7 +261,7 @@ public class TextToolIntegrationTest {
 		textTool = (TextTool) toolReference.getTool();
 
 		assertEquals(TEST_TEXT, textEditText.getText().toString());
-		assertEquals(FONT_SANS_SERIF, ((FontListAdapter) fontList.getAdapter()).getSelectedItem());
+		assertEquals(FontType.SANS_SERIF, ((FontListAdapter) fontList.getAdapter()).getSelectedItem());
 		assertTrue(underlinedToggleButton.isChecked());
 		assertTrue(italicToggleButton.isChecked());
 		assertTrue(boldToggleButton.isChecked());
@@ -290,107 +278,73 @@ public class TextToolIntegrationTest {
 		assertFalse(boldToggleButton.isChecked());
 		assertFalse(italicToggleButton.isChecked());
 
-		ArrayList<FormattingOptions> fonts = new ArrayList<>();
-		fonts.add(FormattingOptions.SERIF);
-		fonts.add(FormattingOptions.SANS_SERIF);
-		fonts.add(FormattingOptions.MONOSPACE);
+		ArrayList<FontType> fonts = new ArrayList<>();
+		fonts.add(FontType.SERIF);
+		fonts.add(FontType.SANS_SERIF);
+		fonts.add(FontType.MONOSPACE);
+		fonts.add(FontType.DUBAI);
+		fonts.add(FontType.STC);
 
-		for (FormattingOptions font : fonts) {
+		checkTextBoxDimensionsAndDefaultPosition();
+
+		for (FontType font : fonts) {
+			layerModel.getCurrentLayer().getBitmap().eraseColor(Color.TRANSPARENT);
+
 			float boxWidth = getToolMemberBoxWidth();
 			float boxHeight = getToolMemberBoxHeight();
-			int[] pixelsBefore;
-			int[] pixelsAfter;
 
-			selectFormatting(font);
-			checkTextBoxDimensionsAndDefaultPosition();
+			selectFontType(font);
 			assertFalse(boxWidth == getToolMemberBoxWidth() && boxHeight == getToolMemberBoxHeight());
 
-			Bitmap bitmap = getToolMemberDrawingBitmap();
+			PointF canvasPoint = centerBox();
 
-			pixelsBefore = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsBefore, 0, 1, bitmap.getWidth() / 2, 0, 1, bitmap.getHeight());
+			layerModel.getCurrentLayer().getBitmap().eraseColor(Color.TRANSPARENT);
+			onTopBarView()
+					.performClickCheckmark();
+
+			int surfaceBitmapHeight = layerModel.getHeight();
+			int[] pixelsDrawingSurface = new int[surfaceBitmapHeight];
+			layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, 1, (int) canvasPoint.x, 0, 1, surfaceBitmapHeight);
+			int pixelAmountBefore = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
+			assert pixelAmountBefore > 0;
+
 			selectFormatting(FormattingOptions.UNDERLINE);
 			assertTrue(underlinedToggleButton.isChecked());
-			bitmap = getToolMemberDrawingBitmap();
-			pixelsAfter = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsAfter, 0, 1, bitmap.getWidth() / 2, 0, 1, bitmap.getHeight());
-			assertTrue(countPixelsWithColor(pixelsAfter, Color.BLACK) > countPixelsWithColor(pixelsBefore, Color.BLACK));
 
-			boxWidth = getToolMemberBoxWidth();
+			layerModel.getCurrentLayer().getBitmap().eraseColor(Color.TRANSPARENT);
+			onTopBarView()
+					.performClickCheckmark();
+
+			layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, 1, (int) canvasPoint.x, 0, 1, surfaceBitmapHeight);
+			int pixelAmountAfter = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
+			assert pixelAmountAfter > 0;
+
+			assertTrue(pixelAmountBefore < pixelAmountAfter);
+
 			selectFormatting(FormattingOptions.ITALIC);
 			assertTrue(italicToggleButton.isChecked());
-			if (font != FormattingOptions.MONOSPACE) {
-				assertTrue(getToolMemberBoxWidth() < boxWidth);
-			} else {
-				assertTrue(getToolMemberItalic());
-			}
+			assertTrue(getToolMemberItalic());
 
-			pixelsBefore = new int[bitmap.getWidth()];
-			bitmap.getPixels(pixelsBefore, 0, bitmap.getWidth(), 0, bitmap.getHeight() / 2, bitmap.getWidth(), 1);
+			layerModel.getCurrentLayer().getBitmap().eraseColor(Color.TRANSPARENT);
+			onTopBarView()
+					.performClickCheckmark();
+
+			layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, 1, (int) canvasPoint.x, 0, 1, surfaceBitmapHeight);
+			pixelAmountBefore = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
+			assert pixelAmountBefore > 0;
+
 			selectFormatting(FormattingOptions.BOLD);
 			assertTrue(boldToggleButton.isChecked());
-			bitmap = getToolMemberDrawingBitmap();
-			pixelsAfter = new int[bitmap.getWidth()];
-			bitmap.getPixels(pixelsAfter, 0, bitmap.getWidth(), 0, bitmap.getHeight() / 2, bitmap.getWidth(), 1);
-			assertTrue(countPixelsWithColor(pixelsAfter, Color.BLACK) > countPixelsWithColor(pixelsBefore, Color.BLACK));
 
-			selectFormatting(FormattingOptions.UNDERLINE);
-			assertFalse(underlinedToggleButton.isChecked());
-			selectFormatting(FormattingOptions.ITALIC);
-			assertFalse(italicToggleButton.isChecked());
-			selectFormatting(FormattingOptions.BOLD);
-			assertFalse(boldToggleButton.isChecked());
-		}
-	}
+			layerModel.getCurrentLayer().getBitmap().eraseColor(Color.TRANSPARENT);
+			onTopBarView()
+					.performClickCheckmark();
 
-	@Test
-	public void testCheckBoxSizeAndContentAfterFormattingToDubaiAndStc() {
-		enterArabicTestText();
+			layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, 1, (int) canvasPoint.x, 0, 1, surfaceBitmapHeight);
+			pixelAmountAfter = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
+			assert pixelAmountAfter > 0;
 
-		assertFalse(underlinedToggleButton.isChecked());
-		assertFalse(boldToggleButton.isChecked());
-		assertFalse(italicToggleButton.isChecked());
-
-		List<FormattingOptions> fonts = Arrays.asList(FormattingOptions.STC, FormattingOptions.DUBAI);
-
-		for (FormattingOptions font : fonts) {
-			float boxWidth = getToolMemberBoxWidth();
-			float boxHeight = getToolMemberBoxHeight();
-			int[] pixelsBefore;
-			int[] pixelsAfter;
-
-			selectFormatting(font);
-			checkTextBoxDimensionsAndDefaultPosition();
-			assertFalse(boxWidth == getToolMemberBoxWidth() && boxHeight == getToolMemberBoxHeight());
-
-			Bitmap bitmap = getToolMemberDrawingBitmap();
-
-			pixelsBefore = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsBefore, 0, 1, bitmap.getWidth() / 2, 0, 1, bitmap.getHeight());
-			selectFormatting(FormattingOptions.UNDERLINE);
-			assertTrue(underlinedToggleButton.isChecked());
-			bitmap = getToolMemberDrawingBitmap();
-			pixelsAfter = new int[bitmap.getHeight()];
-			bitmap.getPixels(pixelsAfter, 0, 1, bitmap.getWidth() / 2, 0, 1, bitmap.getHeight());
-			assertTrue(countPixelsWithColor(pixelsAfter, Color.BLACK) > countPixelsWithColor(pixelsBefore, Color.BLACK));
-
-			boxWidth = getToolMemberBoxWidth();
-			selectFormatting(FormattingOptions.ITALIC);
-			assertTrue(italicToggleButton.isChecked());
-			if (font != FormattingOptions.DUBAI) {
-				assertEquals(getToolMemberBoxWidth(), boxWidth, 5);
-			} else {
-				assertTrue(getToolMemberItalic());
-			}
-
-			pixelsBefore = new int[bitmap.getWidth()];
-			bitmap.getPixels(pixelsBefore, 0, bitmap.getWidth(), 0, bitmap.getHeight() / 2, bitmap.getWidth(), 1);
-			selectFormatting(FormattingOptions.BOLD);
-			assertTrue(boldToggleButton.isChecked());
-			bitmap = getToolMemberDrawingBitmap();
-			pixelsAfter = new int[bitmap.getWidth()];
-			bitmap.getPixels(pixelsAfter, 0, bitmap.getWidth(), 0, bitmap.getHeight() / 2, bitmap.getWidth(), 1);
-			assertTrue(countPixelsWithColor(pixelsAfter, Color.BLACK) > countPixelsWithColor(pixelsBefore, Color.BLACK));
+			assertTrue(pixelAmountAfter > pixelAmountBefore);
 
 			selectFormatting(FormattingOptions.UNDERLINE);
 			assertFalse(underlinedToggleButton.isChecked());
@@ -444,28 +398,7 @@ public class TextToolIntegrationTest {
 		onToolBarView()
 				.performCloseToolOptionsView();
 
-		Bitmap bitmap = getToolMemberDrawingBitmap();
-		int[] pixelsTool = new int[bitmap.getWidth()];
-		int yPos = Math.round(bitmap.getHeight() / 2.0f);
-		bitmap.getPixels(pixelsTool, 0, bitmap.getWidth(), 0, yPos, bitmap.getWidth(), 1);
-		int numberOfBlackPixels = countPixelsWithColor(pixelsTool, Color.BLACK);
-
-		PointF screenPoint = new PointF(activityHelper.getDisplayWidth() / 2.0f, activityHelper.getDisplayHeight() / 2.0f);
-		int statusBarHeight = 0;
-		int resourceId = activity.getResources().getIdentifier("status_bar_height", "dimen", "android");
-		if (resourceId > 0) {
-			statusBarHeight = activity.getResources().getDimensionPixelSize(resourceId);
-		}
-
-		int actionBarHeight;
-		final TypedArray styledAttributes = activity.getTheme().obtainStyledAttributes(
-				new int[]{android.R.attr.actionBarSize}
-		);
-		actionBarHeight = (int) styledAttributes.getDimension(0, 0);
-		PointF canvasPoint = new PointF(screenPoint.x, screenPoint.y - actionBarHeight - statusBarHeight);
-		canvasPoint.x = (float) Math.round(canvasPoint.x);
-		canvasPoint.y = (float) Math.round(canvasPoint.y);
-		setToolMemberBoxPosition(canvasPoint);
+		PointF canvasPoint = centerBox();
 
 		onTopBarView()
 				.performClickCheckmark();
@@ -474,7 +407,7 @@ public class TextToolIntegrationTest {
 		int[] pixelsDrawingSurface = new int[surfaceBitmapWidth];
 		layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, surfaceBitmapWidth, 0, (int) canvasPoint.y, surfaceBitmapWidth, 1);
 		int pixelAmount = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
-		assert pixelAmount > numberOfBlackPixels - 15 && pixelAmount < numberOfBlackPixels + 15;
+		assert pixelAmount > 0;
 
 		onTopBarView()
 				.performUndo();
@@ -487,7 +420,7 @@ public class TextToolIntegrationTest {
 
 		layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, surfaceBitmapWidth, 0, (int) canvasPoint.y, surfaceBitmapWidth, 1);
 		pixelAmount = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
-		assert pixelAmount > numberOfBlackPixels - 15 && pixelAmount < numberOfBlackPixels + 15;
+		assert pixelAmount > 0;
 	}
 
 	@Test
@@ -497,13 +430,7 @@ public class TextToolIntegrationTest {
 		onToolBarView()
 				.performCloseToolOptionsView();
 
-		float newBoxWidth = getToolMemberBoxWidth() * 1.5f;
-		float newBoxHeight = getToolMemberBoxHeight() * 1.5f;
-		setToolMemberBoxWidth(newBoxWidth);
-		setToolMemberBoxHeight(newBoxHeight);
-
-		float boxPositionX = getToolMemberBoxPosition().x;
-		float boxPositionY = getToolMemberBoxPosition().y;
+		PointF canvasPoint = centerBox();
 
 		onToolProperties()
 				.setColor(Color.WHITE);
@@ -511,14 +438,28 @@ public class TextToolIntegrationTest {
 		Paint paint = textTool.textPaint;
 		int selectedColor = paint.getColor();
 		assertEquals(Color.WHITE, selectedColor);
-		Bitmap bitmap = getToolMemberDrawingBitmap();
-		int[] pixels = new int[bitmap.getWidth()];
-		bitmap.getPixels(pixels, 0, bitmap.getWidth(), 0, bitmap.getHeight() / 2, bitmap.getWidth(), 1);
-		assertEquals(countPixelsWithColor(pixels, Color.BLACK), 0);
-		assertTrue(countPixelsWithColor(pixels, selectedColor) > 0);
 
-		assertEquals(boxPositionX, getToolMemberBoxPosition().x, EQUALS_DELTA);
-		assertEquals(boxPositionY, getToolMemberBoxPosition().y, EQUALS_DELTA);
+		onTopBarView()
+				.performClickCheckmark();
+
+		int surfaceBitmapWidth = layerModel.getWidth();
+		int[] pixelsDrawingSurface = new int[surfaceBitmapWidth];
+		layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, surfaceBitmapWidth, 0, (int) canvasPoint.y, surfaceBitmapWidth, 1);
+		int pixelAmount = countPixelsWithColor(pixelsDrawingSurface, Color.WHITE);
+		assert pixelAmount > 0;
+
+		onToolProperties()
+				.setColor(Color.BLACK);
+
+		selectedColor = paint.getColor();
+		assertEquals(Color.BLACK, selectedColor);
+
+		onTopBarView()
+				.performClickCheckmark();
+
+		layerModel.getCurrentLayer().getBitmap().getPixels(pixelsDrawingSurface, 0, surfaceBitmapWidth, 0, (int) canvasPoint.y, surfaceBitmapWidth, 1);
+		pixelAmount = countPixelsWithColor(pixelsDrawingSurface, Color.BLACK);
+		assert pixelAmount > 0;
 	}
 
 	@Test
@@ -538,6 +479,8 @@ public class TextToolIntegrationTest {
 
 	@Test
 	public void testMultiLineText() {
+		checkTextBoxDimensionsAndDefaultPosition();
+
 		enterMultilineTestText();
 
 		onToolBarView()
@@ -547,8 +490,6 @@ public class TextToolIntegrationTest {
 		String[] actualTextSplitUp = getToolMemberMultilineText();
 
 		assertArrayEquals(expectedTextSplitUp, actualTextSplitUp);
-
-		checkTextBoxDimensionsAndDefaultPosition();
 	}
 
 	@Test
@@ -637,19 +578,25 @@ public class TextToolIntegrationTest {
 		assertNotEquals(initialPosition, positionAfterZoom);
 	}
 
-	private void checkTextBoxDimensions() {
-		int boxOffset = BOX_OFFSET;
-		float textSizeMagnificationFactor = TEXT_SIZE_MAGNIFICATION_FACTOR;
+	private PointF centerBox() {
+		PointF screenPoint = new PointF(activityHelper.getDisplayWidth() / 2.0f, activityHelper.getDisplayHeight() / 2.0f);
+		PointF canvasPoint = new PointF(screenPoint.x, screenPoint.y);
+		canvasPoint.x = (float) Math.round(canvasPoint.x);
+		canvasPoint.y = (float) Math.round(canvasPoint.y);
+		setToolMemberBoxPosition(canvasPoint);
+		return canvasPoint;
+	}
 
+	private void checkTextBoxDimensions() {
 		float actualBoxWidth = getToolMemberBoxWidth();
 		float actualBoxHeight = getToolMemberBoxHeight();
 
 		boolean italic = italicToggleButton.isChecked();
 
-		String font = ((FontListAdapter) fontList.getAdapter()).getSelectedItem();
+		FontType font = ((FontListAdapter) fontList.getAdapter()).getSelectedItem();
 
 		String stringTextSize = textSize.getText().toString();
-		float textSize = Float.parseFloat(stringTextSize) * textSizeMagnificationFactor;
+		float textSize = Float.parseFloat(stringTextSize) * TEXT_SIZE_MAGNIFICATION_FACTOR;
 
 		Paint textPaint = new Paint();
 		textPaint.setAntiAlias(true);
@@ -658,16 +605,16 @@ public class TextToolIntegrationTest {
 		int style = italic ? Typeface.ITALIC : Typeface.NORMAL;
 
 		switch (font) {
-			case FONT_SANS_SERIF:
+			case SANS_SERIF:
 				textPaint.setTypeface(Typeface.create(Typeface.SANS_SERIF, style));
 				break;
-			case FONT_SERIF:
+			case SERIF:
 				textPaint.setTypeface(Typeface.create(Typeface.SERIF, style));
 				break;
-			case FONT_STC:
+			case STC:
 				textPaint.setTypeface(ResourcesCompat.getFont(launchActivityRule.getActivity(), R.font.stc_regular));
 				break;
-			case FONT_DUBAI:
+			case DUBAI:
 				textPaint.setTypeface(ResourcesCompat.getFont(launchActivityRule.getActivity(), R.font.dubai));
 				break;
 			default:
@@ -687,10 +634,10 @@ public class TextToolIntegrationTest {
 				maxTextWidth = textWidth;
 			}
 		}
-		float expectedBoxWidth = maxTextWidth + 2 * boxOffset;
+		float expectedBoxWidth = maxTextWidth + 2 * BOX_OFFSET;
 
 		float textHeight = textDescent - textAscent;
-		float expectedBoxHeight = textHeight * multilineText.length + 2 * boxOffset;
+		float expectedBoxHeight = textHeight * multilineText.length + 2 * BOX_OFFSET;
 
 		assertEquals(expectedBoxWidth, actualBoxWidth, EQUALS_DELTA);
 		assertEquals(expectedBoxHeight, actualBoxHeight, EQUALS_DELTA);
@@ -722,6 +669,7 @@ public class TextToolIntegrationTest {
 		 * current IME does not understand how to translatePerspective the string into key events). As a
 		 * workaround, you can use replaceText action to set the text directly in the EditText field.
 		 */
+
 		onView(withId(R.id.pocketpaint_text_tool_dialog_input_text)).perform(replaceText(textToEnter));
 		Espresso.closeSoftKeyboard();
 		onView(withId(R.id.pocketpaint_text_tool_dialog_input_text)).check(matches(withText(textToEnter)));
@@ -731,46 +679,40 @@ public class TextToolIntegrationTest {
 		enterTextInput(TEST_TEXT);
 	}
 
-	private void enterArabicTestText() {
-		enterTextInput(TEST_ARABIC_TEXT);
-	}
-
 	private void enterMultilineTestText() {
 		enterTextInput(TEST_TEXT_MULTILINE);
 	}
 
 	private void selectFormatting(FormattingOptions format) {
-		switch (format) {
-			case MONOSPACE:
-			case SERIF:
+		onView(withText(getFormattingOptionAsString(format))).perform(click());
+	}
+
+	private void selectFontType(FontType fontType) {
+		onView(withId(R.id.pocketpaint_text_tool_dialog_list_font))
+				.perform(RecyclerViewActions.scrollTo(hasDescendant(withText(getFontTypeAsString(fontType)))));
+		onView(withText(getFontTypeAsString(fontType)))
+				.perform(click());
+	}
+
+	private String getFontTypeAsString(FontType fontType) {
+		switch (fontType) {
 			case SANS_SERIF:
+				return activity.getString(R.string.text_tool_dialog_font_sans_serif);
+			case SERIF:
+				return activity.getString(R.string.text_tool_dialog_font_serif);
+			case MONOSPACE:
+				return activity.getString(R.string.text_tool_dialog_font_monospace);
 			case STC:
+				return activity.getString(R.string.text_tool_dialog_font_arabic_stc);
 			case DUBAI:
-				onView(withId(R.id.pocketpaint_text_tool_dialog_list_font)).perform(RecyclerViewActions.scrollTo(hasDescendant(withText(getFontString(format)))));
-				onView(withId(R.id.pocketpaint_text_tool_dialog_list_font)).perform(RecyclerViewActions.actionOnItem(hasDescendant(withText(getFontString(format))), click()));
-				break;
-			case UNDERLINE:
-			case ITALIC:
-			case BOLD:
-				onView(withText(getFontString(format))).perform(click());
-				break;
+				return activity.getString(R.string.text_tool_dialog_font_dubai);
 			default:
-				fail("Formatting option not supported.");
+				return null;
 		}
 	}
 
-	private String getFontString(FormattingOptions format) {
+	private String getFormattingOptionAsString(FormattingOptions format) {
 		switch (format) {
-			case MONOSPACE:
-				return FONT_MONOSPACE;
-			case SERIF:
-				return FONT_SERIF;
-			case SANS_SERIF:
-				return FONT_SANS_SERIF;
-			case STC:
-				return FONT_STC;
-			case DUBAI:
-				return FONT_DUBAI;
 			case UNDERLINE:
 				return activity.getString(R.string.text_tool_dialog_underline_shortcut);
 			case ITALIC:
@@ -796,16 +738,8 @@ public class TextToolIntegrationTest {
 		return textTool.boxWidth;
 	}
 
-	private void setToolMemberBoxWidth(float width) {
-		textTool.boxWidth = width;
-	}
-
 	private float getToolMemberBoxHeight() {
 		return textTool.boxHeight;
-	}
-
-	private void setToolMemberBoxHeight(float height) {
-		textTool.boxHeight = height;
 	}
 
 	private PointF getToolMemberBoxPosition() {
@@ -828,15 +762,11 @@ public class TextToolIntegrationTest {
 		return textTool.bold;
 	}
 
-	private Bitmap getToolMemberDrawingBitmap() {
-		return textTool.drawingBitmap;
-	}
-
 	private String[] getToolMemberMultilineText() {
 		return textTool.getMultilineText();
 	}
 
 	private enum FormattingOptions {
-		UNDERLINE, ITALIC, BOLD, MONOSPACE, SERIF, SANS_SERIF, STC, DUBAI
+		UNDERLINE, ITALIC, BOLD
 	}
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
@@ -57,6 +57,7 @@ import org.catrobat.paintroid.command.serialization.CommandSerializationUtilitie
 import org.catrobat.paintroid.command.serialization.SerializablePath
 import org.catrobat.paintroid.command.serialization.SerializableTypeface
 import org.catrobat.paintroid.model.CommandManagerModel
+import org.catrobat.paintroid.tools.FontType
 import org.catrobat.paintroid.tools.drawable.HeartDrawable
 import org.catrobat.paintroid.tools.drawable.OvalDrawable
 import org.catrobat.paintroid.tools.drawable.RectangleDrawable
@@ -65,9 +66,8 @@ import org.catrobat.paintroid.tools.implementation.DefaultToolPaint
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import kotlin.collections.ArrayList
+import org.mockito.Mockito.mock
 
 class CommandSerializationTest {
 
@@ -174,13 +174,14 @@ class CommandSerializationTest {
     @Test
     fun testSerializeTextToolCommand() {
         val typeface = SerializableTypeface(
-            "Monospace",
-            bold = true,
+            FontType.MONOSPACE,
+            bold = false,
             underline = false,
             italic = true,
             textSize = 25f,
             textSkewX = -0.25f
         )
+
         expectedModel.commands.add(
             commandFactory.createTextToolCommand(
                 arrayOf("Serialization", "is", "fun", "!.?)4`\""),
@@ -569,8 +570,11 @@ class CommandSerializationTest {
         actualTypeFace: SerializableTypeface,
         expectedTypeFace: SerializableTypeface
     ) =
-        actualTypeFace.font == expectedTypeFace.font && actualTypeFace.bold == expectedTypeFace.bold && actualTypeFace.underline == expectedTypeFace.underline &&
-            actualTypeFace.italic == expectedTypeFace.italic && actualTypeFace.textSize == expectedTypeFace.textSize &&
+        actualTypeFace.font == expectedTypeFace.font &&
+            actualTypeFace.bold == expectedTypeFace.bold &&
+            actualTypeFace.underline == expectedTypeFace.underline &&
+            actualTypeFace.italic == expectedTypeFace.italic &&
+            actualTypeFace.textSize == expectedTypeFace.textSize &&
             actualTypeFace.textSkewX == expectedTypeFace.textSkewX
 
     private fun equalsGeometricFillCommand(

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
@@ -84,7 +84,7 @@ interface CommandFactory {
         boxHeight: Float,
         toolPosition: PointF,
         boxRotation: Float,
-        typeFaceInfo: SerializableTypeface
+        typefaceInfo: SerializableTypeface
     ): Command
 
     fun createResizeCommand(newWidth: Int, newHeight: Int): Command

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
@@ -144,11 +144,11 @@ class DefaultCommandFactory : CommandFactory {
         boxHeight: Float,
         toolPosition: PointF,
         boxRotation: Float,
-        typeFaceInfo: SerializableTypeface
+        typefaceInfo: SerializableTypeface
     ): Command = TextToolCommand(
         multilineText, commonFactory.createPaint(textPaint),
         boxOffset.toFloat(), boxWidth, boxHeight, commonFactory.createPointF(toolPosition),
-        boxRotation, typeFaceInfo
+        boxRotation, typefaceInfo
     )
 
     override fun createResizeCommand(newWidth: Int, newHeight: Int): Command =

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/SerializableTypeface.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/SerializableTypeface.kt
@@ -21,13 +21,14 @@ package org.catrobat.paintroid.command.serialization
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
+import org.catrobat.paintroid.tools.FontType
 
-data class SerializableTypeface(val font: String, val bold: Boolean, val underline: Boolean, val italic: Boolean, val textSize: Float, val textSkewX: Float) {
+data class SerializableTypeface(val font: FontType, val bold: Boolean, val underline: Boolean, val italic: Boolean, val textSize: Float, val textSkewX: Float) {
 
     class TypefaceSerializer(version: Int) : VersionSerializer<SerializableTypeface>(version) {
         override fun write(kryo: Kryo, output: Output, typeface: SerializableTypeface) {
             with(output) {
-                writeString(typeface.font)
+                writeString(typeface.font.name)
                 writeBoolean(typeface.bold)
                 writeBoolean(typeface.underline)
                 writeBoolean(typeface.italic)
@@ -41,7 +42,7 @@ data class SerializableTypeface(val font: String, val bold: Boolean, val underli
 
         override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out SerializableTypeface>): SerializableTypeface {
             return with(input) {
-                SerializableTypeface(readString(), readBoolean(), readBoolean(), readBoolean(), readFloat(), readFloat())
+                SerializableTypeface(FontType.valueOf(readString()), readBoolean(), readBoolean(), readBoolean(), readFloat(), readFloat())
             }
         }
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/TextToolCommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/TextToolCommandSerializer.kt
@@ -29,6 +29,7 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.command.implementation.TextToolCommand
+import org.catrobat.paintroid.tools.FontType
 
 class TextToolCommandSerializer(version: Int, private val activityContext: Context) : VersionSerializer<TextToolCommand>(version) {
     override fun write(kryo: Kryo, output: Output, command: TextToolCommand) {
@@ -60,23 +61,24 @@ class TextToolCommandSerializer(version: Int, private val activityContext: Conte
             val position = kryo.readObject(input, PointF::class.java)
             val rotation = readFloat()
             val typeFaceInfo = kryo.readObject(input, SerializableTypeface::class.java)
+
             paint.apply {
                 isFakeBoldText = typeFaceInfo.bold
                 isUnderlineText = typeFaceInfo.underline
                 textSize = typeFaceInfo.textSize
                 textSkewX = typeFaceInfo.textSkewX
                 val style = if (typeFaceInfo.italic) Typeface.ITALIC else Typeface.NORMAL
-                try {
+                typeface = try {
                     when (typeFaceInfo.font) {
-                        "Sans Serif" -> typeface = Typeface.create(Typeface.SANS_SERIF, style)
-                        "Serif" -> typeface = Typeface.create(Typeface.SERIF, style)
-                        "Monospace" -> typeface = Typeface.create(Typeface.MONOSPACE, style)
-                        "STC" -> typeface = ResourcesCompat.getFont(activityContext, R.font.stc_regular)
-                        "Dubai" -> typeface = ResourcesCompat.getFont(activityContext, R.font.dubai)
+                        FontType.SANS_SERIF -> Typeface.create(Typeface.SANS_SERIF, style)
+                        FontType.SERIF -> Typeface.create(Typeface.SERIF, style)
+                        FontType.MONOSPACE -> Typeface.create(Typeface.MONOSPACE, style)
+                        FontType.STC -> ResourcesCompat.getFont(activityContext, R.font.stc_regular)
+                        FontType.DUBAI -> ResourcesCompat.getFont(activityContext, R.font.dubai)
                     }
                 } catch (e: Exception) {
                     Log.e("LoadImageAsync", "Typeface not supported on this mobile phone")
-                    typeface = Typeface.create(Typeface.SANS_SERIF, style)
+                    Typeface.create(Typeface.SANS_SERIF, style)
                 }
             }
             TextToolCommand(text, paint, offset, width, height, position, rotation, typeFaceInfo)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/FontType.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/FontType.kt
@@ -1,0 +1,12 @@
+package org.catrobat.paintroid.tools
+
+import androidx.annotation.StringRes
+import org.catrobat.paintroid.R
+
+enum class FontType(@StringRes val nameResource: Int) {
+    SANS_SERIF(R.string.text_tool_dialog_font_sans_serif),
+    SERIF(R.string.text_tool_dialog_font_serif),
+    MONOSPACE(R.string.text_tool_dialog_font_monospace),
+    STC(R.string.text_tool_dialog_font_arabic_stc),
+    DUBAI(R.string.text_tool_dialog_font_dubai);
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
@@ -18,7 +18,6 @@
  */
 package org.catrobat.paintroid.tools.implementation
 
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.PointF
@@ -30,14 +29,12 @@ import org.catrobat.paintroid.R
 import org.catrobat.paintroid.command.CommandManager
 import org.catrobat.paintroid.command.serialization.SerializableTypeface
 import org.catrobat.paintroid.tools.ContextCallback
+import org.catrobat.paintroid.tools.FontType
 import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.TextToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
-import kotlin.Exception
-import kotlin.math.max
 
 @VisibleForTesting
 const val TEXT_SIZE_MAGNIFICATION_FACTOR = 3f
@@ -86,7 +83,7 @@ class TextTool(
 
     @VisibleForTesting
     @JvmField
-    var font = "Sans Serif"
+    var font = FontType.SANS_SERIF
 
     @VisibleForTesting
     @JvmField
@@ -100,10 +97,7 @@ class TextTool(
     @JvmField
     var bold = false
 
-    @VisibleForTesting
-    @JvmField
-    var textSize = DEFAULT_TEXT_SIZE
-
+    private var textSize = DEFAULT_TEXT_SIZE
     private val stc: Typeface?
     private val dubai: Typeface?
 
@@ -121,51 +115,49 @@ class TextTool(
         dubai = contextCallback.getFont(R.font.dubai)
         textPaint = Paint()
         initializePaint()
-        createAndSetBitmap()
+        resetPreview()
         resetBoxPosition()
-        toolOptionsViewController.setCallback(object : ToolOptionsVisibilityController.Callback {
-            override fun onHide() {
-                createAndSetBitmap()
-            }
 
-            override fun onShow() {
-                createAndSetBitmap()
-            }
-        })
         val callback: TextToolOptionsView.Callback = object : TextToolOptionsView.Callback {
             override fun setText(text: String) {
                 this@TextTool.text = text
-                createAndSetBitmap()
+                resetPreview()
+                workspace.invalidate()
             }
 
-            override fun setFont(font: String) {
-                this@TextTool.font = font
+            override fun setFont(fontType: FontType) {
+                this@TextTool.font = fontType
                 updateTypeface()
-                createAndSetBitmap()
+                resetPreview()
+                workspace.invalidate()
             }
 
             override fun setUnderlined(underlined: Boolean) {
                 this@TextTool.underlined = underlined
                 textPaint.isUnderlineText = this@TextTool.underlined
-                createAndSetBitmap()
+                resetPreview()
+                workspace.invalidate()
             }
 
             override fun setItalic(italic: Boolean) {
                 this@TextTool.italic = italic
                 updateTypeface()
-                createAndSetBitmap()
+                resetPreview()
+                workspace.invalidate()
             }
 
             override fun setBold(bold: Boolean) {
                 this@TextTool.bold = bold
                 textPaint.isFakeBoldText = this@TextTool.bold
-                createAndSetBitmap()
+                resetPreview()
+                workspace.invalidate()
             }
 
             override fun setTextSize(size: Int) {
                 textSize = size
                 textPaint.textSize = textSize * TEXT_SIZE_MAGNIFICATION_FACTOR
-                createAndSetBitmap()
+                resetPreview()
+                workspace.invalidate()
             }
 
             override fun hideToolOptions() {
@@ -179,37 +171,56 @@ class TextTool(
     private fun initializePaint() {
         textPaint.isAntiAlias = DEFAULT_ANTIALIASING_ON
         textPaint.color = toolPaint.previewColor
-        textPaint.textSize = textSize * TEXT_SIZE_MAGNIFICATION_FACTOR
+        textPaint.textSize = DEFAULT_TEXT_SIZE * TEXT_SIZE_MAGNIFICATION_FACTOR
         textPaint.isUnderlineText = underlined
         textPaint.isFakeBoldText = bold
         updateTypeface()
     }
 
-    private fun createAndSetBitmap() {
-        val multilineText = multilineText
-        val textDescent = textPaint.descent()
+    override fun drawBitmap(canvas: Canvas, boxWidth: Float, boxHeight: Float) {
         val textAscent = textPaint.ascent()
-        val upperBoxEdge = toolPosition.y - boxHeight / 2.0f
-        val textHeight = textDescent - textAscent
-        boxHeight = textHeight * multilineText.size + 2 * BOX_OFFSET
-        toolPosition.y = upperBoxEdge + boxHeight / 2.0f
-        var maxTextWidth = 0f
-        for (str in multilineText) {
-            maxTextWidth = max(maxTextWidth, textPaint.measureText(str))
+        val textDescent = textPaint.descent()
+        val textHeight = (textDescent - textAscent) * multilineText.size
+        val lineHeight = textHeight / multilineText.size
+        val maxTextWidth = multilineText.maxOf { line ->
+            textPaint.measureText(line)
         }
-        boxWidth = maxTextWidth + 2 * BOX_OFFSET
-        val bitmap =
-            Bitmap.createBitmap(boxWidth.toInt(), boxHeight.toInt(), Bitmap.Config.ARGB_8888)
-        val drawCanvas = Canvas(bitmap)
-        for (i in multilineText.indices) {
-            drawCanvas.drawText(
-                multilineText[i],
-                BOX_OFFSET.toFloat(),
-                BOX_OFFSET - textAscent + textHeight * i,
+
+        canvas.save()
+
+        val widthScaling = (boxWidth - 2 * BOX_OFFSET) / maxTextWidth
+        val heightScaling = (boxHeight - 2 * BOX_OFFSET) / textHeight
+
+        canvas.scale(widthScaling, heightScaling)
+
+        val scaledHeightOffset = BOX_OFFSET / heightScaling
+        val scaledWidthOffset = BOX_OFFSET / widthScaling
+        val scaledBoxWidth = boxWidth / widthScaling
+        val scaledBoxHeight = boxHeight / heightScaling
+
+        multilineText.forEachIndexed { index, textLine ->
+            canvas.drawText(
+                textLine,
+                -(scaledBoxWidth / 2) + scaledWidthOffset,
+                -(scaledBoxHeight / 2) + scaledHeightOffset - textAscent + lineHeight * index,
                 textPaint
             )
         }
-        setBitmap(bitmap)
+
+        canvas.restore()
+    }
+
+    private fun resetPreview() {
+        val textDescent = textPaint.descent()
+        val textAscent = textPaint.ascent()
+        val textHeight = textDescent - textAscent
+
+        val maxTextWidth = multilineText.maxOf { line ->
+            textPaint.measureText(line)
+        }
+
+        boxHeight = textHeight * multilineText.size + 2 * BOX_OFFSET
+        boxWidth = maxTextWidth + 2 * BOX_OFFSET
     }
 
     override fun onSaveInstanceState(bundle: Bundle?) {
@@ -220,7 +231,7 @@ class TextTool(
             putBoolean(BUNDLE_TOOL_BOLD, bold)
             putString(BUNDLE_TOOL_TEXT, text)
             putInt(BUNDLE_TOOL_TEXT_SIZE, textSize)
-            putString(BUNDLE_TOOL_FONT, font)
+            putString(BUNDLE_TOOL_FONT, font.name)
         }
     }
 
@@ -232,13 +243,12 @@ class TextTool(
             bold = getBoolean(BUNDLE_TOOL_BOLD, bold)
             text = getString(BUNDLE_TOOL_TEXT, text)
             textSize = getInt(BUNDLE_TOOL_TEXT_SIZE, textSize)
-            font = getString(BUNDLE_TOOL_FONT, font)
+            font = FontType.valueOf(getString(BUNDLE_TOOL_FONT, font.name))
         }
         textToolOptionsView.setState(bold, italic, underlined, text, textSize, font)
         textPaint.isUnderlineText = underlined
         textPaint.isFakeBoldText = bold
         updateTypeface()
-        createAndSetBitmap()
     }
 
     @SuppressWarnings("TooGenericExceptionCaught")
@@ -246,17 +256,17 @@ class TextTool(
         val style = if (italic) Typeface.ITALIC else Typeface.NORMAL
         val textSkewX = if (italic) ITALIC_TEXT_SKEW else DEFAULT_TEXT_SKEW
         when (font) {
-            "Sans Serif" -> textPaint.typeface = Typeface.create(Typeface.SANS_SERIF, style)
-            "Serif" -> textPaint.typeface = Typeface.create(Typeface.SERIF, style)
-            "Monospace" -> textPaint.typeface = Typeface.create(Typeface.MONOSPACE, style)
-            "STC" ->
+            FontType.SANS_SERIF -> textPaint.typeface = Typeface.create(Typeface.SANS_SERIF, style)
+            FontType.SERIF -> textPaint.typeface = Typeface.create(Typeface.SERIF, style)
+            FontType.MONOSPACE -> textPaint.typeface = Typeface.create(Typeface.MONOSPACE, style)
+            FontType.STC ->
                 try {
                     textPaint.typeface = stc
                     textPaint.textSkewX = textSkewX
                 } catch (e: Exception) {
                     Log.e(TAG, "stc_regular")
                 }
-            "Dubai" ->
+            FontType.DUBAI ->
                 try {
                     textPaint.typeface = dubai
                     textPaint.textSkewX = textSkewX
@@ -271,10 +281,10 @@ class TextTool(
         val height = boxHeight
         val position = PointF(toolPosition.x, toolPosition.y)
         textPaint.color = toolPaint.previewColor
-        createAndSetBitmap()
         toolPosition.set(position)
         boxWidth = width
         boxHeight = height
+        workspace.invalidate()
     }
 
     override fun resetInternalState() = Unit
@@ -282,6 +292,7 @@ class TextTool(
     override fun onClickOnButton() {
         highlightBox()
         val toolPosition = PointF(toolPosition.x, toolPosition.y)
+
         val typeFaceInfo = SerializableTypeface(
             font,
             bold,
@@ -290,6 +301,7 @@ class TextTool(
             textPaint.textSize,
             textPaint.textSkewX
         )
+
         val command = commandFactory.createTextToolCommand(
             multilineText,
             textPaint,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.kt
@@ -18,6 +18,8 @@
  */
 package org.catrobat.paintroid.tools.options
 
+import org.catrobat.paintroid.tools.FontType
+
 interface TextToolOptionsView {
     fun setState(
         bold: Boolean,
@@ -25,7 +27,7 @@ interface TextToolOptionsView {
         underlined: Boolean,
         text: String,
         textSize: Int,
-        font: String
+        fontType: FontType
     )
 
     fun setCallback(listener: Callback)
@@ -33,7 +35,7 @@ interface TextToolOptionsView {
     interface Callback {
         fun setText(text: String)
 
-        fun setFont(font: String)
+        fun setFont(fontType: FontType)
 
         fun setUnderlined(underlined: Boolean)
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.kt
@@ -32,6 +32,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.button.MaterialButton
 import org.catrobat.paintroid.R
+import org.catrobat.paintroid.tools.FontType
 import org.catrobat.paintroid.tools.options.TextToolOptionsView
 
 private const val DEFAULT_TEXTSIZE = "20"
@@ -48,7 +49,7 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
     private val underlinedToggleButton: MaterialButton
     private val italicToggleButton: MaterialButton
     private val boldToggleButton: MaterialButton
-    private val fonts: List<String>
+    private val fontTypes: List<FontType>
 
     init {
         val inflater = LayoutInflater.from(context)
@@ -65,7 +66,7 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
         underlinedToggleButton.paintFlags =
             underlinedToggleButton.paintFlags or Paint.UNDERLINE_TEXT_FLAG
         @Suppress("SpreadOperator")
-        fonts = listOf(*context.resources.getStringArray(R.array.pocketpaint_main_text_tool_fonts))
+        fontTypes = FontType.values().toList()
         initializeListeners()
         textEditText.requestFocus()
     }
@@ -84,7 +85,7 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
             }
         }
         fontList.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
-        fontList.adapter = FontListAdapter(context, fonts) { font ->
+        fontList.adapter = FontListAdapter(context, fontTypes) { font ->
             notifyFontChanged(font)
             hideKeyboard()
         }
@@ -127,8 +128,8 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
         })
     }
 
-    private fun notifyFontChanged(fontString: String) {
-        callback?.setFont(fontString)
+    private fun notifyFontChanged(fontType: FontType) {
+        callback?.setFont(fontType)
     }
 
     private fun notifyUnderlinedChanged(underlined: Boolean) {
@@ -157,13 +158,13 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
         underlined: Boolean,
         text: String,
         textSize: Int,
-        font: String
+        fontType: FontType
     ) {
         boldToggleButton.isChecked = bold
         italicToggleButton.isChecked = italic
         underlinedToggleButton.isChecked = underlined
         textEditText.setText(text)
-        (fontList.adapter as FontListAdapter).setSelectedIndex(fonts.indexOf(font))
+        (fontList.adapter as FontListAdapter).setSelectedIndex(fontTypes.indexOf(fontType))
         fontSizeText.setText(DEFAULT_TEXTSIZE)
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/FontListAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/FontListAdapter.kt
@@ -27,11 +27,12 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.chip.Chip
 import org.catrobat.paintroid.R
+import org.catrobat.paintroid.tools.FontType
 
 class FontListAdapter internal constructor(
     context: Context,
-    private val fonts: List<String>,
-    private val onFontChanged: (String) -> Unit
+    private val fontTypes: List<FontType>,
+    private val onFontChanged: (FontType) -> Unit
 ) : RecyclerView.Adapter<FontListAdapter.ViewHolder>() {
     private val mInflater: LayoutInflater = LayoutInflater.from(context)
     private var selectedIndex = 0
@@ -56,20 +57,20 @@ class FontListAdapter internal constructor(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val font = fonts[position]
-        holder.fontChip.text = font
+        val font = fontTypes[position]
+        holder.fontChip.setText(font.nameResource)
         holder.fontChip.typeface = typeFaces[position]
         holder.fontChip.isChecked = position == selectedIndex
     }
 
-    override fun getItemCount(): Int = fonts.size
+    override fun getItemCount(): Int = fontTypes.size
 
     fun setSelectedIndex(selectedIndex: Int) {
         this.selectedIndex = selectedIndex
         notifyDataSetChanged()
     }
 
-    fun getSelectedItem(): String = fonts[selectedIndex]
+    fun getSelectedItem(): FontType = fontTypes[selectedIndex]
 
     inner class ViewHolder internal constructor(itemView: View) :
         RecyclerView.ViewHolder(itemView),
@@ -82,7 +83,7 @@ class FontListAdapter internal constructor(
 
         override fun onClick(p0: View?) {
             setSelectedIndex(layoutPosition)
-            onFontChanged(fonts[layoutPosition])
+            onFontChanged(fontTypes[layoutPosition])
         }
     }
 }

--- a/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
@@ -13,7 +13,7 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *
+ *e
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->

--- a/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
@@ -27,7 +27,8 @@
     android:paddingStart="8dp"
     android:paddingTop="10dp"
     android:paddingEnd="8dp"
-    android:paddingBottom="10dp">
+    android:paddingBottom="10dp"
+    android:baselineAligned="false">
 
     <LinearLayout
         android:layout_width="wrap_content"


### PR DESCRIPTION
Made the texttool draw directly on the canvas instead of generation a bitmap and scaling it accordingly.
Has the side effect that scaled text is no longer blurry.

Introduces a new enum for Fonts to standardize the FontTyppe across the project.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
