### PR TITLE
PAINTROID-146 set center tool with algorithm similar to scratch

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.kt
@@ -1334,6 +1334,44 @@ class TransformToolIntegrationTest {
         assertEquals(scale, perspective.scale, 0.0001f)
     }
 
+    @Test
+    fun testTransformToolSetCenterCloseCenter() {
+        drawPlus(layerModel.currentLayer!!.bitmap!!, initialWidth / 2)
+        onToolBarView()
+            .performSelectTool(ToolType.TRANSFORM)
+
+        runBlocking {
+            onTransformToolOptionsView().performSetCenterClick()
+        }
+        onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.BOTTOM_RIGHT_CLOSE_CENTER))
+        runBlocking {
+            TopBarViewInteraction.onTopBarView().performClickCheckmark()
+            delay(1500)
+        }
+        assertThat(toolSelectionBoxWidth, lessThan(initialWidth.toFloat()))
+        assertThat(toolSelectionBoxHeight, lessThan(initialHeight.toFloat()))
+    }
+
+    @Test
+    fun testTransformToolSetCenterFarCenter() {
+        drawPlus(layerModel.currentLayer!!.bitmap!!, initialWidth / 2)
+        onToolBarView()
+            .performSelectTool(ToolType.TRANSFORM)
+
+        runBlocking {
+            onTransformToolOptionsView().performSetCenterClick()
+        }
+        onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.BOTTOM_RIGHT_CORNER))
+        runBlocking {
+            TopBarViewInteraction.onTopBarView().performClickCheckmark()
+            delay(1500)
+        }
+        assertThat(toolSelectionBoxWidth, greaterThan(initialWidth.toFloat()))
+        assertThat(toolSelectionBoxHeight, greaterThan(initialHeight.toFloat()))
+    }
+
     companion object {
         private fun drawPlus(bitmap: Bitmap, lineLength: Int) {
             val horizontalStartX = bitmap.width / 4

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/DrawingSurfaceLocationProvider.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/DrawingSurfaceLocationProvider.java
@@ -104,6 +104,18 @@ public enum DrawingSurfaceLocationProvider implements CoordinatesProvider {
 			return calculatePercentageOffset(view, .75f, .75f);
 		}
 	},
+	BOTTOM_RIGHT_CLOSE_CENTER {
+		@Override
+		public float[] calculateCoordinates(View view) {
+			return calculatePercentageOffset(view, .55f, .55f);
+		}
+	},
+	BOTTOM_RIGHT_CORNER {
+		@Override
+		public float[] calculateCoordinates(View view) {
+			return calculatePercentageOffset(view, 1f, 1f);
+		}
+	},
 	BOTTOM_MIDDLE {
 		@Override
 		public float[] calculateCoordinates(View view) {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/TransformToolOptionsViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/TransformToolOptionsViewInteraction.java
@@ -47,6 +47,12 @@ public final class TransformToolOptionsViewInteraction extends CustomViewInterac
 		return new TransformToolOptionsViewInteraction();
 	}
 
+	public TransformToolOptionsViewInteraction performSetCenterClick() {
+		onView(withId(R.id.pocketpaint_transform_set_center_btn))
+				.perform(click());
+		return this;
+	}
+
 	public TransformToolOptionsViewInteraction performAutoCrop() {
 		onView(withId(R.id.pocketpaint_transform_auto_crop_btn))
 				.perform(click());

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BaseToolWithRectangleShapeToolTest.java
@@ -30,7 +30,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +69,7 @@ public class BaseToolWithRectangleShapeToolTest {
 	@Mock
 	private CommandManager commandManager;
 	@Mock
-	private ToolOptionsVisibilityController toolOptionsViewController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock
@@ -376,8 +376,7 @@ public class BaseToolWithRectangleShapeToolTest {
 	private class BaseToolWithRectangleShapeImpl extends BaseToolWithRectangleShape {
 		private final ToolType toolType;
 
-		BaseToolWithRectangleShapeImpl(ContextCallback contextCallback,
-										ToolOptionsVisibilityController toolOptionsViewController, ToolType toolType, ToolPaint toolPaint, Workspace layerModelWrapper, CommandManager commandManager) {
+		BaseToolWithRectangleShapeImpl(ContextCallback contextCallback, ToolOptionsViewController toolOptionsViewController, ToolType toolType, ToolPaint toolPaint, Workspace layerModelWrapper, CommandManager commandManager) {
 			super(contextCallback, toolOptionsViewController, toolPaint, layerModelWrapper, commandManager);
 			this.toolType = toolType;
 		}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BrushToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/BrushToolTest.java
@@ -37,7 +37,7 @@ import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.common.ConstantsKt;
 import org.catrobat.paintroid.tools.implementation.BrushTool;
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,7 +68,7 @@ public class BrushToolTest {
 	@Mock
 	private BrushToolOptionsView brushToolOptionsView;
 	@Mock
-	private ToolOptionsVisibilityController toolOptionsViewController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private Workspace workspace;
 	@Mock

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/CursorToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/CursorToolTest.java
@@ -35,7 +35,7 @@ import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.common.ConstantsKt;
 import org.catrobat.paintroid.tools.implementation.CursorTool;
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,7 +68,7 @@ public class CursorToolTest {
 	@Mock
 	private BrushToolOptionsView brushToolOptionsView;
 	@Mock
-	private ToolOptionsVisibilityController toolOptionsViewController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/FillToolTest.java
@@ -28,7 +28,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.FillTool;
 import org.catrobat.paintroid.tools.options.FillToolOptionsView;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -44,7 +44,7 @@ public class FillToolTest {
 	@Mock
 	public ContextCallback contextCallback;
 	@Mock
-	public ToolOptionsVisibilityController toolOptionsViewController;
+	public ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	public Workspace workspace;
 	@Mock

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
@@ -27,7 +27,7 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.ImportTool;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class ImportToolTest {
 	@Mock
 	private ToolPaint toolPaint;
 	@Mock
-	private ToolOptionsVisibilityController toolOptionsViewController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
@@ -33,7 +33,7 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.implementation.LineTool
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import org.catrobat.paintroid.ui.Perspective
 import org.catrobat.paintroid.ui.viewholder.TopBarViewHolder
 import org.junit.Assert
@@ -47,7 +47,7 @@ class LineToolTest {
     private val commandManager = Mockito.mock(CommandManager::class.java)
     private var workspace = Mockito.mock(Workspace::class.java)
     private val brushToolOptions = Mockito.mock(BrushToolOptionsView::class.java)
-    private val toolOptionsController = Mockito.mock(ToolOptionsVisibilityController::class.java)
+    private val toolOptionsViewController = Mockito.mock(ToolOptionsViewController::class.java)
     private val contextCallback = Mockito.mock(ContextCallback::class.java)
     private lateinit var tool: LineTool
     private var screenWidth = 1920
@@ -84,7 +84,7 @@ class LineToolTest {
         tool = LineTool(
             brushToolOptions,
             contextCallback,
-            toolOptionsController,
+            toolOptionsViewController,
             toolPaint,
             workspace,
             commandManager,

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/PipetteToolTest.java
@@ -30,7 +30,7 @@ import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.PipetteTool;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,7 +64,7 @@ public class PipetteToolTest {
 	@Mock
 	private Workspace workspace;
 	@Mock
-	private ToolOptionsVisibilityController toolOptionsViewController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ShapeToolTest.java
@@ -29,7 +29,7 @@ import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.drawable.DrawableShape;
 import org.catrobat.paintroid.tools.implementation.ShapeTool;
 import org.catrobat.paintroid.tools.options.ShapeToolOptionsView;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,7 +58,7 @@ public class ShapeToolTest {
 	@Mock
 	private ShapeToolOptionsView shapeToolOptions;
 	@Mock
-	private ToolOptionsVisibilityController toolOptionsViewController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/SprayToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/SprayToolTest.kt
@@ -33,7 +33,7 @@ import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.implementation.STROKE_25
 import org.catrobat.paintroid.tools.implementation.SprayTool
 import org.catrobat.paintroid.tools.options.SprayToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -48,7 +48,7 @@ class SprayToolTest {
     private val workspace = Mockito.mock(Workspace::class.java)
     private val sprayToolOptionsView = Mockito.mock(SprayToolOptionsView::class.java)
     private val toolOptionsViewController =
-        Mockito.mock(ToolOptionsVisibilityController::class.java)
+        Mockito.mock(ToolOptionsViewController::class.java)
     private val contextCallback = Mockito.mock(ContextCallback::class.java)
     private lateinit var tool: SprayTool
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/StampToolTest.java
@@ -33,7 +33,7 @@ import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.implementation.StampTool;
 import org.catrobat.paintroid.tools.options.StampToolOptionsView;
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController;
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +60,7 @@ public class StampToolTest {
 	@Mock
 	private StampToolOptionsView stampToolOptions;
 	@Mock
-	private ToolOptionsVisibilityController toolOptionsViewController;
+	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
 	private ContextCallback contextCallback;
 	@Mock

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/JavaCropAlgorithm.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/JavaCropAlgorithm.kt
@@ -32,29 +32,34 @@ class JavaCropAlgorithm : CropAlgorithm {
 
     private fun isOpaquePixel(x: Int, y: Int): Boolean = bitmap.getPixel(x, y) != Color.TRANSPARENT
 
-    private fun getTopmostCellWithOpaquePixel(): Int? =
+    fun getTopmostCellWithOpaquePixel(): Int? =
         bounds.yRange().firstOrNull { y ->
             bounds.xRange()
                 .firstOrNull { x -> isOpaquePixel(x, y) } != null
         }
 
-    private fun getBottommostCellWithOpaquePixel(): Int? =
+    fun getBottommostCellWithOpaquePixel(): Int? =
         bounds.yRange().lastOrNull { y ->
             bounds.xRange()
                 .firstOrNull { x -> isOpaquePixel(x, y) } != null
         }
 
-    private fun getLeftmostCellWithOpaquePixel(): Int? =
+    fun getLeftmostCellWithOpaquePixel(): Int? =
         bounds.xRange().firstOrNull { x ->
             bounds.yRange()
                 .firstOrNull { y -> isOpaquePixel(x, y) } != null
         }
 
-    private fun getRightmostCellWithOpaquePixel(): Int? =
+    fun getRightmostCellWithOpaquePixel(): Int? =
         bounds.xRange().lastOrNull { x ->
             bounds.yRange()
                 .firstOrNull { y -> isOpaquePixel(x, y) } != null
         }
+
+    fun init(bitmap: Bitmap) {
+        this.bitmap = bitmap
+        bounds = Rect(0, 0, bitmap.width - 1, bitmap.height - 1)
+    }
 
     override fun crop(bitmap: Bitmap?): Rect? {
         this.bitmap = bitmap ?: return null

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/SetCenterAlgorithm.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/SetCenterAlgorithm.kt
@@ -1,0 +1,80 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.tools.helper
+
+import android.graphics.Bitmap
+import android.graphics.PointF
+import android.graphics.Rect
+
+class SetCenterAlgorithm(javaCropAlgorithm: JavaCropAlgorithm) {
+    private var cropAlgorithm: JavaCropAlgorithm = javaCropAlgorithm
+
+    private lateinit var bounds: Rect
+    private lateinit var position: PointF
+    private lateinit var bitmap: Bitmap
+
+    private fun getDistanceLeft(): Int {
+        val leftmostCell = cropAlgorithm.getLeftmostCellWithOpaquePixel() ?: return Int.MIN_VALUE
+        return this.position.x.toInt() - leftmostCell
+    }
+
+    private fun getDistanceRight(): Int {
+        val rightmostCell = cropAlgorithm.getRightmostCellWithOpaquePixel() ?: return Int.MIN_VALUE
+        return rightmostCell - this.position.x.toInt()
+    }
+
+    private fun getDistanceTop(): Int {
+        val topmostCell = cropAlgorithm.getTopmostCellWithOpaquePixel() ?: return Int.MIN_VALUE
+        return this.position.y.toInt() - topmostCell
+    }
+
+    private fun getDistanceBottom(): Int {
+        val bottommostCell =
+            cropAlgorithm.getBottommostCellWithOpaquePixel() ?: return Int.MIN_VALUE
+        return bottommostCell - this.position.y.toInt()
+    }
+
+    private fun checkIfNothingFound(): Boolean =
+        cropAlgorithm.getLeftmostCellWithOpaquePixel() == null
+
+    fun crop(bitmap: Bitmap?, position: PointF?): Rect? {
+        this.bitmap = bitmap ?: return null
+        this.position = position ?: return null
+        cropAlgorithm.init(bitmap)
+
+        if (checkIfNothingFound()) return null
+
+        val distanceLeft = getDistanceLeft()
+        val distanceRight = getDistanceRight()
+        val distanceTop = getDistanceTop()
+        val distanceBottom = getDistanceBottom()
+
+        bounds = Rect(0, 0, 0, 0)
+
+        val distanceVertical = if (distanceTop > distanceBottom) distanceTop else distanceBottom
+        val distanceHorizontal = if (distanceLeft > distanceRight) distanceLeft else distanceRight
+
+        bounds.top = position.y.toInt() - distanceVertical
+        bounds.bottom = position.y.toInt() + distanceVertical
+        bounds.left = position.x.toInt() - distanceHorizontal
+        bounds.right = position.x.toInt() + distanceHorizontal
+
+        return bounds
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
@@ -35,13 +35,13 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.common.PointScrollBehavior
 import org.catrobat.paintroid.tools.common.ScrollBehavior
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 abstract class BaseTool(
     @JvmField
     open var contextCallback: ContextCallback,
     @JvmField
-    protected var toolOptionsViewController: ToolOptionsVisibilityController,
+    protected var toolOptionsViewController: ToolOptionsViewController,
     @JvmField
     protected var toolPaint: ToolPaint,
     @JvmField

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -40,7 +40,7 @@ import org.catrobat.paintroid.tools.ContextCallback
 import org.catrobat.paintroid.tools.ContextCallback.ScreenOrientation
 import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.Workspace
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import java.lang.Math.toDegrees
 import java.lang.Math.toRadians
 import kotlin.math.PI
@@ -85,7 +85,7 @@ private const val BUNDLE_BOX_ROTATION = "BOX_ROTATION"
 
 abstract class BaseToolWithRectangleShape(
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager
@@ -148,6 +148,9 @@ abstract class BaseToolWithRectangleShape(
 
     @JvmField
     var rectangleShrinkingOnHighlight: Int
+
+    @JvmField
+    var shouldDrawRectangle = true
 
     private var boxResizeMargin: Float? = 0f
     private var rotationSymbolWidth: Float? = 0f
@@ -323,7 +326,9 @@ abstract class BaseToolWithRectangleShape(
         if (overlayDrawable != null) {
             drawOverlayDrawable(canvas, boxWidth, boxHeight, boxRotation)
         }
-        drawRectangle(canvas, boxWidth, boxHeight)
+        if (shouldDrawRectangle) {
+            drawRectangle(canvas, boxWidth, boxHeight)
+        }
         drawToolSpecifics(canvas, boxWidth, boxHeight)
         canvas.restore()
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.kt
@@ -31,7 +31,7 @@ import org.catrobat.paintroid.command.CommandManager
 import org.catrobat.paintroid.tools.ContextCallback
 import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.Workspace
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import kotlin.math.max
 import kotlin.math.min
 
@@ -40,7 +40,7 @@ private const val BUNDLE_TOOL_POSITION_X = "TOOL_POSITION_X"
 
 abstract class BaseToolWithShape @SuppressLint("VisibleForTests") constructor(
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
@@ -36,7 +36,7 @@ import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms
 import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms.smoothing
 import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms.threshold
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.sqrt
@@ -44,7 +44,7 @@ import kotlin.math.sqrt
 open class BrushTool(
     val brushToolOptionsView: BrushToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
@@ -40,7 +40,7 @@ import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms.smoothing
 import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms.smoothingAlgorithm
 import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms.threshold
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -54,7 +54,7 @@ private const val CURSOR_LINES = 4
 open class CursorTool(
     private val brushToolOptionsView: BrushToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/EraserTool.kt
@@ -26,12 +26,12 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 class EraserTool(
     brushToolOptionsView: BrushToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.kt
@@ -27,7 +27,7 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.FillToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 private const val HUNDRED = 100f
 const val DEFAULT_TOLERANCE_IN_PERCENT = 12
@@ -36,7 +36,7 @@ const val MAX_ABSOLUTE_TOLERANCE = 510
 class FillTool(
     fillToolOptionsView: FillToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.kt
@@ -26,7 +26,7 @@ import org.catrobat.paintroid.tools.ContextCallback
 import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import kotlin.math.max
 import kotlin.math.min
 
@@ -34,7 +34,7 @@ private const val BUNDLE_TOOL_DRAWING_BITMAP = "BUNDLE_TOOL_DRAWING_BITMAP"
 
 class ImportTool(
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
@@ -33,13 +33,13 @@ import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.common.CommonBrushChangedListener
 import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import org.catrobat.paintroid.ui.viewholder.TopBarViewHolder
 
 class LineTool(
     private val brushToolOptionsView: BrushToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.kt
@@ -27,11 +27,11 @@ import org.catrobat.paintroid.tools.ContextCallback
 import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 class PipetteTool(
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
@@ -32,7 +32,7 @@ import org.catrobat.paintroid.tools.drawable.DrawableShape
 import org.catrobat.paintroid.tools.drawable.DrawableStyle
 import org.catrobat.paintroid.tools.helper.toPoint
 import org.catrobat.paintroid.tools.options.ShapeToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 private const val SHAPE_OFFSET = 10f
 private const val DEFAULT_OUTLINE_WIDTH = 25
@@ -43,7 +43,7 @@ private const val BUNDLE_OUTLINE_WIDTH = "OUTLINE_WIDTH"
 class ShapeTool(
     shapeToolOptionsView: ShapeToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SprayTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SprayTool.kt
@@ -35,7 +35,7 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.SprayToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.math.cos
 import kotlin.math.pow
@@ -50,7 +50,7 @@ private const val CONSTANT_1 = 0.5f
 class SprayTool(
     var stampToolOptionsView: SprayToolOptionsView,
     override var contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/StampTool.kt
@@ -29,7 +29,7 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.StampToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 private const val BUNDLE_TOOL_READY_FOR_PASTE = "BUNDLE_TOOL_READY_FOR_PASTE"
 private const val BUNDLE_TOOL_DRAWING_BITMAP = "BUNDLE_TOOL_DRAWING_BITMAP"
@@ -37,7 +37,7 @@ private const val BUNDLE_TOOL_DRAWING_BITMAP = "BUNDLE_TOOL_DRAWING_BITMAP"
 class StampTool(
     stampToolOptionsView: StampToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
@@ -34,6 +34,7 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.TextToolOptionsView
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
 import kotlin.Exception
 import kotlin.math.max
@@ -63,7 +64,7 @@ private const val TAG = "Can't set custom font"
 class TextTool(
     private val textToolOptionsView: TextToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
@@ -25,7 +25,7 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
-import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 private const val MAX_ALPHA_VALUE = 255
 private const val MAX_NEW_RANGE = 150
@@ -34,7 +34,7 @@ private const val MIN_NEW_RANGE = 20
 class WatercolorTool(
     brushToolOptionsView: BrushToolOptionsView,
     contextCallback: ContextCallback,
-    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
     workspace: Workspace,
     commandManager: CommandManager,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TransformToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TransformToolOptionsView.kt
@@ -34,6 +34,8 @@ interface TransformToolOptionsView {
     interface Callback {
         fun autoCropClicked()
 
+        fun setCenterClicked()
+
         fun rotateCounterClockwiseClicked()
 
         fun rotateClockwiseClicked()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTransformToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTransformToolOptionsView.kt
@@ -74,6 +74,10 @@ class DefaultTransformToolOptionsView(rootView: ViewGroup) : TransformToolOption
             .setOnClickListener {
                 callback?.autoCropClicked()
             }
+        optionsView.findViewById<View>(R.id.pocketpaint_transform_set_center_btn)
+            .setOnClickListener {
+                callback?.setCenterClicked()
+            }
         optionsView.findViewById<View>(R.id.pocketpaint_transform_rotate_left_btn)
             .setOnClickListener {
                 callback?.rotateCounterClockwiseClicked()

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_center_focus_strong.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_center_focus_strong.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M0 0h24v24H0z" />
+    <path
+        android:fillColor="#33B5E5"
+        android:pathData="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm-7 7H3v4c0 1.1 0.9 2 2 2h4v-2H5v-4zM5 5h4V3H5c-1.1 0-2 0.9-2 2v4h2V5zm14-2h-4v2h4v4h2V5c0-1.1-0.9-2-2-2zm0 16h-4v2h4c1.1 0 2-0.9 2-2v-4h-2v4z" />
+</vector>

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_transform_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_transform_tool.xml
@@ -37,19 +37,9 @@
 
         <LinearLayout style="@style/PocketPaintToolSection">
 
-            <Button
-                android:id="@+id/pocketpaint_transform_auto_crop_btn"
-                style="?android:borderlessButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/transform_tool_auto_crop_text"
-                android:drawableTop="@drawable/ic_pocketpaint_tool_resize_adjust"
-                android:text="@string/transform_auto_crop_text"
-                android:textAppearance="@style/TextAppearance.AppCompat.Small"
-                android:textColor="?attr/colorAccent"
-                android:textSize="14sp" />
-
-            <Space style="@style/PocketPaintToolHorizontalSpace" />
+            <Space
+                style="@style/PocketPaintToolHorizontalSpace"
+                android:layout_width="21dp" />
 
             <TextView
                 android:id="@+id/pocketpaint_transform_width_text"
@@ -81,8 +71,9 @@
                 android:textColor="?attr/colorAccent"
                 android:textSize="14sp" />
 
-            <Space style="@style/PocketPaintToolHorizontalSpace"
-                android:layout_width="16dp" />
+            <Space
+                style="@style/PocketPaintToolHorizontalSpace"
+                android:layout_width="35dp" />
 
             <TextView
                 android:id="@+id/pocketpaint_transform_height_text"
@@ -114,14 +105,47 @@
                 android:textColor="?attr/colorAccent"
                 android:textSize="14sp" />
 
-            <Space style="@style/PocketPaintToolHorizontalSpace" />
+            <Space
+                style="@style/PocketPaintToolHorizontalSpace"
+                android:layout_width="21dp" />
+        </LinearLayout>
+
+        <LinearLayout
+            style="@style/PocketPaintToolSection"
+            android:gravity="center_horizontal"
+            android:layout_marginTop="5dp">
+
+            <Button
+                android:id="@+id/pocketpaint_transform_set_center_btn"
+                style="?android:borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/transform_tool_auto_crop_text"
+                android:drawableTop="@drawable/ic_pocketpaint_tool_center_focus_strong"
+                android:text="@string/transform_set_center_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?attr/colorAccent"
+                android:textSize="14sp" />
+
+            <Button
+                android:id="@+id/pocketpaint_transform_auto_crop_btn"
+                style="?android:borderlessButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/transform_tool_auto_crop_text"
+                android:drawableTop="@drawable/ic_pocketpaint_tool_resize_adjust"
+                android:text="@string/transform_auto_crop_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                android:textColor="?attr/colorAccent"
+                android:textSize="14sp" />
+
         </LinearLayout>
 
         <TextView
             style="@style/PocketPaintToolSubtitle"
             android:text="@string/transform_tool_resize_text" />
 
-        <View style="@style/PocketPaintToolSectionDivider"/>
+        <View style="@style/PocketPaintToolSectionDivider" />
 
         <LinearLayout style="@style/PocketPaintToolSection">
             <SeekBar

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -17,11 +17,12 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <string name="pocketpaint_app_name">Pocket Paint</string>
     <string name="button_brush">Brush</string>
     <string name="button_cursor">Cursor</string>
+    <string name="button_set_center">Set Center</string>
     <string name="button_pipette">Pipette</string>
     <string name="button_undo">Undo</string>
     <string name="button_redo">Redo</string>
@@ -143,6 +144,7 @@
     <string name="transform_width_text">Width</string>
     <string name="transform_height_text">Height</string>
     <string name="transform_auto_crop_text">Auto</string>
+    <string name="transform_set_center_text">Set center</string>
     <string name="pixel">px</string>
 
     <string name="stamp_tool_copy_hint">Tap on copy to copy content</string>
@@ -181,7 +183,8 @@
     <string name="permission_info_permanent_denial_text">This app needs the requested permission to function properly. In order to save images to the local memory, the app needs read and write access to it.
         As you have denied permission with do not ask again, please go to your phone settings and grant the required permissions if you wish to use the associated functions.</string>
 
-    <string name="transform_info_text">Drag edges to their new position, then tap on the checkmark to enlarge or crop the image area.</string>
+    <string name="set_center_info_text">Tap the screen to define the new center position.</string>
+    <string name="transform_info_text">Drag edges to their new position, tap on the checkmark to enlarge or crop the image area.</string>
     <string name="cursor_draw_inactive">Pan to position, then tap to start painting.</string>
     <string name="cursor_draw_active">Pan to draw, then tap again to stop painting.</string>
     <string name="welcome_to_pocket_paint">Welcome To Pocket Paint</string>


### PR DESCRIPTION
This PR is for the new set center feature in the transform tool.
https://jira.catrob.at/browse/PAINTROID-146

changes:

- added button for set center with the defined icon in transform tool
- refactored base class in order not to draw rectangle in transform tool
- fixed usage ToolOptionsViewController instead of ToolOptionsVisibilityController in multiple places
- added algorithm based on the idea that "Scratch" uses
- drawing a cursor in set center mode
- add history entry for set center
- added integration tests: one for a close center where and one for a further away center

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
