### PR TITLE
PAINTROID-408 Remove minimum size limitation of selections

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -40,7 +40,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
-import static org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShapeKt.DEFAULT_BOX_RESIZE_MARGIN;
+import static org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShapeKt.MINIMAL_BOX_SIZE;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -130,7 +130,7 @@ public class BaseToolWithRectangleShapeToolTest {
 
 		float newWidth = toolToTest.boxWidth;
 		float newHeight = toolToTest.boxHeight;
-		float boxResizeMargin = DEFAULT_BOX_RESIZE_MARGIN;
+		float boxResizeMargin = MINIMAL_BOX_SIZE;
 
 		assertThat(newHeight, is(greaterThanOrEqualTo(boxResizeMargin)));
 		assertThat(newWidth, is(greaterThanOrEqualTo(boxResizeMargin)));
@@ -235,8 +235,8 @@ public class BaseToolWithRectangleShapeToolTest {
 
 		// try rotate right
 		toolToTest.handleDown(topLeftRotationPoint);
-		toolToTest.handleMove(new PointF(screenWidth / 2, topLeftRotationPoint.y));
-		toolToTest.handleUp(new PointF(screenWidth / 2, topLeftRotationPoint.y));
+		toolToTest.handleMove(new PointF(screenWidth / 2f, topLeftRotationPoint.y));
+		toolToTest.handleUp(new PointF(screenWidth / 2f, topLeftRotationPoint.y));
 		float newRotation = toolToTest.boxRotation;
 		assertThat(newRotation, is(greaterThan(rotation)));
 	}
@@ -353,8 +353,8 @@ public class BaseToolWithRectangleShapeToolTest {
 
 		//rotate right
 		toolToTest.handleDown(topLeftRotationPoint);
-		toolToTest.handleMove(new PointF(screenWidth / 2, topLeftRotationPoint.y));
-		toolToTest.handleUp(new PointF(screenWidth / 2, topLeftRotationPoint.y));
+		toolToTest.handleMove(new PointF(screenWidth / 2f, topLeftRotationPoint.y));
+		toolToTest.handleUp(new PointF(screenWidth / 2f, topLeftRotationPoint.y));
 
 		assertFalse(toolToTest.boxContainsPoint(topLeftCorner));
 		assertTrue(toolToTest.boxContainsPoint(pointInRotatedRectangle));

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -55,6 +55,8 @@ import kotlin.math.sin
 const val MAXIMUM_BORDER_RATIO = 2f
 
 @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+const val MINIMAL_BOX_SIZE = 3
+
 const val DEFAULT_BOX_RESIZE_MARGIN = 20
 
 const val DEFAULT_ANTIALIASING_ON = true
@@ -628,12 +630,12 @@ abstract class BaseToolWithRectangleShape(
         resizeWidth(deltaXCorrected.toFloat(), rotationRadian)
 
         // prevent that box gets too small
-        if (boxWidth < DEFAULT_BOX_RESIZE_MARGIN) {
-            boxWidth = DEFAULT_BOX_RESIZE_MARGIN.toFloat()
+        if (boxWidth < MINIMAL_BOX_SIZE) {
+            boxWidth = MINIMAL_BOX_SIZE.toFloat()
             toolPosition.x = oldPosX
         }
-        if (boxHeight < DEFAULT_BOX_RESIZE_MARGIN) {
-            boxHeight = DEFAULT_BOX_RESIZE_MARGIN.toFloat()
+        if (boxHeight < MINIMAL_BOX_SIZE) {
+            boxHeight = MINIMAL_BOX_SIZE.toFloat()
             toolPosition.y = oldPosY
         }
         if (respectMaximumBoxResolution && maximumBoxResolution > 0 && boxWidth * boxHeight > maximumBoxResolution) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
@@ -35,6 +35,7 @@ import org.catrobat.paintroid.tools.options.ShapeToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
 
 private const val SHAPE_OFFSET = 10f
+private const val MIN_SHAPE_OFFSET = 0.75f
 private const val DEFAULT_OUTLINE_WIDTH = 25
 private const val BUNDLE_BASE_SHAPE = "BASE_SHAPE"
 private const val BUNDLE_SHAPE_DRAW_TYPE = "SHAPE_DRAW_TYPE"
@@ -134,7 +135,10 @@ class ShapeTool(
 
     private fun prepareShapeRectangle(shapeRect: RectF, boxWidth: Float, boxHeight: Float) {
         shapeRect.setEmpty()
-        shapeRect.inset(SHAPE_OFFSET - boxWidth / 2, SHAPE_OFFSET - boxHeight / 2)
+        val zoomScaling = if (workspace.scale > 1) workspace.scale else 1f
+        var shapeOffset = SHAPE_OFFSET / zoomScaling
+        shapeOffset = if (shapeOffset > MIN_SHAPE_OFFSET) shapeOffset else MIN_SHAPE_OFFSET
+        shapeRect.inset(shapeOffset - boxWidth / 2, shapeOffset - boxHeight / 2)
         if (shapePreviewPaint.style == Paint.Style.STROKE) {
             shapeRect.inset(shapeOutlineWidth / 2f, shapeOutlineWidth / 2f)
         }


### PR DESCRIPTION
* decreased the minimum box size from 20 to 3 (smaller than 3 doesn't provide good results)

* adapted ShapeTool offset calculation for high zoom levels as margin was too high

https://jira.catrob.at/browse/PAINTROID-408

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
