### PR TITLE
PAINTROID-292 Smudge tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/SmudgeToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/SmudgeToolIntegrationTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.test.espresso.tools
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import org.catrobat.paintroid.MainActivity
+import org.catrobat.paintroid.R
+import org.catrobat.paintroid.test.espresso.util.UiMatcher.withProgress
+import org.catrobat.paintroid.test.espresso.util.wrappers.ToolBarViewInteraction
+import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule
+import org.catrobat.paintroid.tools.ToolReference
+import org.catrobat.paintroid.tools.ToolType
+import org.catrobat.paintroid.tools.implementation.DEFAULT_DRAG_IN_PERCENT
+import org.catrobat.paintroid.tools.implementation.DEFAULT_PRESSURE_IN_PERCENT
+import org.catrobat.paintroid.tools.implementation.SmudgeTool
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SmudgeToolIntegrationTest {
+
+    @get:Rule
+    var launchActivityRule = ActivityTestRule(MainActivity::class.java)
+
+    @get:Rule
+    var screenshotOnFailRule = ScreenshotOnFailRule()
+
+    private lateinit var toolReference: ToolReference
+
+    @Before
+    fun setUp() {
+        toolReference = launchActivityRule.activity.toolReference
+        ToolBarViewInteraction.onToolBarView().performSelectTool(ToolType.SMUDGE)
+    }
+
+    @Test
+    fun testSmudgeToolOptionsDialog() {
+        val smudgeTool = toolReference.tool as SmudgeTool
+        ToolBarViewInteraction.onToolBarView()
+            .performClickSelectedToolButton()
+
+        val pressureInput = onView(withId(R.id.pocketpaint_smudge_tool_dialog_pressure_input))
+        val pressureSeekBar = onView(withId(R.id.pocketpaint_pressure_seek_bar))
+        val testPressureText = "100"
+        pressureInput.check(matches(withText(Integer.toString(DEFAULT_PRESSURE_IN_PERCENT))))
+        pressureInput.perform(replaceText(testPressureText), ViewActions.closeSoftKeyboard())
+        pressureInput.check(matches(withText(testPressureText)))
+        pressureSeekBar.check(matches(withProgress(testPressureText.toInt())))
+        val expectedPressure = 1f
+        Assert.assertEquals(expectedPressure, smudgeTool.maxPressure)
+
+        val dragInput = onView(withId(R.id.pocketpaint_smudge_tool_dialog_drag_input))
+        val dragSeekBar = onView(withId(R.id.pocketpaint_drag_seek_bar))
+        val testDragText = "100"
+        dragInput.check(matches(withText(Integer.toString(DEFAULT_DRAG_IN_PERCENT))))
+        dragInput.perform(replaceText(testDragText), ViewActions.closeSoftKeyboard())
+        dragInput.check(matches(withText(testDragText)))
+        dragSeekBar.check(matches(withProgress(testDragText.toInt())))
+        val expectedMaxSize = 25f
+        val expectedMinSize = 25f
+        Assert.assertEquals(expectedMaxSize, smudgeTool.maxSmudgeSize)
+        Assert.assertEquals(expectedMinSize, smudgeTool.minSmudgeSize)
+
+        // Close tool options
+        ToolBarViewInteraction.onToolBarView()
+            .performClickSelectedToolButton()
+    }
+}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/SmudgePathCommandTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/SmudgePathCommandTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.test.junit.command
+
+import android.graphics.Canvas
+import android.graphics.Bitmap
+import android.graphics.PointF
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.RectF
+import org.catrobat.paintroid.command.Command
+import org.catrobat.paintroid.command.implementation.SmudgePathCommand
+import org.catrobat.paintroid.model.Layer
+import org.catrobat.paintroid.model.LayerModel
+import org.catrobat.paintroid.test.utils.PaintroidAsserts
+import org.junit.Before
+import org.junit.Test
+
+class SmudgePathCommandTest {
+    private lateinit var commandUnderTest: Command
+    private lateinit var canvasUnderTest: Canvas
+    private lateinit var bitmapUnderTest: Bitmap
+    private lateinit var canvasBitmapUnderTest: Bitmap
+    private lateinit var commandBitmap: Bitmap
+    private lateinit var commandPath: MutableList<PointF>
+    private var commandPressure = 1f
+    private var commandMaxSize = 25f
+    private var commandMinSize = 25f
+
+    companion object {
+        private const val BITMAP_BASE_COLOR = Color.WHITE
+        private const val COMMAND_BITMAP_BASE_COLOR = Color.GREEN
+        private const val INITIAL_HEIGHT = 80
+        private const val INITIAL_WIDTH = 80
+    }
+
+    @Before
+    fun setUp() {
+        val layerModel = LayerModel()
+        layerModel.width = INITIAL_WIDTH
+        layerModel.height = INITIAL_HEIGHT
+        canvasBitmapUnderTest = Bitmap.createBitmap(INITIAL_WIDTH, INITIAL_HEIGHT, Bitmap.Config.ARGB_8888)
+        canvasBitmapUnderTest.eraseColor(BITMAP_BASE_COLOR)
+        bitmapUnderTest = canvasBitmapUnderTest.copy(Bitmap.Config.ARGB_8888, true)
+        val layerUnderTest = Layer(bitmapUnderTest)
+
+        canvasUnderTest = Canvas()
+        canvasUnderTest.setBitmap(canvasBitmapUnderTest)
+        layerModel.addLayerAt(0, layerUnderTest)
+        layerModel.currentLayer = layerUnderTest
+
+        commandBitmap = Bitmap.createBitmap(commandMaxSize.toInt(), commandMaxSize.toInt(), Bitmap.Config.ARGB_8888)
+        commandBitmap.eraseColor(COMMAND_BITMAP_BASE_COLOR)
+        commandPath = mutableListOf()
+        commandPath.add(PointF(40f, 30f))
+        commandPath.add(PointF(40f, 34f))
+        commandPath.add(PointF(40f, 38f))
+        commandPath.add(PointF(40f, 42f))
+        commandPath.add(PointF(40f, 46f))
+        commandPath.add(PointF(40f, 50f))
+        commandPath.add(PointF(40f, 54f))
+        commandUnderTest = SmudgePathCommand(commandBitmap, commandPath, commandPressure, commandMaxSize, commandMinSize)
+    }
+
+    @Test
+    fun testRun() {
+        var bitmap = commandBitmap.copy(Bitmap.Config.ARGB_8888, true)
+        val colorMatrix = ColorMatrix()
+        val paint = Paint()
+        var pressure = commandPressure
+        commandPath.forEach {
+            colorMatrix.setScale(1f, 1f, 1f, pressure)
+            paint.colorFilter = ColorMatrixColorFilter(colorMatrix)
+
+            val newBitmap = Bitmap.createBitmap(commandMaxSize.toInt(), commandMaxSize.toInt(), Bitmap.Config.ARGB_8888)
+
+            newBitmap.let {
+                Canvas(it).apply {
+                    drawBitmap(bitmap, 0f, 0f, paint)
+                }
+            }
+
+            bitmap.recycle()
+            bitmap = newBitmap
+
+            val rect = RectF(-commandMaxSize / 2f, -commandMaxSize / 2f, commandMaxSize / 2f, commandMaxSize / 2f)
+            with(Canvas(bitmapUnderTest)) {
+                save()
+                translate(it.x, it.y)
+                drawBitmap(bitmap, null, rect, Paint(Paint.DITHER_FLAG))
+                restore()
+            }
+            pressure -= 0.004f
+        }
+
+        commandUnderTest.run(canvasUnderTest, LayerModel())
+        PaintroidAsserts.assertBitmapEquals(bitmapUnderTest, canvasBitmapUnderTest)
+    }
+}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
@@ -52,6 +52,7 @@ import org.catrobat.paintroid.command.implementation.SetDimensionCommand
 import org.catrobat.paintroid.command.implementation.SprayCommand
 import org.catrobat.paintroid.command.implementation.StampCommand
 import org.catrobat.paintroid.command.implementation.TextToolCommand
