### PR TITLE
PAINTROID-199 simplify layer moving and merging

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.kt
@@ -642,8 +642,10 @@ class LayerIntegrationTest {
             .performAddLayer()
             .checkLayerCount(2)
             .performToggleLayerVisibility(0)
-            .performLongClickLayer(0)
-        onView(withText(R.string.no_longclick_on_hidden_layer)).inRoot(RootMatchers.withDecorView(Matchers.not(launchActivityRule.activity.window.decorView))).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+            .performStartDragging(0)
+        onView(withText(R.string.no_longclick_on_hidden_layer))
+            .inRoot(RootMatchers.withDecorView(Matchers.not(launchActivityRule.activity.window.decorView)))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 
     @Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
@@ -44,7 +44,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -103,10 +102,11 @@ public final class LayerMenuViewInteraction extends CustomViewInteraction {
 		return this;
 	}
 
-	public LayerMenuViewInteraction performLongClickLayer(int listPosition) {
+	public LayerMenuViewInteraction performStartDragging(int listPosition) {
 		check(matches(isDisplayed()));
 		onLayerAt(listPosition)
-				.perform(longClick());
+				.onChildView(withId(R.id.pocketpaint_layer_drag_handle))
+				.perform(click());
 		return this;
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/CropCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/CropCommand.kt
@@ -56,7 +56,7 @@ class CropCommand(
         val iterator = layerModel.listIterator(0)
         while (iterator.hasNext()) {
             val currentLayer = iterator.next()
-            if (currentLayer.checkBox) {
+            if (currentLayer.isVisible) {
                 val currentBitmap = currentLayer.bitmap ?: Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
                 val resizedBitmap = Bitmap.createBitmap(width, height, currentBitmap.config)
                 val resizedTransparentBitmap = Bitmap.createBitmap(width, height, currentBitmap.config)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
@@ -150,7 +150,7 @@ class DefaultCommandManager(
         val currentLayer = layerModel.currentLayer
         val canvas = commonFactory.createCanvas()
         if (currentLayer != null) {
-            if (currentLayer.checkBox) {
+            if (currentLayer.isVisible) {
                 canvas.setBitmap(currentLayer.bitmap)
             } else {
                 canvas.setBitmap(currentLayer.transparentBitmap)
@@ -191,12 +191,12 @@ class DefaultCommandManager(
         if (layerCount > 1) {
             for (index in layerCount - 1 downTo 0) {
                 layerModel.getLayerAt(index)?.let {
-                    checkBoxes[index] = it.checkBox
+                    checkBoxes[index] = it.isVisible
                 } ?: run { success = false }
             }
         } else {
             layerModel.getLayerAt(0)?.let {
-                checkBoxes[0] = it.checkBox
+                checkBoxes[0] = it.isVisible
             } ?: run { success = false }
         }
 
@@ -210,7 +210,7 @@ class DefaultCommandManager(
                 if (!checkBoxes[index]) {
                     destinationLayer?.let {
                         it.switchBitmaps(false)
-                        it.checkBox = false
+                        it.isVisible = false
                     }
                 }
             }
@@ -218,7 +218,7 @@ class DefaultCommandManager(
             val destinationLayer = layerModel.currentLayer
             if (destinationLayer != null && !checkBoxes[0]) {
                 destinationLayer.switchBitmaps(false)
-                destinationLayer.checkBox = false
+                destinationLayer.isVisible = false
             }
         }
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.kt
@@ -35,7 +35,7 @@ class FillCommand(private val fillAlgorithmFactory: FillAlgorithmFactory, clicke
     override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
         val currentLayer = layerModel.currentLayer
         currentLayer ?: return
-        if (currentLayer.checkBox) {
+        if (currentLayer.isVisible) {
             currentLayer.bitmap?.let { bitmap ->
                 val replacementColor = bitmap.getPixel(clickedPixel.x, clickedPixel.y)
                 val fillAlgorithm = fillAlgorithmFactory.createFillAlgorithm()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
@@ -67,6 +67,10 @@ interface LayerContracts {
         fun setBottomNavigationViewHolder(bottomNavigationViewHolder: BottomNavigationViewHolder)
 
         fun isShown(): Boolean
+
+        fun onStartDragging(position: Int, view: View)
+
+        fun onStopDragging()
     }
 
     interface LayerViewHolder {
@@ -89,7 +93,7 @@ interface LayerContracts {
 
         fun isSelected(): Boolean
 
-        fun setCheckBox(setTo: Boolean)
+        fun setLayerVisibilityCheckbox(setTo: Boolean)
     }
 
     interface LayerMenuViewHolder {
@@ -107,7 +111,7 @@ interface LayerContracts {
     interface Layer {
         var bitmap: Bitmap?
         var transparentBitmap: Bitmap?
-        var checkBox: Boolean
+        var isVisible: Boolean
 
         fun switchBitmaps(isUnhide: Boolean)
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/Layer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/Layer.kt
@@ -24,7 +24,7 @@ import org.catrobat.paintroid.contract.LayerContracts
 
 open class Layer(override var bitmap: Bitmap?) : LayerContracts.Layer {
     override var transparentBitmap: Bitmap? = null
-    override var checkBox: Boolean = true
+    override var isVisible: Boolean = true
 
     init {
         bitmap?.apply {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
@@ -31,14 +31,14 @@ import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.implementation.LineTool
 import org.catrobat.paintroid.ui.DrawingSurface
 import org.catrobat.paintroid.ui.dragndrop.DragAndDropPresenter
-import org.catrobat.paintroid.ui.dragndrop.ListItemLongClickHandler
+import org.catrobat.paintroid.ui.dragndrop.ListItemDragHandler
 import org.catrobat.paintroid.ui.viewholder.BottomNavigationViewHolder
 import java.util.ArrayList
 import java.util.Collections.swap
 
 class LayerPresenter(
     private val model: LayerContracts.Model,
-    private val listItemLongClickHandler: ListItemLongClickHandler,
+    private val listItemDragHandler: ListItemDragHandler,
     private val layerMenuViewHolder: LayerContracts.LayerMenuViewHolder,
     private val commandManager: CommandManager,
     private val commandFactory: CommandFactory,
@@ -111,12 +111,12 @@ class LayerPresenter(
         } else {
             viewHolder.setDeselected()
         }
-        if (!layers[position].checkBox) {
+        if (!layers[position].isVisible) {
             viewHolder.updateImageView(layer.transparentBitmap)
-            viewHolder.setCheckBox(false)
+            viewHolder.setLayerVisibilityCheckbox(false)
         } else {
             viewHolder.updateImageView(layer.bitmap)
-            viewHolder.setCheckBox(true)
+            viewHolder.setLayerVisibilityCheckbox(true)
         }
     }
 
@@ -165,7 +165,7 @@ class LayerPresenter(
         val newBitmap = if (!isUnhide) transparentBitmap else bitmap
         if (!isUnhide) switchBitmaps(isUnhide)
         bitmap = newBitmap
-        checkBox = isUnhide
+        isVisible = isUnhide
     }
 
     override fun hideLayer(position: Int) {
@@ -222,20 +222,24 @@ class LayerPresenter(
         adapter?.getViewHolderAt(mergeWith)?.setMergable()
     }
 
-    override fun onLongClickLayerAtPosition(position: Int, view: View) {
+    override fun onStopDragging() {
+        listItemDragHandler.stopDragging()
+    }
+
+    override fun onStartDragging(position: Int, view: View) {
         if (!isPositionValid(position)) {
             Log.e(TAG, "onLongClickLayerAtPosition at invalid position")
             return
         }
         var isAllowedToLongclick = true
         for (i in layers.indices) {
-            if (!layers[i].checkBox) {
+            if (!layers[i].isVisible) {
                 isAllowedToLongclick = false
             }
         }
         if (isAllowedToLongclick) {
             if (layerCount > 1) {
-                listItemLongClickHandler.handleOnItemLongClick(position, view)
+                listItemDragHandler.startDragging(position, view)
             }
         } else {
             navigator.showToast(R.string.no_longclick_on_hidden_layer, Toast.LENGTH_SHORT)
@@ -260,7 +264,7 @@ class LayerPresenter(
         }
         refreshLayerMenuViewHolder()
         adapter?.notifyDataSetChanged()
-        listItemLongClickHandler.stopDragging()
+        listItemDragHandler.stopDragging()
     }
 
     fun resetMergeColor(layerPosition: Int) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -132,7 +132,7 @@ open class MainActivityPresenter(
     }
 
     private fun setFirstCheckBoxInLayerMenu() {
-        layerAdapter?.getViewHolderAt(0)?.apply { setCheckBox(true) }
+        layerAdapter?.getViewHolderAt(0)?.apply { setLayerVisibilityCheckbox(true) }
     }
 
     override fun saveBeforeLoadImage() {
@@ -889,7 +889,7 @@ open class MainActivityPresenter(
         if (bottomBarViewHolder.isVisible) {
             bottomBarViewHolder.hide()
         } else {
-            if (!layerAdapter!!.presenter.getLayerItem(workspace.currentLayerIndex).checkBox) {
+            if (!layerAdapter!!.presenter.getLayerItem(workspace.currentLayerIndex).isVisible) {
                 navigator.showToast(R.string.no_tools_on_hidden_layer, Toast.LENGTH_SHORT)
                 return
             }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -22,12 +22,14 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.util.SparseArray
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.LinearLayout
+import androidx.appcompat.widget.AppCompatImageView
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.catrobat.paintroid.R
@@ -69,13 +71,24 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
             with(presenter) {
                 if (checkBox.isChecked) {
                     unhideLayer(position, viewHolder)
-                    getLayerItem(position).checkBox = true
+                    getLayerItem(position).isVisible = true
                 } else {
                     hideLayer(position)
-                    getLayerItem(position).checkBox = false
+                    getLayerItem(position).isVisible = false
                 }
             }
         }
+
+        val dragHandle = localConvertView?.findViewById<AppCompatImageView>(R.id.pocketpaint_layer_drag_handle)
+        dragHandle?.setOnTouchListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> presenter.onStartDragging(position, localConvertView!!)
+                MotionEvent.ACTION_UP -> presenter.onStopDragging()
+            }
+
+            true
+        }
+
         return localConvertView
     }
 
@@ -85,7 +98,7 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
         private val layerBackground: LinearLayout = itemView.findViewById(R.id.pocketpaint_item_layer_background)
         private val imageView: ImageView = itemView.findViewById(R.id.pocketpaint_item_layer_image)
         private var currentBitmap: Bitmap? = null
-        private val checkBox: CheckBox = itemView.findViewById(R.id.pocketpaint_checkbox_layer)
+        private val layerVisibilityCheckbox: CheckBox = itemView.findViewById(R.id.pocketpaint_checkbox_layer)
         private var isSelected = false
 
         companion object {
@@ -99,7 +112,7 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
             get() = itemView
 
         override fun setSelected(position: Int, bottomNavigationViewHolder: BottomNavigationViewHolder?, defaultToolController: DefaultToolController?) {
-            if (!layerPresenter.getLayerItem(position).checkBox) {
+            if (!layerPresenter.getLayerItem(position).isVisible) {
                 defaultToolController?.switchTool(ToolType.HAND, false)
                 bottomNavigationViewHolder?.showCurrentTool(ToolType.HAND)
             }
@@ -113,7 +126,7 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
         }
 
         override fun setDeselected() {
-            layerBackground.setBackgroundColor(Color.TRANSPARENT)
+            layerBackground.setBackgroundResource(R.color.pocketpaint_colorPrimary)
             isSelected = false
         }
 
@@ -141,10 +154,10 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
             return Bitmap.createScaledBitmap(bitmap, newWidth.toInt(), newHeight.toInt(), false)
         }
 
-        override fun setCheckBox(setTo: Boolean) {
-            checkBox.isChecked = setTo
+        override fun setLayerVisibilityCheckbox(setTo: Boolean) {
+            layerVisibilityCheckbox.isChecked = setTo
         }
 
-        override fun setMergable() = layerBackground.setBackgroundColor(Color.YELLOW)
+        override fun setMergable() = layerBackground.setBackgroundResource(R.color.pocketpaint_color_merge_layer)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropListView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropListView.kt
@@ -25,21 +25,19 @@ package org.catrobat.paintroid.ui.dragndrop
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.LightingColorFilter
 import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import android.widget.AdapterView.OnItemClickListener
-import android.widget.AdapterView.OnItemLongClickListener
 import android.widget.ListView
 import org.catrobat.paintroid.presenter.LayerPresenter
 import kotlin.math.max
 import kotlin.math.min
 
-private const val ALPHA_VALUE = 192
-
-class DragAndDropListView : ListView, ListItemLongClickHandler {
+class DragAndDropListView : ListView, ListItemDragHandler {
     private var view: View? = null
     private var hoveringListItem: BitmapDrawable? = null
     private var viewBounds: Rect? = null
@@ -61,10 +59,6 @@ class DragAndDropListView : ListView, ListItemLongClickHandler {
     )
 
     init {
-        onItemLongClickListener = OnItemLongClickListener { _, view, position, _ ->
-            presenter?.onLongClickLayerAtPosition(position, view)
-            true
-        }
         onItemClickListener = OnItemClickListener { _, view, position, _ ->
             presenter?.onClickLayerAtPosition(position, view)
         }
@@ -97,7 +91,7 @@ class DragAndDropListView : ListView, ListItemLongClickHandler {
         return true
     }
 
-    override fun handleOnItemLongClick(position: Int, view: View) {
+    override fun startDragging(position: Int, view: View) {
         this.view?.visibility = VISIBLE
         this.view = view
         initialPosition = position
@@ -129,12 +123,14 @@ class DragAndDropListView : ListView, ListItemLongClickHandler {
         val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         view.draw(canvas)
+        val colorFilter = LightingColorFilter(BRIGHTNESS_MUL_VALUE, BRIGHTNESS_ADD_VALUE)
         val drawable = BitmapDrawable(resources, bitmap)
+        drawable.colorFilter = colorFilter
         viewBounds = Rect(view.left, view.top, view.right, view.bottom)
         viewBounds?.let {
             drawable.bounds = it
         }
-        drawable.alpha = ALPHA_VALUE
+        drawable.alpha = Companion.ALPHA_VALUE
         return drawable
     }
 
@@ -205,5 +201,11 @@ class DragAndDropListView : ListView, ListItemLongClickHandler {
             presenter?.reorderItems(initialPosition, position)
         }
         stopDragging()
+    }
+
+    companion object {
+        private const val ALPHA_VALUE = 192
+        private const val BRIGHTNESS_MUL_VALUE = 0xffffff
+        private const val BRIGHTNESS_ADD_VALUE = 0x222222
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.kt
@@ -33,7 +33,5 @@ interface DragAndDropPresenter {
 
     fun markMergeable(position: Int, mergeWith: Int)
 
-    fun onLongClickLayerAtPosition(position: Int, view: View)
-
     fun onClickLayerAtPosition(position: Int, view: View)
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/ListItemDragHandler.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/ListItemDragHandler.kt
@@ -24,8 +24,8 @@ package org.catrobat.paintroid.ui.dragndrop
 
 import android.view.View
 
-interface ListItemLongClickHandler {
-    fun handleOnItemLongClick(position: Int, view: View)
+interface ListItemDragHandler {
+    fun startDragging(position: Int, view: View)
 
     fun stopDragging()
 }

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_drag_handle.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_drag_handle.xml
@@ -1,0 +1,144 @@
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2021 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector  xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="25.636dp"
+    android:viewportWidth="31.458"
+    android:viewportHeight="25.636">
+  <group>
+    <clip-path android:pathData="M1.229,0h29v5h-29z"/>
+    <group>
+      <path
+          android:fillAlpha="0.05"
+          android:pathData="M0,0h31v7.5h-31z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#fff">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,0h31.458v1h-31.458z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,0h1.5v7.636h-1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M31.5,0h-1.5v7.636h1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+    </group>
+  </group>
+  <group>
+    <clip-path android:pathData="M1.229,6h29v5h-29z"/>
+    <group>
+      <path
+          android:fillAlpha="0.05"
+          android:pathData="M0,6h31v7.5h-31z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#fff">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,6h31.458v1h-31.458z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,6h1.5v7.636h-1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M31.5,6h-1.5v7.636h1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+    </group>
+  </group>
+  <group>
+    <clip-path android:pathData="M1.229,12h29v5h-29z"/>
+    <group>
+      <path
+          android:fillAlpha="0.05"
+          android:pathData="M0,12h31v7.5h-31z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#fff">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,12h31.458v1h-31.458z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,12h1.5v7.636h-1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M31.5,12h-1.5v7.636h1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+    </group>
+  </group>
+  <group>
+    <clip-path android:pathData="M1.229,18h29v5h-29z" />
+    <group>
+      <path
+          android:fillAlpha="0.05"
+          android:pathData="M0,18h31v7.5h-31z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#fff"/>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,18h31.458v1h-31.458z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M0,18h1.5v7.636h-1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+      <path
+          android:fillAlpha="0.2"
+          android:pathData="M31.5,18h-1.5v7.636h1.5z"
+          android:strokeAlpha="0.5"
+          android:fillColor="#000">
+      </path>
+    </group>
+  </group>
+</vector>

--- a/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  *  Paintroid: An image manipulation application for Android.
  *  Copyright (C) 2010-2015 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
@@ -25,26 +24,38 @@
     android:descendantFocusability="blocksDescendants"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingStart="5dp"
+    android:paddingStart="8dp"
     android:paddingTop="10dp"
-    android:paddingEnd="5dp"
+    android:paddingEnd="8dp"
     android:paddingBottom="10dp">
 
-    <CheckBox
-        android:id="@+id/pocketpaint_checkbox_layer"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:checked="true"
-        android:focusable="false"
-        android:translationX="3dp" />
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
 
-    <Space
-        android:layout_width="16dp"
-        android:layout_height="0dp" />
+        <CheckBox
+            android:id="@+id/pocketpaint_checkbox_layer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/pocketpaint_layer_drag_handle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:src="@drawable/ic_pocketpaint_drag_handle" />
+
+    </LinearLayout>
 
     <FrameLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
         android:layout_weight="1">
 
         <ImageView
@@ -52,12 +63,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:maxHeight="100dp"
             android:adjustViewBounds="true"
             android:background="@drawable/pocketpaint_checkeredbg_repeat"
             android:contentDescription="@string/layer_background"
             android:focusable="false"
+            android:maxHeight="100dp"
             android:scaleType="fitXY" />
 
     </FrameLayout>
+
 </LinearLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  *  Paintroid: An image manipulation application for Android.
  *  Copyright (C) 2010-2015 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
@@ -23,52 +22,59 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
-    <ImageButton
-        android:id="@+id/pocketpaint_layer_side_nav_button_visibility"
-        style="?borderlessButtonStyle"
-        android:layout_width="50dp"
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/pocketpaint_layer_actions_container"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/layer_new"
-        android:padding="5dp"
-        android:scaleType="fitXY"
-        android:src="@drawable/ic_pocketpaint_layers_visibility"
-        android:theme="@style/PocketPaintHighlightColorTheme"
-        android:tint="@android:color/white" />
+        android:orientation="horizontal">
 
+        <ImageButton
+            android:id="@+id/pocketpaint_layer_side_nav_button_visibility"
+            style="?borderlessButtonStyle"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/layer_new"
+            android:padding="5dp"
+            android:scaleType="fitXY"
+            android:src="@drawable/ic_pocketpaint_layers_visibility"
+            android:theme="@style/PocketPaintHighlightColorTheme"
+            android:tint="@android:color/white" />
 
-    <ImageButton
-        android:id="@+id/pocketpaint_layer_side_nav_button_add"
-        style="?borderlessButtonStyle"
-        android:layout_width="50dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="-2dp"
-        android:layout_toEndOf="@+id/pocketpaint_layer_side_nav_button_visibility"
-        android:contentDescription="@string/layer_new"
-        android:padding="5dp"
-        android:scaleType="fitXY"
-        android:src="@drawable/ic_pocketpaint_layers_add_selector"
-        android:theme="@style/PocketPaintHighlightColorTheme"
-        android:tint="@android:color/white" />
+        <ImageButton
+            android:id="@+id/pocketpaint_layer_side_nav_button_add"
+            style="?borderlessButtonStyle"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="-2dp"
+            android:layout_toEndOf="@+id/pocketpaint_layer_side_nav_button_visibility"
+            android:contentDescription="@string/layer_new"
+            android:padding="5dp"
+            android:scaleType="fitXY"
+            android:src="@drawable/ic_pocketpaint_layers_add_selector"
+            android:theme="@style/PocketPaintHighlightColorTheme"
+            android:tint="@android:color/white" />
 
-    <ImageButton
-        android:id="@+id/pocketpaint_layer_side_nav_button_delete"
-        style="?borderlessButtonStyle"
-        android:layout_width="50dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="-1dp"
-        android:layout_toEndOf="@+id/pocketpaint_layer_side_nav_button_add"
-        android:contentDescription="@string/layer_delete"
-        android:padding="5dp"
-        android:scaleType="fitXY"
-        android:src="@drawable/ic_pocketpaint_layers_delete_selector"
-        android:theme="@style/PocketPaintHighlightColorTheme"
-        android:tint="@android:color/white" />
+        <ImageButton
+            android:id="@+id/pocketpaint_layer_side_nav_button_delete"
+            style="?borderlessButtonStyle"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="-1dp"
+            android:layout_toEndOf="@+id/pocketpaint_layer_side_nav_button_add"
+            android:contentDescription="@string/layer_delete"
+            android:padding="5dp"
+            android:scaleType="fitXY"
+            android:src="@drawable/ic_pocketpaint_layers_delete_selector"
+            android:theme="@style/PocketPaintHighlightColorTheme"
+            android:tint="@android:color/white" />
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
     <org.catrobat.paintroid.ui.dragndrop.DragAndDropListView
         android:id="@+id/pocketpaint_layer_side_nav_list"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/pocketpaint_layer_side_nav_button_add"
+        android:layout_below="@id/pocketpaint_layer_actions_container"
         android:background="@color/pocketpaint_colorPrimary"
         android:splitMotionEvents="true"
         tools:listitem="@layout/pocketpaint_item_layer">

--- a/Paintroid/src/main/res/values/colors.xml
+++ b/Paintroid/src/main/res/values/colors.xml
@@ -41,4 +41,6 @@
     <color name="pocketpaint_welcome_dot_inactive">#64ffffff</color>
     <!-- PocketPaint Toggle Button -->
     <color name="pocketpaint_lighter_gray">#DFDADA</color>
+    <!-- PocketPaint Highlight Merge Layer -->
+    <color name="pocketpaint_color_merge_layer">#33ac86</color>
 </resources>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/FillCommandTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/FillCommandTest.java
@@ -63,7 +63,7 @@ public class FillCommandTest {
 		layerModel.setCurrentLayer(layer);
 
 		when(layer.getBitmap()).thenReturn(bitmap);
-		when(layer.getCheckBox()).thenReturn(true);
+		when(layer.isVisible()).thenReturn(true);
 		when(bitmap.getPixel(3, 5)).thenReturn(Color.RED);
 		when(paint.getColor()).thenReturn(Color.BLUE);
 

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/model/LayerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/model/LayerTest.java
@@ -47,8 +47,8 @@ public class LayerTest {
 
 		assertEquals(firstBitmap, firstLayer.getBitmap());
 		assertEquals(secondBitmap, secondLayer.getBitmap());
-		assertTrue(firstLayer.getCheckBox());
-		assertTrue(secondLayer.getCheckBox());
+		assertTrue(firstLayer.isVisible());
+		assertTrue(secondLayer.isVisible());
 		verify(secondBitmap).getWidth();
 		verify(secondBitmap).getHeight();
 		verify(firstBitmap).getWidth();
@@ -62,7 +62,7 @@ public class LayerTest {
 		layer.setBitmap(secondBitmap);
 
 		assertEquals(secondBitmap, layer.getBitmap());
-		assertTrue(layer.getCheckBox());
+		assertTrue(layer.isVisible());
 		verify(firstBitmap).getWidth();
 		verify(firstBitmap).getHeight();
 	}

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
@@ -32,7 +32,7 @@ import org.catrobat.paintroid.contract.LayerContracts.LayerViewHolder;
 import org.catrobat.paintroid.model.Layer;
 import org.catrobat.paintroid.model.LayerModel;
 import org.catrobat.paintroid.presenter.LayerPresenter;
-import org.catrobat.paintroid.ui.dragndrop.ListItemLongClickHandler;
+import org.catrobat.paintroid.ui.dragndrop.ListItemDragHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
 public class LayerPresenterTest {
 
 	@Mock
-	private ListItemLongClickHandler listItemLongClickHandler;
+	private ListItemDragHandler listItemDragHandler;
 
 	@Mock
 	private LayerContracts.LayerMenuViewHolder layerMenuViewHolder;
@@ -78,7 +78,7 @@ public class LayerPresenterTest {
 	}
 
 	private void createPresenter() {
-		layerPresenter = new LayerPresenter(layerModel, listItemLongClickHandler,
+		layerPresenter = new LayerPresenter(layerModel, listItemDragHandler,
 				layerMenuViewHolder, commandManager, commandFactory, navigator);
 		layerPresenter.setAdapter(layerAdapter);
 	}
@@ -86,7 +86,7 @@ public class LayerPresenterTest {
 	@Test
 	public void testSetUp() {
 		createPresenter();
-		verifyZeroInteractions(layerAdapter, layerMenuViewHolder, listItemLongClickHandler,
+		verifyZeroInteractions(layerAdapter, layerMenuViewHolder, listItemDragHandler,
 				commandManager, commandFactory, navigator);
 	}
 
@@ -106,10 +106,10 @@ public class LayerPresenterTest {
 
 		verify(layerViewHolder).setSelected(0, null, null);
 		verify(layerViewHolder).updateImageView(firstLayerBitmap);
-		verify(layerViewHolder).setCheckBox(false);
+		verify(layerViewHolder).setLayerVisibilityCheckbox(false);
 		verifyNoMoreInteractions(layerViewHolder);
 		verifyZeroInteractions(commandManager, commandFactory, layerAdapter,
-				listItemLongClickHandler, layerMenuViewHolder);
+				listItemDragHandler, layerMenuViewHolder);
 	}
 
 	@Test
@@ -128,10 +128,10 @@ public class LayerPresenterTest {
 
 		verify(layerViewHolder).setDeselected();
 		verify(layerViewHolder).updateImageView(secondLayer.getTransparentBitmap());
-		verify(layerViewHolder).setCheckBox(false);
+		verify(layerViewHolder).setLayerVisibilityCheckbox(false);
 		verifyNoMoreInteractions(layerViewHolder);
 		verifyZeroInteractions(firstLayer, commandManager, layerAdapter,
-				listItemLongClickHandler, layerMenuViewHolder);
+				listItemDragHandler, layerMenuViewHolder);
 	}
 
 	@Test
@@ -145,7 +145,7 @@ public class LayerPresenterTest {
 		verify(layerMenuViewHolder).enableAddLayerButton();
 		verify(layerMenuViewHolder).enableRemoveLayerButton();
 		verifyNoMoreInteractions(layerMenuViewHolder);
-		verifyZeroInteractions(commandManager, commandFactory, layerAdapter, listItemLongClickHandler);
+		verifyZeroInteractions(commandManager, commandFactory, layerAdapter, listItemDragHandler);
 	}
 
 	@Test
@@ -161,7 +161,7 @@ public class LayerPresenterTest {
 		verify(layerMenuViewHolder).disableAddLayerButton();
 		verify(layerMenuViewHolder).enableRemoveLayerButton();
 		verifyNoMoreInteractions(layerMenuViewHolder);
-		verifyZeroInteractions(commandManager, commandFactory, layerAdapter, listItemLongClickHandler);
+		verifyZeroInteractions(commandManager, commandFactory, layerAdapter, listItemDragHandler);
 	}
 
 	@Test
@@ -174,7 +174,7 @@ public class LayerPresenterTest {
 		verify(layerMenuViewHolder).enableAddLayerButton();
 		verify(layerMenuViewHolder).disableRemoveLayerButton();
 		verifyNoMoreInteractions(layerMenuViewHolder);
-		verifyZeroInteractions(commandManager, commandFactory, layerAdapter, listItemLongClickHandler);
+		verifyZeroInteractions(commandManager, commandFactory, layerAdapter, listItemDragHandler);
 	}
 
 	@Test
@@ -221,7 +221,7 @@ public class LayerPresenterTest {
 		layerPresenter.addLayer();
 
 		verify(commandManager).addCommand(command);
-		verifyZeroInteractions(layerMenuViewHolder, layerAdapter, listItemLongClickHandler);
+		verifyZeroInteractions(layerMenuViewHolder, layerAdapter, listItemDragHandler);
 	}
 
 	@Test
@@ -235,7 +235,7 @@ public class LayerPresenterTest {
 		layerPresenter.addLayer();
 
 		verify(navigator).showToast(R.string.layer_too_many_layers, Toast.LENGTH_SHORT);
-		verifyZeroInteractions(commandManager, layerMenuViewHolder, layerAdapter, listItemLongClickHandler);
+		verifyZeroInteractions(commandManager, layerMenuViewHolder, layerAdapter, listItemDragHandler);
 	}
 
 	@Test
@@ -251,7 +251,7 @@ public class LayerPresenterTest {
 		layerPresenter.removeLayer();
 
 		verify(commandManager).addCommand(command);
-		verifyZeroInteractions(selectedLayer, layerMenuViewHolder, layerAdapter, listItemLongClickHandler);
+		verifyZeroInteractions(selectedLayer, layerMenuViewHolder, layerAdapter, listItemDragHandler);
 	}
 
 	@Test
@@ -261,46 +261,46 @@ public class LayerPresenterTest {
 		createPresenter();
 		layerPresenter.removeLayer();
 
-		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter, listItemLongClickHandler);
+		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter, listItemDragHandler);
 	}
 
 	@Test
-	public void testOnLongClickLayerAtPosition() {
+	public void testOnDragLayerAtPosition() {
 		View view = mock(View.class);
 		Layer firstLayer = new Layer(null);
 		Layer secondLayer = new Layer(null);
-		assertTrue(firstLayer.getCheckBox());
-		assertTrue(secondLayer.getCheckBox());
+		assertTrue(firstLayer.isVisible());
+		assertTrue(secondLayer.isVisible());
 		layerModel.addLayerAt(0, firstLayer);
 		layerModel.addLayerAt(1, secondLayer);
 		createPresenter();
-		layerPresenter.onLongClickLayerAtPosition(0, view);
+		layerPresenter.onStartDragging(0, view);
 
-		verify(listItemLongClickHandler).handleOnItemLongClick(0, view);
+		verify(listItemDragHandler).startDragging(0, view);
 		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
 	}
 
 	@Test
-	public void testOnLongClickLayerAtPositionWhenOnlyOneLayer() {
+	public void testOnDragLayerAtPositionWhenOnlyOneLayer() {
 		View view = mock(View.class);
 		layerModel.addLayerAt(0, mock(Layer.class));
 
 		createPresenter();
-		layerPresenter.onLongClickLayerAtPosition(0, view);
+		layerPresenter.onStartDragging(0, view);
 
-		verifyZeroInteractions(listItemLongClickHandler, commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
+		verifyZeroInteractions(listItemDragHandler, commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
 	}
 
 	@Test
-	public void testOnLongClickLayerAtPositionWhenPositionOutOfBounds() {
+	public void testOnDragLayerAtPositionWhenPositionOutOfBounds() {
 		View view = mock(View.class);
 		layerModel.addLayerAt(0, mock(Layer.class));
 		layerModel.addLayerAt(1, mock(Layer.class));
 
 		createPresenter();
-		layerPresenter.onLongClickLayerAtPosition(2, view);
+		layerPresenter.onStartDragging(2, view);
 
-		verifyZeroInteractions(listItemLongClickHandler, commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
+		verifyZeroInteractions(listItemDragHandler, commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
 	}
 
 	@Test
@@ -495,7 +495,7 @@ public class LayerPresenterTest {
 		layerPresenter.markMergeable(0, 1);
 
 		verify(layerViewHolder).setMergable();
-		verifyZeroInteractions(commandManager, layerMenuViewHolder, listItemLongClickHandler);
+		verifyZeroInteractions(commandManager, layerMenuViewHolder, listItemDragHandler);
 	}
 
 	@Test
@@ -503,7 +503,7 @@ public class LayerPresenterTest {
 		createPresenter();
 		layerPresenter.markMergeable(0, 1);
 
-		verifyZeroInteractions(commandManager, layerMenuViewHolder, listItemLongClickHandler);
+		verifyZeroInteractions(commandManager, layerMenuViewHolder, listItemDragHandler);
 	}
 
 	@Test


### PR DESCRIPTION
Deviated a little bit from the suggested design because layers are now displayed according to their aspect ratio, which makes the preview really small, if the layers height is greater than the width. This makes sense because in ticket [PAINTROID-283](https://jira.catrob.at/browse/PAINTROID-283) a seekbar for the alpha value of the layer will be introduced. The seekbar should then be implemented horizontal instead of vertical to avoid a compressed seekbar.


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
