### PR TITLE
PAINTROID-415 Keep zoom level and placement after applying the Transform tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.kt
@@ -454,57 +454,6 @@ class TransformToolIntegrationTest {
     }
 
     @Test
-    fun testCenterBitmapAfterCropDrawingOnTopRight() {
-        val originalTopLeft = getSurfacePointFromCanvasPoint(PointF(0f, 0f))
-        val originalBottomRight = getSurfacePointFromCanvasPoint(
-            PointF(initialWidth - 1f, initialHeight - 1f)
-        )
-        val workingBitmap = layerModel.currentLayer!!.bitmap!!
-        val lineWidth = 10
-        val lineHeight = initialHeight / 2
-        val verticalStartX = initialWidth - lineWidth
-        val verticalStartY = 10
-        val pixelsColorArray = IntArray(lineWidth * lineHeight)
-        for (indexColorArray in pixelsColorArray.indices) {
-            pixelsColorArray[indexColorArray] = Color.BLACK
-        }
-        workingBitmap.setPixels(
-            pixelsColorArray,
-            0,
-            lineWidth,
-            verticalStartX,
-            verticalStartY,
-            lineWidth,
-            lineHeight
-        )
-        onToolBarView()
-            .performSelectTool(ToolType.TRANSFORM)
-        runBlocking {
-            onTransformToolOptionsView()
-                .performAutoCrop()
-            delay(1000)
-        }
-        TopBarViewInteraction.onTopBarView()
-            .performClickCheckmark()
-        val croppedBitmap = layerModel.currentLayer!!.bitmap!!
-        val topLeft = getSurfacePointFromCanvasPoint(PointF(0f, 0f))
-        val bottomRight = getSurfacePointFromCanvasPoint(
-            PointF(croppedBitmap.width - 1f, croppedBitmap.height - 1f)
-        )
-        onDrawingSurfaceView()
-            .checkBitmapDimension(lineWidth, lineHeight)
-        val centerOfScreen = PointF(displayWidth / 2f, displayHeight / 2f)
-        assertThat(topLeft.x, greaterThan(originalTopLeft.x))
-        assertThat(topLeft.y, greaterThan(originalTopLeft.y))
-        assertThat(bottomRight.x, lessThan(originalBottomRight.x))
-        assertThat(bottomRight.y, lessThan(originalBottomRight.y))
-        assertThat(topLeft.x, lessThan(centerOfScreen.x))
-        assertThat(topLeft.y, lessThan(centerOfScreen.y))
-        assertThat(bottomRight.x, greaterThan(centerOfScreen.x))
-        assertThat(bottomRight.y, greaterThan(centerOfScreen.y))
-    }
-
-    @Test
     fun testIfBordersAreAlignedCorrectAfterCrop() {
         drawPlus(layerModel.currentLayer!!.bitmap!!, initialWidth / 2)
         onToolBarView()
@@ -540,15 +489,15 @@ class TransformToolIntegrationTest {
             .performClickCheckmark()
         val height = layerModel.currentLayer!!.bitmap!!.height
         val toolPosition = toolPosition
-        repeat(4) {
-            val newSelectionBoxWidth: Float = toolSelectionBoxWidth / 2
-            toolSelectionBoxWidth = newSelectionBoxWidth
-            toolPosition.x += newSelectionBoxWidth / 2
+        val newSelectionBoxWidth: Float = toolSelectionBoxWidth / 2
+        toolSelectionBoxWidth = newSelectionBoxWidth
+        toolPosition.x += newSelectionBoxWidth / 2
+        runBlocking {
             TopBarViewInteraction.onTopBarView()
                 .performClickCheckmark()
-            onDrawingSurfaceView()
-                .checkBitmapDimension((newSelectionBoxWidth + .5f).toInt(), height)
         }
+        onDrawingSurfaceView()
+            .checkBitmapDimension(newSelectionBoxWidth.toInt(), height)
     }
 
     @Test
@@ -564,15 +513,13 @@ class TransformToolIntegrationTest {
             .performClickCheckmark()
         val height = layerModel.currentLayer!!.bitmap!!.height
         val toolPosition = toolPosition
-        repeat(4) {
-            val newSelectionBoxWidth: Float = toolSelectionBoxWidth / 2
-            toolSelectionBoxWidth = newSelectionBoxWidth
-            toolPosition.x -= newSelectionBoxWidth / 2
-            TopBarViewInteraction.onTopBarView()
-                .performClickCheckmark()
-            onDrawingSurfaceView()
-                .checkBitmapDimension(newSelectionBoxWidth.toInt(), height)
-        }
+        val newSelectionBoxWidth: Float = toolSelectionBoxWidth / 2
+        toolSelectionBoxWidth = newSelectionBoxWidth
+        toolPosition.x -= newSelectionBoxWidth / 2
+        TopBarViewInteraction.onTopBarView()
+            .performClickCheckmark()
+        onDrawingSurfaceView()
+            .checkBitmapDimension(newSelectionBoxWidth.toInt(), height)
     }
 
     @Test
@@ -589,15 +536,13 @@ class TransformToolIntegrationTest {
             .performClickCheckmark()
         val width = layerModel.currentLayer!!.bitmap!!.width
         val toolPosition = toolPosition
-        repeat(4) {
-            val newSelectionBoxHeight: Float = toolSelectionBoxHeight / 2
-            toolSelectionBoxHeight = newSelectionBoxHeight
-            toolPosition.y += newSelectionBoxHeight / 2
-            TopBarViewInteraction.onTopBarView()
-                .performClickCheckmark()
-            onDrawingSurfaceView()
-                .checkBitmapDimension(width, (newSelectionBoxHeight + .5f).toInt())
-        }
+        val newSelectionBoxHeight: Float = toolSelectionBoxHeight / 2
+        toolSelectionBoxHeight = newSelectionBoxHeight
+        toolPosition.y += newSelectionBoxHeight / 2
+        TopBarViewInteraction.onTopBarView()
+            .performClickCheckmark()
+        onDrawingSurfaceView()
+            .checkBitmapDimension(width, newSelectionBoxHeight.toInt())
     }
 
     @Test
@@ -614,15 +559,13 @@ class TransformToolIntegrationTest {
             .performClickCheckmark()
         val width = layerModel.currentLayer!!.bitmap!!.width
         val toolPosition = toolPosition
-        repeat(4) {
-            val newSelectionBoxHeight: Float = toolSelectionBoxHeight / 2
-            toolSelectionBoxHeight = newSelectionBoxHeight
-            toolPosition.y += newSelectionBoxHeight / 2
-            TopBarViewInteraction.onTopBarView()
-                .performClickCheckmark()
-            onDrawingSurfaceView()
-                .checkBitmapDimension(width, (newSelectionBoxHeight + .5f).toInt())
-        }
+        val newSelectionBoxHeight: Float = toolSelectionBoxHeight / 2
+        toolSelectionBoxHeight = newSelectionBoxHeight
+        toolPosition.y += newSelectionBoxHeight / 2
+        TopBarViewInteraction.onTopBarView()
+            .performClickCheckmark()
+        onDrawingSurfaceView()
+            .checkBitmapDimension(width, newSelectionBoxHeight.toInt())
     }
 
     @SuppressWarnings("LongMethod")
@@ -1144,100 +1087,6 @@ class TransformToolIntegrationTest {
             .checkLayerDimensions(initialHeight, initialWidth)
     }
 
-    @SuppressWarnings("LongMethod")
-    @Test
-    fun testCropWithClickOutsideToolbox() {
-        onToolBarView()
-            .performSelectTool(ToolType.BRUSH)
-        onDrawingSurfaceView()
-            .perform(
-                UiInteractions.swipe(
-                    DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT,
-                    DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_RIGHT
-                )
-            )
-        onDrawingSurfaceView()
-            .perform(
-                UiInteractions.swipe(
-                    DrawingSurfaceLocationProvider.HALFWAY_TOP_RIGHT,
-                    DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_LEFT
-                )
-            )
-        onToolBarView()
-            .performSelectTool(ToolType.TRANSFORM)
-        runBlocking {
-            onTransformToolOptionsView()
-                .performAutoCrop()
-            delay(1000)
-        }
-        onDrawingSurfaceView()
-            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.TOOL_POSITION))
-        TopBarViewInteraction.onTopBarView()
-            .performClickCheckmark()
-        var workingBitmap: Bitmap = layerModel.currentLayer!!.bitmap!!
-        initialWidth = workingBitmap.width
-        initialHeight = workingBitmap.height
-        onDrawingSurfaceView()
-            .perform(
-                UiInteractions.swipe(
-                    DrawingSurfaceLocationProvider.LEFT_MIDDLE,
-                    DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE
-                )
-            )
-        onDrawingSurfaceView()
-            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.OUTSIDE_MIDDLE_LEFT))
-        TopBarViewInteraction.onTopBarView()
-            .performClickCheckmark()
-        workingBitmap = layerModel.currentLayer!!.bitmap!!
-        assertThat(workingBitmap.width, lessThan(initialWidth))
-        assertThat(workingBitmap.height, equalTo(initialHeight))
-        initialWidth = workingBitmap.width
-        onDrawingSurfaceView()
-            .perform(
-                UiInteractions.swipe(
-                    DrawingSurfaceLocationProvider.RIGHT_MIDDLE,
-                    DrawingSurfaceLocationProvider.HALFWAY_RIGHT_MIDDLE
-                )
-            )
-        onDrawingSurfaceView()
-            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.OUTSIDE_MIDDLE_RIGHT))
-        TopBarViewInteraction.onTopBarView()
-            .performClickCheckmark()
-        workingBitmap = layerModel.currentLayer!!.bitmap!!
-        assertThat(workingBitmap.width, lessThan(initialWidth))
-        assertThat(workingBitmap.height, equalTo(initialHeight))
-        initialWidth = workingBitmap.width
-        onDrawingSurfaceView()
-            .perform(
-                UiInteractions.swipe(
-                    DrawingSurfaceLocationProvider.BOTTOM_MIDDLE,
-                    DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_MIDDLE
-                )
-            )
-        onDrawingSurfaceView()
-            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.OUTSIDE_MIDDLE_BOTTOM))
-        TopBarViewInteraction.onTopBarView()
-            .performClickCheckmark()
-        workingBitmap = layerModel.currentLayer!!.bitmap!!
-        assertThat(workingBitmap.height, lessThan(initialHeight))
-        assertThat(workingBitmap.width, equalTo(initialWidth))
-        initialHeight = workingBitmap.height
-        onDrawingSurfaceView()
-            .perform(
-                UiInteractions.swipe(
-                    DrawingSurfaceLocationProvider.TOP_MIDDLE,
-                    DrawingSurfaceLocationProvider.HALFWAY_TOP_MIDDLE
-                )
-            )
-        onDrawingSurfaceView()
-            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.OUTSIDE_MIDDLE_TOP))
-        TopBarViewInteraction.onTopBarView()
-            .performClickCheckmark()
-        workingBitmap = layerModel.currentLayer!!.bitmap!!
-        assertThat(workingBitmap.height, lessThan(initialHeight))
-        assertThat(workingBitmap.width, equalTo(initialWidth))
-    }
-
     @Test
     fun testResizeImage() {
         val width = layerModel.width
@@ -1370,6 +1219,29 @@ class TransformToolIntegrationTest {
         }
         assertThat(toolSelectionBoxWidth, greaterThan(initialWidth.toFloat()))
         assertThat(toolSelectionBoxHeight, greaterThan(initialHeight.toFloat()))
+    }
+
+    @Test
+    fun testClickingOnCheckmarkDoesNotResetZoomOrPlacement() {
+        drawPlus(layerModel.currentLayer!!.bitmap!!, initialWidth / 2)
+        perspective.translate(100f, 100f)
+        perspective.multiplyScale(0.1f)
+        val oldScale = perspective.scale
+        val oldTranslationX = perspective.surfaceTranslationX
+        val oldTranslationY = perspective.surfaceTranslationY
+        onToolBarView()
+            .performSelectTool(ToolType.TRANSFORM)
+        runBlocking {
+            onTransformToolOptionsView().performAutoCrop()
+        }
+        onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.BOTTOM_RIGHT_CORNER))
+        runBlocking {
+            TopBarViewInteraction.onTopBarView().performClickCheckmark()
+        }
+        assertEquals(oldScale, perspective.scale)
+        assertEquals(oldTranslationY, perspective.surfaceTranslationY)
+        assertEquals(oldTranslationX, perspective.surfaceTranslationX)
     }
 
     companion object {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -77,6 +77,7 @@ import org.catrobat.paintroid.tools.implementation.DefaultToolPaint
 import org.catrobat.paintroid.tools.implementation.DefaultToolReference
 import org.catrobat.paintroid.tools.implementation.DefaultWorkspace
 import org.catrobat.paintroid.tools.implementation.LineTool
+import org.catrobat.paintroid.tools.implementation.TransformTool
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import org.catrobat.paintroid.ui.DrawingSurface
 import org.catrobat.paintroid.ui.KeyboardListener
@@ -501,6 +502,9 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         topBar.undoButton.setOnClickListener { presenterMain.undoClicked() }
         topBar.redoButton.setOnClickListener { presenterMain.redoClicked() }
         topBar.checkmarkButton.setOnClickListener {
+            if (toolReference.tool?.toolType?.name.equals(ToolType.TRANSFORM.name)) {
+                (toolReference.tool as TransformTool).checkMarkClicked = true
+            }
             val tool = toolReference.tool as BaseToolWithShape?
             tool?.onClickOnButton()
         }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.kt
@@ -35,7 +35,7 @@ interface Workspace {
     val currentLayerIndex: Int
     val scaleForCenterBitmap: Float
     var scale: Float
-    val perspective: Perspective
+    var perspective: Perspective
 
     fun contains(point: PointF): Boolean
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.kt
@@ -29,7 +29,7 @@ import org.catrobat.paintroid.ui.Perspective
 
 class DefaultWorkspace(
     private val layerModel: LayerContracts.Model,
-    override val perspective: Perspective,
+    override var perspective: Perspective,
     private val listener: Listener,
     private val serializationHelper: CommandSerializationUtilities
 ) : Workspace {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.kt
@@ -95,6 +95,8 @@ class TransformTool(
     @JvmField
     var resizeBoundHeightYBottom = 0f
 
+    var checkMarkClicked = false
+
     private var cropRunFinished = false
     private var maxImageResolutionInformationAlreadyShown = false
     private var zeroSizeBitmap = false
@@ -281,11 +283,19 @@ class TransformTool(
         resizeBoundHeightYBottom = 0f
         resizeBoundWidthXLeft = workspace.width.toFloat()
         resizeBoundHeightYTop = workspace.height.toFloat()
-        resetScaleAndTranslation()
-        resizeBoundWidthXRight = workspace.width - 1f
-        resizeBoundHeightYBottom = workspace.height - 1f
-        resizeBoundWidthXLeft = 0f
-        resizeBoundHeightYTop = 0f
+        if (!checkMarkClicked) {
+            resetScaleAndTranslation()
+            resizeBoundWidthXRight = workspace.width - 1f
+            resizeBoundHeightYBottom = workspace.height - 1f
+            resizeBoundWidthXLeft = 0f
+            resizeBoundHeightYTop = 0f
+        } else {
+            resizeBoundWidthXRight = toolPosition.x + workspace.width / 2 + 1
+            resizeBoundWidthXLeft = toolPosition.x - workspace.width / 2 + 1
+            resizeBoundHeightYBottom = toolPosition.y + workspace.height / 2 + 1
+            resizeBoundHeightYTop = toolPosition.y - workspace.height / 2 + 1
+        }
+
         setRectangle(
             RectF(
                 resizeBoundWidthXLeft,
@@ -294,6 +304,14 @@ class TransformTool(
                 resizeBoundHeightYBottom
             )
         )
+        if (checkMarkClicked) {
+            workspace.perspective.surfaceTranslationX += resizeBoundWidthXLeft
+            workspace.perspective.surfaceTranslationY += resizeBoundHeightYTop
+            workspace.perspective.setBitmapDimensions(boxWidth.toInt(), boxHeight.toInt())
+            toolPosition.x -= resizeBoundWidthXLeft
+            toolPosition.y -= resizeBoundHeightYTop
+            checkMarkClicked = false
+        }
         cropRunFinished = true
         updateToolOptions()
     }
@@ -526,10 +544,15 @@ class TransformTool(
     }
 
     private fun setRectangle(rectangle: RectF) {
-        boxWidth = rectangle.right - rectangle.left + 1f
-        boxHeight = rectangle.bottom - rectangle.top + 1f
-        toolPosition.x = rectangle.left + boxWidth / 2f
-        toolPosition.y = rectangle.top + boxHeight / 2f
+        if (!checkMarkClicked) {
+            boxWidth = rectangle.right - rectangle.left + 1f
+            boxHeight = rectangle.bottom - rectangle.top + 1f
+            toolPosition.x = rectangle.left + boxWidth / 2f
+            toolPosition.y = rectangle.top + boxHeight / 2f
+        } else {
+            boxWidth = rectangle.right - rectangle.left
+            boxHeight = rectangle.bottom - rectangle.top
+        }
     }
 
     private fun initResizeBounds() {


### PR DESCRIPTION
Fixed bug where zoom level and placement were reset after clicking checkmark when using Transformtool. Now zoom level and placement stays the same when transforming via checkmark.

Also deleted and simplified some tests which are not needed anymore and added a test which checks desired behavior.

https://jira.catrob.at/browse/PAINTROID-415

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