+import org.catrobat.paintroid.command.implementation.SmudgePathCommand
 import org.catrobat.paintroid.command.serialization.CommandSerializationUtilities
 import org.catrobat.paintroid.command.serialization.SerializablePath
 import org.catrobat.paintroid.command.serialization.SerializableTypeface
@@ -288,6 +289,21 @@ class CommandSerializationTest {
     }
 
     @Test
+    fun testSerializeSmudgePathCommand() {
+        val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        val pointArray = mutableListOf<PointF>()
+        pointArray.add(PointF(0f, 0f))
+        pointArray.add(PointF(1f, 1f))
+        pointArray.add(PointF(2f, 2f))
+        pointArray.add(PointF(3f, 3f))
+        val pressure = 1f
+        val maxSize = 100f
+        val minSize = 1f
+        expectedModel.commands.add(commandFactory.createSmudgePathCommand(bitmap, pointArray, pressure, maxSize, minSize))
+        assertSerializeAndDeserialize()
+    }
+
+    @Test
     fun testSerializeRemoveLayerCommand() {
         expectedModel.commands.add(commandFactory.createRemoveLayerCommand(4))
         assertSerializeAndDeserialize()
@@ -424,6 +440,9 @@ class CommandSerializationTest {
             )
             is PathCommand -> equalsPathCommand(
                 expectedCommand, actualCommand as PathCommand
+            )
+            is SmudgePathCommand -> equalsSmudgePathCommand(
+                expectedCommand, actualCommand as SmudgePathCommand
             )
             else -> false
         }
@@ -571,6 +590,13 @@ class CommandSerializationTest {
             actualCommand.path as SerializablePath
         ) &&
             DefaultToolPaint.arePaintEquals(expectedCommand.paint, actualCommand.paint)
