### PR TITLE
PAINTROID-230 Add tests whether memory check for rescaling works

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.java
@@ -40,6 +40,7 @@ import androidx.test.annotation.UiThreadTest;
 import static org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShapeKt.DEFAULT_BOX_RESIZE_MARGIN;
 import static org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShapeKt.MAXIMUM_BORDER_RATIO;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
@@ -116,5 +117,22 @@ public class ImportToolTest {
 
 		assertEquals(width, tool.boxWidth, Float.MIN_VALUE);
 		assertEquals(height, tool.boxHeight, Float.MIN_VALUE);
+	}
+
+	@Test
+	public void testImportGetsDownscaledWhenNotEnoughMemory() {
+		drawingSurfaceWidth = 1080;
+		drawingSurfaceHeight = 1920;
+		when(workspace.getHeight()).thenReturn(1920);
+		when(workspace.getWidth()).thenReturn(1080);
+
+		final int width = drawingSurfaceWidth * 8;
+		final int height = drawingSurfaceHeight * 8;
+
+		Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+		tool.setBitmapFromSource(bitmap);
+
+		assertTrue(tool.boxHeight < height);
+		assertTrue(tool.boxWidth < width);
 	}
 }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -1497,4 +1497,11 @@ public class MainActivityPresenterTest {
 		assertTrue(presenter.isFinishing());
 		assertFalse(presenter.isFinishing());
 	}
+
+	@Test
+	public void testShowScaleDialogWhenNotEnoughMemory() {
+		BitmapReturnValue bmr = new BitmapReturnValue(workspace.getBitmapLisOfAllLayers(), workspace.getBitmapOfAllLayers(), true);
+		presenter.onLoadImagePostExecute(LOAD_IMAGE_IMPORT_PNG, null, bmr);
+		verify(navigator).showScaleImageRequestDialog(null, LOAD_IMAGE_IMPORT_PNG);
+	}
 }


### PR DESCRIPTION
Added 2 Tests, 1 for checking whether bitmap will be downscaled when not enough memory is present while importing and the other checks if the scale dialog will be displayed when not enough memory is present while importing. 

Original PR is https://github.com/Catrobat/Paintroid/pull/846 where tests were not added.

https://jira.catrob.at/browse/PAINTROID-230

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