+
+    private fun equalsSmudgePathCommand(expectedCommand: SmudgePathCommand, actualCommand: SmudgePathCommand) =
+        expectedCommand.maxPressure == actualCommand.maxPressure &&
+            expectedCommand.maxSize == actualCommand.maxSize &&
+            expectedCommand.minSize == actualCommand.minSize &&
+            expectedCommand.originalBitmap.sameAs(actualCommand.originalBitmap) &&
+            expectedCommand.pointPath == actualCommand.pointPath
 
     private fun equalsSerializablePath(
         expectedPath: SerializablePath,

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/SmudgeToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/SmudgeToolTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.test.junit.tools
+
+import android.graphics.Paint
+import android.graphics.Bitmap
+import android.graphics.PointF
+import android.graphics.Color
+import org.catrobat.paintroid.command.CommandManager
+import org.catrobat.paintroid.command.implementation.SmudgePathCommand
+import org.catrobat.paintroid.tools.ContextCallback
+import org.catrobat.paintroid.tools.Tool
+import org.catrobat.paintroid.tools.ToolPaint
+import org.catrobat.paintroid.tools.ToolType
+import org.catrobat.paintroid.tools.Workspace
+import org.catrobat.paintroid.tools.implementation.SmudgeTool
+import org.catrobat.paintroid.tools.options.SmudgeToolOptionsView
+import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito
+
+class SmudgeToolTest {
+    private val toolPaint = Mockito.mock(ToolPaint::class.java)
+    private val commandManager = Mockito.mock(CommandManager::class.java)
+    private val workspace = Mockito.mock(Workspace::class.java)
+    private val smudgeToolOptionsView = Mockito.mock(SmudgeToolOptionsView::class.java)
+    private val toolOptionsViewController =
+        Mockito.mock(ToolOptionsVisibilityController::class.java)
+    private val contextCallback = Mockito.mock(ContextCallback::class.java)
+    private lateinit var tool: SmudgeTool
+
+    @Before
+    fun setUp() {
+        Mockito.`when`(toolPaint.strokeWidth).thenReturn(100f)
+        Mockito.`when`(toolPaint.strokeCap).thenReturn(Paint.Cap.ROUND)
+
+        val bitmap = Bitmap.createBitmap(200, 200, Bitmap.Config.ARGB_8888)
+        bitmap.setPixel(100, 100, Color.GREEN)
+        Mockito.`when`(workspace.bitmapOfCurrentLayer).thenReturn(bitmap)
+
+        tool = SmudgeTool(
+            smudgeToolOptionsView,
+            contextCallback,
+            toolOptionsViewController,
+            toolPaint,
+            workspace,
+            commandManager
+        )
+    }
+
+    @After
+    fun tearDown() {
+        tool.resetInternalState(Tool.StateChange.ALL)
+    }
+
+    @Test
+    fun testShouldReturnCorrectToolType() {
+        Assert.assertEquals(ToolType.SMUDGE, tool.toolType)
+    }
+
+    @Test
+    fun testNotExecutingSmudgeWhenBitmapHasNoColor() {
+        Mockito.`when`(workspace.bitmapOfCurrentLayer).thenReturn(Bitmap.createBitmap(200, 200, Bitmap.Config.ARGB_8888))
+        val event = PointF(100f, 100f)
+        Assert.assertFalse(tool.handleDown(event))
+        Assert.assertFalse(tool.handleMove(event))
+        Assert.assertFalse(tool.handleUp(event))
+    }
+
+    @Test
+    fun testExecutingSmudgeWhenBitmapHasColor() {
+        val event = PointF(100f, 100f)
+        Assert.assertTrue(tool.handleDown(event))
+        Assert.assertTrue(tool.handleMove(event))
+        Assert.assertTrue(tool.handleUp(event))
+    }
+
+    @Test
+    fun testSmudgePathCommandCreated() {
+        val event = PointF(100f, 100f)
+        tool.handleDown(event)
+        val event2 = PointF(110f, 110f)
+        tool.handleMove(event2)
+        tool.handleUp(event2)
+        val argument = ArgumentCaptor.forClass(SmudgePathCommand::class.java)
+        Mockito.verify(commandManager).addCommand(argument.capture())
+    }
+
+    @Test
+    fun testPointsArrayIsClearedAfterCommandRun() {
+        val event = PointF(100f, 100f)
+        tool.handleDown(event)
+        val event2 = PointF(110f, 110f)
+        tool.handleMove(event2)
+        tool.handleUp(event2)
+        Assert.assertTrue(tool.pointArray.isEmpty())
+    }
+
+    @Test
+    fun testPressureUpdatedCorrectly() {
+        tool.updatePressure(40)
+        val pressure = tool.maxPressure
+        tool.updatePressure(20)
+        Assert.assertNotEquals(pressure, tool.maxPressure)
+    }
+
+    @Test
+    fun testDragUpdatedCorrectly() {
+        tool.updateDrag(80)
+        val minSize = tool.minSmudgeSize
+        tool.updateDrag(40)
+        Assert.assertNotEquals(minSize, tool.minSmudgeSize)
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
@@ -74,6 +74,8 @@ interface CommandFactory {
 
     fun createPathCommand(paint: Paint, path: SerializablePath): Command
 
+    fun createSmudgePathCommand(bitmap: Bitmap, pointPath: MutableList<PointF>, maxPressure: Float, maxSize: Float, minSize: Float): Command
+
     fun createTextToolCommand(
         multilineText: Array<String>,
         textPaint: Paint,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
@@ -126,6 +126,16 @@ class DefaultCommandFactory : CommandFactory {
         commonFactory.createSerializablePath(path)
     )
 
+    override fun createSmudgePathCommand(bitmap: Bitmap, pointPath: MutableList<PointF>, maxPressure: Float, maxSize: Float, minSize: Float): Command {
+        val copy = mutableListOf<PointF>()
+
+        pointPath.forEach {
+            copy.add(commonFactory.createPointF(it))
+        }
+
+        return SmudgePathCommand(bitmap.copy(Bitmap.Config.ARGB_8888, false), copy, maxPressure, maxSize, minSize)
+    }
+
     override fun createTextToolCommand(
         multilineText: Array<String>,
         textPaint: Paint,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/SmudgePathCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/SmudgePathCommand.kt
@@ -1,0 +1,79 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.paintroid.command.implementation
+
+import android.graphics.Bitmap
+import android.graphics.PointF
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.Paint
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.RectF
+import org.catrobat.paintroid.command.Command
+import org.catrobat.paintroid.contract.LayerContracts
+import org.catrobat.paintroid.tools.implementation.PRESSURE_UPDATE_STEP
+
+class SmudgePathCommand(bitmap: Bitmap, pointPath: MutableList<PointF>, maxPressure: Float, maxSize: Float, minSize: Float) : Command {
+
+    var originalBitmap = bitmap; private set
+    var pointPath = pointPath; private set
+    var maxPressure = maxPressure; private set
+    var maxSize = maxSize; private set
+    var minSize = minSize; private set
+
+    override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
+        val step = (maxSize - minSize) / pointPath.size
+        var size = maxSize
+        var pressure = maxPressure
+        val colorMatrix = ColorMatrix()
+        val paint = Paint()
+        var bitmap = originalBitmap.copy(Bitmap.Config.ARGB_8888, false)
+
+        pointPath.forEach {
+            colorMatrix.setScale(1f, 1f, 1f, pressure)
+            paint.colorFilter = ColorMatrixColorFilter(colorMatrix)
+
+            val newBitmap = Bitmap.createBitmap(maxSize.toInt(), maxSize.toInt(), Bitmap.Config.ARGB_8888)
+
+            newBitmap.let {
+                Canvas(it).apply {
+                    drawBitmap(bitmap, 0f, 0f, paint)
+                }
+            }
+
+            bitmap.recycle()
+            bitmap = newBitmap
+
+            val rect = RectF(-size / 2f, -size / 2f, size / 2f, size / 2f)
+            with(canvas) {
+                save()
+                translate(it.x, it.y)
+                drawBitmap(bitmap, null, rect, Paint(Paint.DITHER_FLAG))
+                restore()
+            }
+            size -= step
+            pressure -= PRESSURE_UPDATE_STEP
+        }
+    }
+
+    override fun freeResources() {
+        originalBitmap.recycle()
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/BitmapSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/BitmapSerializer.kt
@@ -1,0 +1,39 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.command.serialization
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+
+const val BITMAP_SERIALIZATION_COMPRESSION_QUALITY = 100
+
+class BitmapSerializer(version: Int) : VersionSerializer<Bitmap>(version) {
+    override fun write(kryo: Kryo, output: Output, bitmap: Bitmap) {
+        bitmap.compress(Bitmap.CompressFormat.PNG, BITMAP_SERIALIZATION_COMPRESSION_QUALITY, output)
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<out Bitmap>): Bitmap =
+        super.handleVersions(this, kryo, input, type)
+
+    override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out Bitmap>): Bitmap =
+        BitmapFactory.decodeStream(input)
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializationUtilities.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializationUtilities.kt
@@ -24,6 +24,7 @@ import android.graphics.Paint
 import android.graphics.Point
 import android.graphics.PointF
 import android.graphics.RectF
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -55,6 +56,7 @@ import org.catrobat.paintroid.command.implementation.SetDimensionCommand
 import org.catrobat.paintroid.command.implementation.SprayCommand
 import org.catrobat.paintroid.command.implementation.StampCommand
 import org.catrobat.paintroid.command.implementation.TextToolCommand
+import org.catrobat.paintroid.command.implementation.SmudgePathCommand
 import org.catrobat.paintroid.common.Constants
 import org.catrobat.paintroid.model.CommandManagerModel
 import org.catrobat.paintroid.tools.drawable.HeartDrawable
@@ -129,6 +131,8 @@ class CommandSerializationUtilities(private val activityContext: Context, privat
             put(SerializableTypeface::class.java, SerializableTypeface.TypefaceSerializer(version))
             put(PointCommand::class.java, PointCommandSerializer(version))
             put(SerializablePath.Cube::class.java, SerializablePath.PathActionCubeSerializer(version))
+            put(Bitmap::class.java, BitmapSerializer(version))
+            put(SmudgePathCommand::class.java, SmudgePathCommandSerializer(version))
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/SmudgePathCommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/SmudgePathCommandSerializer.kt
@@ -1,0 +1,59 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.command.serialization
+
+import android.graphics.Bitmap
+import android.graphics.PointF
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import org.catrobat.paintroid.command.implementation.SmudgePathCommand
+
+class SmudgePathCommandSerializer(version: Int) : VersionSerializer<SmudgePathCommand>(version) {
+    override fun write(kryo: Kryo, output: Output, command: SmudgePathCommand) {
+        with(kryo) {
+            writeObject(output, command.originalBitmap)
+            writeObject(output, command.pointPath.size)
+            command.pointPath.forEach {
+                writeObject(output, it)
+            }
+            writeObject(output, command.maxPressure)
+            writeObject(output, command.maxSize)
+            writeObject(output, command.minSize)
+        }
+    }
+
+    override fun read(kryo: Kryo, input: Input, type: Class<out SmudgePathCommand>): SmudgePathCommand =
+        super.handleVersions(this, kryo, input, type)
+
+    override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out SmudgePathCommand>): SmudgePathCommand {
+        return with(kryo) {
+            val originalBitmap = readObject(input, Bitmap::class.java)
+            val pointPath = mutableListOf<PointF>()
+            val size = readObject(input, Int::class.java)
+            repeat(size) {
+                pointPath.add(readObject(input, PointF::class.java))
+            }
+            val maxPressure = readObject(input, Float::class.java)
+            val maxSize = readObject(input, Float::class.java)
+            val minSize = readObject(input, Float::class.java)
+            SmudgePathCommand(originalBitmap, pointPath, maxPressure, maxSize, minSize)
+        }
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.kt
@@ -196,6 +196,15 @@ enum class ToolType(
         R.id.pocketpaint_tools_watercolor,
         INVALID_RESOURCE_ID,
         true
+    ),
+    SMUDGE(
+        R.string.button_smudge,
+        R.string.help_content_smudge,
+        R.drawable.ic_pocketpaint_tool_smudge,
+        EnumSet.of(StateChange.ALL),
+        R.id.pocketpaint_tools_smudge,
+        INVALID_RESOURCE_ID,
+        true
     );
 
     fun shouldReactToStateChange(stateChange: StateChange): Boolean =

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.kt
@@ -34,6 +34,7 @@ import org.catrobat.paintroid.ui.tools.DefaultSprayToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultStampToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultTextToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultTransformToolOptionsView
+import org.catrobat.paintroid.ui.tools.DefaultSmudgeToolOptionsView
 
 private const val DRAW_TIME_INIT: Long = 30_000_000
 
@@ -163,6 +164,14 @@ class DefaultToolFactory : ToolFactory {
                 workspace,
                 commandManager,
                 DRAW_TIME_INIT
+            )
+            ToolType.SMUDGE -> SmudgeTool(
+                DefaultSmudgeToolOptionsView(toolLayout),
+                contextCallback,
+                toolOptionsViewController,
+                toolPaint,
+                workspace,
+                commandManager
             )
             else -> BrushTool(
                 DefaultBrushToolOptionsView(toolLayout),

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
@@ -1,0 +1,253 @@
+package org.catrobat.paintroid.tools.implementation
+
+import androidx.annotation.VisibleForTesting
+import android.graphics.PointF
+import android.graphics.Canvas
+import android.graphics.Bitmap
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.RectF
+import org.catrobat.paintroid.command.CommandManager
+import org.catrobat.paintroid.tools.ContextCallback
+import org.catrobat.paintroid.tools.ToolPaint
+import org.catrobat.paintroid.tools.ToolType
+import org.catrobat.paintroid.tools.Workspace
+import org.catrobat.paintroid.tools.common.CommonBrushChangedListener
+import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener
+import org.catrobat.paintroid.tools.options.SmudgeToolOptionsView
+import org.catrobat.paintroid.tools.options.ToolOptionsVisibilityController
+
+const val PERCENT_100 = 100f
+const val BITMAP_ROTATION_FACTOR = -0.0f
+const val DEFAULT_PRESSURE_IN_PERCENT = 50
+const val MAX_PRESSURE = 1f
+const val MIN_PRESSURE = 0.85f
+const val DEFAULT_DRAG_IN_PERCENT = 50
+const val DISTANCE_SMOOTHING = 3f
+const val DRAW_THRESHOLD = 0.8f
+const val PRESSURE_UPDATE_STEP = 0.004f
+
+class SmudgeTool(
+    private val smudgeToolOptionsView: SmudgeToolOptionsView,
+    contextCallback: ContextCallback,
+    toolOptionsViewController: ToolOptionsVisibilityController,
+    toolPaint: ToolPaint,
+    workspace: Workspace,
+    commandManager: CommandManager
+) : BaseTool(contextCallback, toolOptionsViewController, toolPaint, workspace, commandManager) {
+
+    override var drawTime: Long = 0
+    private var currentBitmap: Bitmap? = null
+    private var prevPoint: PointF? = null
+    private var numOfPointsOnPath = -1
+
+    @VisibleForTesting
+    var maxPressure = 0f
+    @VisibleForTesting
+    var pressure = maxPressure
+    @VisibleForTesting
+    var maxSmudgeSize = toolPaint.strokeWidth
+    @VisibleForTesting
+    var minSmudgeSize = 0f
+    @VisibleForTesting
+    val pointArray = mutableListOf<PointF>()
+
+    override val toolType: ToolType
+        get() = ToolType.SMUDGE
+
+    init {
+        smudgeToolOptionsView.setBrushChangedListener(CommonBrushChangedListener(this))
+        smudgeToolOptionsView.setBrushPreviewListener(
+            CommonBrushPreviewListener(
+                toolPaint,
+                toolType
+            )
+        )
+        smudgeToolOptionsView.setCurrentPaint(toolPaint.paint)
+
+        smudgeToolOptionsView.setCallback(object : SmudgeToolOptionsView.Callback {
+            override fun onPressureChanged(pressure: Int) {
+                updatePressure(pressure)
+            }
+
+            override fun onDragChanged(drag: Int) {
+                updateDrag(drag)
+            }
+        })
+
+        updatePressure(DEFAULT_PRESSURE_IN_PERCENT)
+        updateDrag(DEFAULT_DRAG_IN_PERCENT)
+    }
+
+    fun updatePressure(pressureInPercent: Int) {
+        val onePercent = (MAX_PRESSURE - MIN_PRESSURE) / PERCENT_100
+        maxPressure = MIN_PRESSURE + onePercent * pressureInPercent
+        pressure = maxPressure
+    }
+
+    fun updateDrag(dragInPercent: Int) {
+        val onePercent = maxSmudgeSize / PERCENT_100
+        minSmudgeSize = onePercent * dragInPercent
+    }
+
+    override fun handleDown(coordinate: PointF?): Boolean {
+        coordinate ?: return false
+        if (maxSmudgeSize != toolPaint.strokeWidth) {
+            val ratio = minSmudgeSize / maxSmudgeSize
+            maxSmudgeSize = toolPaint.strokeWidth
+            minSmudgeSize = maxSmudgeSize * ratio
+        }
+
+        val layerBitmap = workspace.bitmapOfCurrentLayer
+        currentBitmap = Bitmap.createBitmap(maxSmudgeSize.toInt(), maxSmudgeSize.toInt(), Bitmap.Config.ARGB_8888)
+        currentBitmap?.let {
+            Canvas(it).apply {
+                translate(-coordinate.x + maxSmudgeSize / 2f, -coordinate.y + maxSmudgeSize / 2f)
+                rotate(BITMAP_ROTATION_FACTOR, coordinate.x, coordinate.y)
+                drawBitmap(layerBitmap!!, 0f, 0f, null)
+            }
+        }
+
+        if (toolPaint.strokeCap == Paint.Cap.ROUND) {
+            currentBitmap = getBitmapClippedCircle(currentBitmap!!)
+        }
+
+        if (!currentBitmapHasColor()) {
+            currentBitmap?.recycle()
+            currentBitmap = null
+            return false
+        }
+
+        prevPoint = PointF(coordinate.x, coordinate.y)
+        pointArray.add(PointF(prevPoint!!.x, prevPoint!!.y))
+
+        return true
+    }
+
+    override fun handleMove(coordinate: PointF?): Boolean {
+        coordinate ?: return false
+        if (currentBitmap != null) {
+            if (pressure < DRAW_THRESHOLD) { // Needed to stop drawing preview when bitmap becomes too transparent. Has no effect on final drawing.
+                return false
+            }
+
+            val x = coordinate.x - prevPoint!!.x
+            val y = coordinate.y - prevPoint!!.y
+
+            val distance = kotlin.math.floor(kotlin.math.sqrt(x * x + y * y) / DISTANCE_SMOOTHING)
+            val xInterval = x / distance
+            val yInterval = y / distance
+
+            var i = 0
+            while (i < distance) {
+                prevPoint!!.x += xInterval
+                prevPoint!!.y += yInterval
+
+                pressure -= PRESSURE_UPDATE_STEP
+
+                pointArray.add(PointF(prevPoint!!.x, prevPoint!!.y))
+
+                i++
+            }
+            return true
+        } else {
+            return false
+        }
+    }
+
+    private fun getBitmapClippedCircle(bitmap: Bitmap): Bitmap {
+        val width = bitmap.width
+        val height = bitmap.height
+        val outputBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val path = Path()
+        path.addCircle((width / 2).toFloat(), (height / 2).toFloat(), kotlin.math.min(width, height / 2).toFloat(), Path.Direction.CCW)
+        val canvas = Canvas(outputBitmap)
+        canvas.clipPath(path)
+        canvas.drawBitmap(bitmap, 0f, 0f, null)
+        return outputBitmap
+    }
+
+    private fun currentBitmapHasColor(): Boolean {
+        for (x in 0 until currentBitmap!!.width) {
+            for (y in 0 until currentBitmap!!.height) {
+                if (currentBitmap!!.getPixel(x, y) != 0) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    override fun handleUp(coordinate: PointF?): Boolean {
+        coordinate ?: return false
+        if (!pointArray.isEmpty() && currentBitmap != null) {
+            val command = commandFactory.createSmudgePathCommand(currentBitmap!!, pointArray, maxPressure, maxSmudgeSize, minSmudgeSize)
+            commandManager.addCommand(command)
+
+            numOfPointsOnPath = if (numOfPointsOnPath < 0) {
+                pointArray.size
+            } else {
+                (numOfPointsOnPath + pointArray.size) / 2
+            }
+
+            pressure = maxPressure
+            pointArray.clear()
+            currentBitmap?.recycle()
+            currentBitmap = null
+            return true
+        } else {
+            return false
+        }
+    }
+
+    override fun draw(canvas: Canvas) {
+        if (pointArray.isNotEmpty()) {
+            val pointPath = pointArray.toMutableList()
+
+            val step = if (numOfPointsOnPath < 0) {
+                (maxSmudgeSize - minSmudgeSize) / pointPath.size
+            } else {
+                (maxSmudgeSize - minSmudgeSize) / numOfPointsOnPath
+            }
+
+            var size = maxSmudgeSize
+            var pressure = maxPressure
+            val colorMatrix = ColorMatrix()
+            val paint = Paint()
+            var bitmap = currentBitmap!!.copy(Bitmap.Config.ARGB_8888, false)
+
+            pointPath.forEach {
+                colorMatrix.setScale(1f, 1f, 1f, pressure)
+                paint.colorFilter = ColorMatrixColorFilter(colorMatrix)
+
+                val newBitmap = Bitmap.createBitmap(maxSmudgeSize.toInt(), maxSmudgeSize.toInt(), Bitmap.Config.ARGB_8888)
+
+                Canvas(newBitmap).apply {
+                    drawBitmap(bitmap, 0f, 0f, paint)
+                }
+
+                bitmap.recycle()
+                bitmap = newBitmap
+
+                val rect = RectF(-size / 2f, -size / 2f, size / 2f, size / 2f)
+                with(canvas) {
+                    save()
+                    clipRect(0, 0, workspace.width, workspace.height)
+                    translate(it.x, it.y)
+                    drawBitmap(bitmap, null, rect, Paint(Paint.DITHER_FLAG))
+                    restore()
+                }
+                size -= step
+                pressure -= PRESSURE_UPDATE_STEP
+            }
+
+            bitmap.recycle()
+        }
+    }
+
+    override fun changePaintColor(color: Int) {
+        // Doesn't need to change the color.
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/SmudgeToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/SmudgeToolOptionsView.kt
@@ -1,0 +1,29 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.tools.options
+
+interface SmudgeToolOptionsView : BrushToolOptionsView {
+    fun setCallback(callback: Callback)
+
+    interface Callback {
+        fun onPressureChanged(pressure: Int)
+
+        fun onDragChanged(drag: Int)
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultSmudgeToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultSmudgeToolOptionsView.kt
@@ -1,0 +1,281 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.ui.tools
+
+import android.graphics.Paint
+import android.graphics.Paint.Cap
+import android.text.Editable
+import android.text.InputFilter
+import android.text.TextWatcher
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.SeekBar
+import android.widget.SeekBar.OnSeekBarChangeListener
+import com.google.android.material.chip.Chip
+import org.catrobat.paintroid.R
+import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter
+import org.catrobat.paintroid.tools.implementation.DEFAULT_PRESSURE_IN_PERCENT
+import org.catrobat.paintroid.tools.implementation.DEFAULT_DRAG_IN_PERCENT
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView.OnBrushChangedListener
+import org.catrobat.paintroid.tools.options.BrushToolOptionsView.OnBrushPreviewListener
+import org.catrobat.paintroid.tools.options.BrushToolPreview
+import org.catrobat.paintroid.tools.options.SmudgeToolOptionsView
+import java.lang.NumberFormatException
+import java.util.Locale
+
+private const val MIN_BRUSH_SIZE = 1
+private const val MIN_VAL = 1
+private const val MAX_VAL = 100
+
+class DefaultSmudgeToolOptionsView(rootView: ViewGroup) : SmudgeToolOptionsView {
+    private val brushSizeText: EditText
+    private val brushWidthSeekBar: SeekBar
+    private val buttonCircle: Chip
+    private val buttonRect: Chip
+    private val brushToolPreview: BrushToolPreview
+    private var brushChangedListener: OnBrushChangedListener? = null
+
+    private var callback: SmudgeToolOptionsView.Callback? = null
+
+    private val pressureText: EditText
+    private val pressureSeekBar: SeekBar
+    private val dragText: EditText
+    private val dragSeekBar: SeekBar
+
+    companion object {
+        private val TAG = DefaultSmudgeToolOptionsView::class.java.simpleName
+    }
+
+    init {
+        val inflater = LayoutInflater.from(rootView.context)
+        val brushPickerView = inflater.inflate(R.layout.dialog_pocketpaint_smudge_tool, rootView, true)
+        brushPickerView.apply {
+            buttonCircle = findViewById(R.id.pocketpaint_stroke_ibtn_circle)
+            buttonRect = findViewById(R.id.pocketpaint_stroke_ibtn_rect)
+            brushWidthSeekBar = findViewById(R.id.pocketpaint_stroke_width_seek_bar)
+            brushWidthSeekBar.setOnSeekBarChangeListener(OnBrushChangedWidthSeekBarListener())
+            brushSizeText = findViewById(R.id.pocketpaint_stroke_width_width_text)
+            brushToolPreview = findViewById(R.id.pocketpaint_brush_tool_preview)
+            pressureText = findViewById(R.id.pocketpaint_smudge_tool_dialog_pressure_input)
+            pressureSeekBar = findViewById(R.id.pocketpaint_pressure_seek_bar)
+            pressureSeekBar.setOnSeekBarChangeListener(OnPressureChangedSeekBarListener())
+            dragText = findViewById(R.id.pocketpaint_smudge_tool_dialog_drag_input)
+            dragSeekBar = findViewById(R.id.pocketpaint_drag_seek_bar)
+            dragSeekBar.setOnSeekBarChangeListener(OnDragChangedSeekBarListener())
+        }
+        brushSizeText.filters = arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
+        pressureText.filters = arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
+        dragText.filters = arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
+        buttonCircle.setOnClickListener { onCircleButtonClicked() }
+        buttonRect.setOnClickListener { onRectButtonClicked() }
+
+        brushSizeText.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) = Unit
+
+            override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) = Unit
+
+            override fun afterTextChanged(editable: Editable) {
+                val sizeText = brushSizeText.text.toString()
+                val sizeTextInt: Int = try {
+                    sizeText.toInt()
+                } catch (exp: NumberFormatException) {
+                    exp.localizedMessage?.let {
+                        Log.d(TAG, it)
+                    }
+                    MIN_BRUSH_SIZE
+                }
+                brushWidthSeekBar.progress = sizeTextInt
+            }
+        })
+        pressureText.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) = Unit
+
+            override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) = Unit
+
+            override fun afterTextChanged(editable: Editable) {
+                val sizeText = pressureText.text.toString()
+                val sizeTextInt: Int = try {
+                    sizeText.toInt()
+                } catch (exp: NumberFormatException) {
+                    exp.localizedMessage?.let {
+                        Log.d(TAG, it)
+                    }
+                    MIN_VAL
+                }
+                pressureSeekBar.progress = sizeTextInt
+            }
+        })
+        dragText.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) = Unit
+
+            override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) = Unit
+
+            override fun afterTextChanged(editable: Editable) {
+                val sizeText = dragText.text.toString()
+                val sizeTextInt: Int = try {
+                    sizeText.toInt()
+                } catch (exp: NumberFormatException) {
+                    exp.localizedMessage?.let {
+                        Log.d(TAG, it)
+                    }
+                    MIN_VAL
+                }
+                dragSeekBar.progress = sizeTextInt
+            }
+        })
+
+        setPressureText(DEFAULT_PRESSURE_IN_PERCENT)
+        setDragText(DEFAULT_DRAG_IN_PERCENT)
+    }
+
+    private fun onRectButtonClicked() {
+        updateStrokeCap(Cap.SQUARE)
+        buttonRect.isSelected = true
+        buttonCircle.isSelected = false
+        invalidate()
+    }
+
+    private fun onCircleButtonClicked() {
+        updateStrokeCap(Cap.ROUND)
+        buttonCircle.isSelected = true
+        buttonRect.isSelected = false
+        invalidate()
+    }
+
+    override fun setCurrentPaint(paint: Paint) {
+        if (paint.strokeCap == Cap.ROUND) {
+            buttonCircle.isSelected = true
+            buttonRect.isSelected = false
+        } else {
+            buttonCircle.isSelected = false
+            buttonRect.isSelected = true
+        }
+        brushWidthSeekBar.progress = paint.strokeWidth.toInt()
+        brushSizeText.setText(
+            String.format(
+                Locale.getDefault(), "%d",
+                paint.strokeWidth.toInt()
+            )
+        )
+    }
+
+    override fun setBrushChangedListener(onBrushChangedListener: OnBrushChangedListener) {
+        this.brushChangedListener = onBrushChangedListener
+    }
+
+    override fun setBrushPreviewListener(onBrushPreviewListener: OnBrushPreviewListener) {
+        brushToolPreview.setListener(onBrushPreviewListener)
+        brushToolPreview.invalidate()
+    }
+
+    private fun updateStrokeWidthChange(strokeWidth: Int) {
+        brushChangedListener?.setStrokeWidth(strokeWidth)
+    }
+
+    private fun updateStrokeCap(cap: Cap) {
+        brushChangedListener?.setCap(cap)
+    }
+
+    override fun invalidate() {
+        brushToolPreview.invalidate()
+    }
+
+    override fun setCallback(callback: SmudgeToolOptionsView.Callback) {
+        this.callback = callback
+    }
+
+    private fun updatePressure(pressure: Int) {
+        callback?.onPressureChanged(pressure)
+    }
+
+    private fun updateDrag(drag: Int) {
+        callback?.onDragChanged(drag)
+    }
+
+    private fun setPressureText(pressureInPercent: Int) {
+        pressureText.setText(String.format(Locale.getDefault(), "%d", pressureInPercent))
+    }
+
+    private fun setDragText(dragInPercent: Int) {
+        dragText.setText(String.format(Locale.getDefault(), "%d", dragInPercent))
+    }
+
+    inner class OnBrushChangedWidthSeekBarListener : OnSeekBarChangeListener {
+        override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+            var currentProgress = progress
+            if (currentProgress < MIN_BRUSH_SIZE) {
+                currentProgress = MIN_BRUSH_SIZE
+                seekBar.progress = currentProgress
+            }
+            updateStrokeWidthChange(currentProgress)
+            if (fromUser) {
+                brushSizeText.setText(String.format(Locale.getDefault(), "%d", currentProgress))
+            }
+            brushToolPreview.invalidate()
+        }
+
+        override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+
+        override fun onStopTrackingTouch(seekBar: SeekBar) {
+            brushSizeText.setText(String.format(Locale.getDefault(), "%d", seekBar.progress))
+        }
+    }
+
+    inner class OnPressureChangedSeekBarListener : OnSeekBarChangeListener {
+        override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+            var currentProgress = progress
+            if (currentProgress < MIN_VAL) {
+                currentProgress = MIN_VAL
+                seekBar.progress = currentProgress
+            }
+            if (fromUser) {
+                setPressureText(currentProgress)
+            }
+            updatePressure(currentProgress)
+        }
+
+        override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+
+        override fun onStopTrackingTouch(seekBar: SeekBar) {
+            setPressureText(seekBar.progress)
+        }
+    }
+
+    inner class OnDragChangedSeekBarListener : OnSeekBarChangeListener {
+        override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+            var currentProgress = progress
+            if (currentProgress < MIN_VAL) {
+                currentProgress = MIN_VAL
+                seekBar.progress = currentProgress
+            }
+            if (fromUser) {
+                setDragText(currentProgress)
+            }
+            updateDrag(currentProgress)
+        }
+
+        override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+
+        override fun onStopTrackingTouch(seekBar: SeekBar) {
+            setDragText(seekBar.progress)
+        }
+    }
+}

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_smudge.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_smudge.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6.5,9.9l1.9,3.7c0.1,0.1,0.2,0.3,0.3,0.4l0.5,0.4l-2.7,3.4c-0.8,1-0.8,2.6,0.2,3.5c1.1,1,2.8,0.9,3.7-0.3l5.1-6.4
+				l1.2,1.5c0.1,0.1,0.7,0.8,1.7,0.6l2-0.2l-0.8-7.2c-0.1-0.5-0.3-1-0.7-1.3l-5.1-4.1c-0.8-0.6-1.9-0.6-2.6,0.1L6.9,7.6
+				C6.3,8.2,6.1,9.1,6.5,9.9z M8.3,9.1l4.1-3.7l5.1,4.1l0.6,5.3l-2.7-3.3l-6.6,8.3C8.6,19.9,8.3,20,8,19.8c-0.2-0.2-0.3-0.5-0.1-0.7
+				l3.8-4.8l-1.4-1.1L8.3,9.1z"/>
+</vector>

--- a/Paintroid/src/main/res/layout-land/pocketpaint_layout_bottom_bar.xml
+++ b/Paintroid/src/main/res/layout-land/pocketpaint_layout_bottom_bar.xml
@@ -216,5 +216,18 @@
                 style="@style/PocketPaintToolSelectionButtonTextView"
                 android:text="@string/button_watercolor"/>
         </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/pocketpaint_tools_smudge"
+            tools:ignore="UseCompoundDrawables"
+            style="@style/PocketPaintToolSelectionButton">
+            <ImageView
+                style="@style/PocketPaintToolSelectionButtonImageView"
+                android:src="@drawable/ic_pocketpaint_tool_smudge"
+                android:contentDescription="@string/button_smudge"/>
+            <TextView
+                style="@style/PocketPaintToolSelectionButtonTextView"
+                android:text="@string/button_smudge"/>
+        </LinearLayout>
     </TableRow>
 </TableLayout>

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_smudge_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_smudge_tool.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2015 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+<RelativeLayout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/pocketpaint_stroke_width_width_text_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:layout_margin="10dp"
+        style="@style/TextFieldTheme">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/pocketpaint_stroke_width_width_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionDone"
+            android:importantForAutofill="no"
+            android:inputType="number"
+            android:padding="4dp"
+            android:minEms="3"
+            android:saveEnabled="false"
+            android:background="@drawable/pocketpaint_round_rect_shape"
+            android:textColor="?attr/colorAccent"
+            android:textStyle="bold"
+            android:layoutDirection="ltr"
+            tools:ignore="LabelFor"
+            android:gravity="center"
+            tools:text="100" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <SeekBar
+        android:id="@+id/pocketpaint_stroke_width_seek_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:max="100"
+        android:minHeight="30dip"
+        android:layout_marginEnd="10dp"
+        android:layout_alignTop="@id/pocketpaint_stroke_width_width_text_layout"
+        android:layout_toEndOf="@+id/pocketpaint_stroke_width_width_text_layout"
+        android:layout_alignBottom="@id/pocketpaint_stroke_width_width_text_layout"
+        android:layout_alignParentEnd="true"/>
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="50dp">
+        <!--> This Linear layout is needed for the preview.
+        The Brush tool searches for the Top of the parent<-->
+        <org.catrobat.paintroid.ui.tools.BrushToolView
+            android:id="@+id/pocketpaint_brush_tool_preview"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.5"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_alignParentBottom="true">
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/pocketpaint_stroke_types"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:layoutDirection="ltr"
+            app:singleSelection="true"
+            app:singleLine="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/pocketpaint_stroke_ibtn_circle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/ChipTheme"
+                android:checkable="true"
+                app:chipIcon="@drawable/ic_pocketpaint_tool_circle"
+                android:checked="true"/>
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/pocketpaint_stroke_ibtn_rect"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/ChipTheme"
+                app:chipIcon="@drawable/ic_pocketpaint_tool_square" />
+
+        </com.google.android.material.chip.ChipGroup>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/white"
+                android:focusableInTouchMode="true"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/pocketpaint_smudge_tool_dialog_pressure_input_text_view"
+                    style="@style/PocketPaintToolSubtitle"
+                    android:labelFor="@+id/pocketpaint_smudge_tool_dialog_pressure_input"
+                    android:text="@string/smudge_tool_dialog_pressure_title" />
+
+                <View style="@style/PocketPaintToolSectionDivider" />
+
+                <LinearLayout style="@style/PocketPaintToolSection">
+
+                    <SeekBar
+                        android:id="@+id/pocketpaint_pressure_seek_bar"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:max="100"
+                        android:minHeight="30dip" />
+
+                    <Space style="@style/PocketPaintToolHorizontalSpace" />
+
+                    <EditText
+                        android:id="@+id/pocketpaint_smudge_tool_dialog_pressure_input"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:imeOptions="actionDone"
+                        android:importantForAutofill="no"
+                        android:inputType="number"
+                        android:minEms="3"
+                        android:saveEnabled="false"
+                        android:textColor="?attr/colorAccent"
+                        android:textCursorDrawable="@null"
+                        android:textSize="14sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
+
+            </LinearLayout>
+        </ScrollView>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@android:color/white"
+                android:focusableInTouchMode="true"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/pocketpaint_smudge_tool_dialog_drag_input_text_view"
+                    style="@style/PocketPaintToolSubtitle"
+                    android:labelFor="@+id/pocketpaint_smudge_tool_dialog_drag_input"
+                    android:text="@string/smudge_tool_dialog_drag_title" />
+
+                <View style="@style/PocketPaintToolSectionDivider" />
+
+                <LinearLayout style="@style/PocketPaintToolSection">
+
+                    <SeekBar
+                        android:id="@+id/pocketpaint_drag_seek_bar"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:max="100"
+                        android:minHeight="30dip" />
+
+                    <Space style="@style/PocketPaintToolHorizontalSpace" />
+
+                    <EditText
+                        android:id="@+id/pocketpaint_smudge_tool_dialog_drag_input"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:imeOptions="actionDone"
+                        android:importantForAutofill="no"
+                        android:inputType="number"
+                        android:minEms="3"
+                        android:saveEnabled="false"
+                        android:textColor="?attr/colorAccent"
+                        android:textCursorDrawable="@null"
+                        android:textSize="14sp"
+                        android:textStyle="bold" />
+                </LinearLayout>
+
+            </LinearLayout>
+        </ScrollView>
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_bottom_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_bottom_bar.xml
@@ -221,5 +221,18 @@
                 style="@style/PocketPaintToolSelectionButtonTextView"
                 android:text="@string/button_watercolor"/>
         </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/pocketpaint_tools_smudge"
+            tools:ignore="UseCompoundDrawables"
+            style="@style/PocketPaintToolSelectionButton">
+            <ImageView
+                style="@style/PocketPaintToolSelectionButtonImageView"
+                android:src="@drawable/ic_pocketpaint_tool_smudge"
+                android:contentDescription="@string/button_smudge"/>
+            <TextView
+                style="@style/PocketPaintToolSelectionButtonTextView"
+                android:text="@string/button_smudge"/>
+        </LinearLayout>
     </TableRow>
 </TableLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_help_bottom_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_help_bottom_bar.xml
@@ -250,5 +250,20 @@
                 android:text="@string/button_watercolor"
                 android:textColor="@color/pocketpaint_color_picker_white"/>
         </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/pocketpaint_tools_smudge"
+            tools:ignore="UseCompoundDrawables"
+            style="@style/PocketPaintToolSelectionButton">
+            <ImageView
+                style="@style/PocketPaintToolSelectionButtonImageView"
+                android:src="@drawable/ic_pocketpaint_tool_smudge"
+                android:contentDescription="@string/button_smudge"
+                app:tint="@color/pocketpaint_color_picker_white"/>
+            <TextView
+                style="@style/PocketPaintToolSelectionButtonTextView"
+                android:text="@string/button_smudge"
+                android:textColor="@color/pocketpaint_color_picker_white"/>
+        </LinearLayout>
     </TableRow>
 </TableLayout>

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -37,6 +37,7 @@
     <string name="button_hand">Hand</string>
     <string name="button_watercolor">Watercolor</string>
     <string name="button_spray_can">Spray can</string>
+    <string name="button_smudge">Smudge</string>
     <string name="button_apply">Apply</string>
     <string name="button_checkmark">Checkmark</string>
     <string name="button_plus">Connect Line Segment</string>
@@ -80,6 +81,7 @@
     <string name="help_content_color_chooser">Select or adjust a color.</string>
     <string name="help_content_hand">Move your finger to move the canvas.</string>
     <string name="help_content_spray_can">Move your finger on the image to create a spray can pattern.</string>
+    <string name="help_content_smudge">Move your finger on the image on different drawings to smudge them.</string>
     <string name="closing_catroid_security_question_title">Back to project</string>
     <string name="closing_security_question_title">Quit</string>
     <string name="closing_security_question">Save changes?</string>
@@ -133,6 +135,9 @@
     <string name="shape_tool_dialog_outline_title">Outline</string>
 
     <string name="fill_tool_dialog_color_tolerance_title">Color tolerance</string>
+
+    <string name="smudge_tool_dialog_pressure_title">Pressure</string>
+    <string name="smudge_tool_dialog_drag_title">Drag</string>
 
     <string name="transform_tool_rotate_left">rotate left</string>
     <string name="transform_tool_rotate_right">rotate right</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
@@ -105,10 +105,12 @@ public class ToolControllerTest {
 				ToolType.LAYER,
 				ToolType.COLORCHOOSER,
 				ToolType.HAND,
-				ToolType.WATERCOLOR
+				ToolType.WATERCOLOR,
+				ToolType.SMUDGE
 		);
 		when(toolReference.getTool()).thenReturn(tool);
 
+		assertFalse(toolController.isDefaultTool());
 		assertFalse(toolController.isDefaultTool());
 		assertFalse(toolController.isDefaultTool());
 		assertFalse(toolController.isDefaultTool());


### PR DESCRIPTION
1. The smudge tool creates a bitmap of the size of the brush on handle down and stores the pixel information from the selected layer.
2. It then stores amortized points in handle move, such that the points lead in the direction of the move, but are layed out at a fixed distance (to ensure that the drawed smudge would not contain any glitching effects).
3. On handle up it creates a new SmudgePathCommand, which then draws the stored bitmap with varying amounts of transparency at each of the stored points location.

The command ensures that the smudge is considered a single operation and can be entirely undone and redone by the user.
The tool also implements the draw function, which is used to preview the drawing of the smudge while the user is dragging the finger on the screen.
There are two parameters that are available in the tool's option menu: the pressure and the drag. The first determines how long the smudge will be (bigger value -> longer smudge). The second one determines how much will the smudge be reduced in size through its path (bigger value -> smaller reduction in size).

I also implemented tests for both the smudge tool and the SmudgePathCommand.

https://jira.catrob.at/browse/PAINTROID-292

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
