### PR TITLE
PAINTROID-283: add opacity for layers

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/CatrobatImageIOIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/CatrobatImageIOIntegrationTest.kt
@@ -35,6 +35,7 @@ import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import org.catrobat.paintroid.FileIO
 import org.catrobat.paintroid.MainActivity
+import org.catrobat.paintroid.command.serialization.CommandSerializer
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils
@@ -107,8 +108,6 @@ class CatrobatImageIOIntegrationTest {
             .perform(ViewActions.click())
         uriFile = activity.model.savedPictureUri!!
         Assert.assertNotNull(uriFile)
-        Assert.assertNotNull(
-            activity.workspace.getCommandSerializationHelper().readFromFile(uriFile!!)
-        )
+        Assert.assertNotNull(CommandSerializer(activity, activity.commandManager, activity.model).readFromFile(uriFile!!))
     }
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LayerIntegrationTest.kt
@@ -181,6 +181,7 @@ class LayerIntegrationTest {
             .checkLayerCount(4)
         TopBarViewInteraction.onTopBarView()
             .performOpenMoreOptions()
+
         onView(withText(R.string.menu_new_image))
             .perform(click())
         onView(withText(R.string.discard_button_text))
@@ -554,6 +555,50 @@ class LayerIntegrationTest {
     }
 
     @Test
+    fun testLayerOpacity() {
+        ToolBarViewInteraction.onToolBarView()
+            .performSelectTool(ToolType.FILL)
+
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE)
+
+        LayerMenuViewInteraction.onLayerMenuView()
+            .performOpen()
+            .performSetOpacityTo(50, 0)
+            .performClose()
+
+        ToolBarViewInteraction.onToolBarView()
+            .performSelectTool(ToolType.PIPETTE)
+
+        val fiftyPercentOpacityBlack = Color.argb(255 / 2, 0, 0, 0)
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .checkPixelColor(fiftyPercentOpacityBlack, BitmapLocationProvider.MIDDLE)
+
+        LayerMenuViewInteraction.onLayerMenuView()
+            .performOpen()
+            .performSetOpacityTo(0, 0)
+            .performClose()
+
+        DrawingSurfaceInteraction.onDrawingSurfaceView()
+            .checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE)
+    }
+
+    @Test
+    fun testOpacityAndVisiblityIconDisabled() {
+        LayerMenuViewInteraction.onLayerMenuView()
+            .performOpen()
+
+        onView(withId(R.id.pocketpaint_layer_side_nav_button_visibility)).check(ViewAssertions.matches(Matchers.not(isClickable())))
+        onView(withId(R.id.pocketpaint_layer_side_nav_button_opacity)).check(ViewAssertions.matches(Matchers.not(isClickable())))
+    }
+
+    @Test
     fun testLayerOrderUndoDelete() {
         ToolBarViewInteraction.onToolBarView()
             .performSelectTool(ToolType.FILL)
@@ -565,8 +610,8 @@ class LayerIntegrationTest {
             .checkLayerCount(2)
             .performClose()
         ToolPropertiesInteraction.onToolProperties()
-            .setColorResource(R.color.pocketpaint_color_picker_green1)
-            .checkMatchesColorResource(R.color.pocketpaint_color_picker_green1)
+            .setColorResource(R.color.pocketpaint_color_merge_layer)
+            .checkMatchesColorResource(R.color.pocketpaint_color_merge_layer)
         DrawingSurfaceInteraction.onDrawingSurfaceView()
             .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
         LayerMenuViewInteraction.onLayerMenuView()
@@ -586,7 +631,7 @@ class LayerIntegrationTest {
         DrawingSurfaceInteraction.onDrawingSurfaceView()
             .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
         ToolPropertiesInteraction.onToolProperties()
-            .checkMatchesColorResource(R.color.pocketpaint_color_picker_green1)
+            .checkMatchesColorResource(R.color.pocketpaint_color_merge_layer)
     }
 
     @Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MainActivityIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MainActivityIntegrationTest.kt
@@ -37,6 +37,7 @@ import org.catrobat.paintroid.R
 import org.catrobat.paintroid.UserPreferences
 import org.catrobat.paintroid.command.CommandFactory
 import org.catrobat.paintroid.command.CommandManager
+import org.catrobat.paintroid.command.serialization.CommandSerializer
 import org.catrobat.paintroid.contract.MainActivityContracts
 import org.catrobat.paintroid.contract.MainActivityContracts.Interactor
 import org.catrobat.paintroid.contract.MainActivityContracts.MainView
@@ -103,6 +104,9 @@ class MainActivityIntegrationTest {
     private val context: Context? = null
 
     @Mock
+    private val commandSerializer: CommandSerializer? = null
+
+    @Mock
     private val internalMemoryPath: File? = null
     private var presenter: MainActivityPresenter? = null
 
@@ -131,7 +135,8 @@ class MainActivityIntegrationTest {
                     commandFactory!!,
                     commandManager!!,
                     perspective!!,
-                    toolController!!, sharedPreferences!!, idlingResource, it1, it
+                    toolController!!, sharedPreferences!!, idlingResource, it1, it,
+                    commandSerializer!!
                 )
             }
         }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClippingToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClippingToolIntegrationTest.kt
@@ -177,8 +177,8 @@ class ClippingToolIntegrationTest {
         val colorInAreaCurrentLayer = workspace.bitmapOfCurrentLayer?.getPixel(inAreaX.toInt(), inAreaY.toInt())
         val colorOutOfAreaCurrentLayer = workspace.bitmapOfCurrentLayer?.getPixel(outOfAreaX, outOfAreaY)
 
-        val colorInAreaSecondLayer = workspace.bitmapLisOfAllLayers[1]?.getPixel(inAreaX.toInt(), inAreaY.toInt())
-        val colorOutOfAreaSecondLayer = workspace.bitmapLisOfAllLayers[1]?.getPixel(outOfAreaX, outOfAreaY)
+        val colorInAreaSecondLayer = workspace.bitmapListOfAllLayers[1]?.getPixel(inAreaX.toInt(), inAreaY.toInt())
+        val colorOutOfAreaSecondLayer = workspace.bitmapListOfAllLayers[1]?.getPixel(outOfAreaX, outOfAreaY)
 
         assertEquals(colorInAreaCurrentLayer, Color.YELLOW)
         assertEquals(colorOutOfAreaCurrentLayer, Color.TRANSPARENT)

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/PipetteToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/PipetteToolIntegrationTest.java
@@ -174,7 +174,7 @@ public class PipetteToolIntegrationTest {
 				.checkMatchesColor(Color.TRANSPARENT);
 
 		onDrawingSurfaceView()
-				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE)
+				.checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE)
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
 		onToolProperties()

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/StampToolIntegrationTest.java
@@ -25,7 +25,9 @@ import android.graphics.Color;
 import android.graphics.PointF;
 
 import org.catrobat.paintroid.MainActivity;
+import org.catrobat.paintroid.test.espresso.util.BitmapLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
+import org.catrobat.paintroid.test.espresso.util.wrappers.LayerMenuViewInteraction;
 import org.catrobat.paintroid.test.espresso.util.wrappers.StampToolViewInteraction;
 import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
 import org.catrobat.paintroid.tools.ToolReference;
@@ -112,6 +114,52 @@ public class StampToolIntegrationTest {
 		assertEquals(topRight, Color.BLACK);
 		assertEquals(bottomLeft, Color.BLACK);
 		assertEquals(bottomRight, Color.BLACK);
+	}
+
+	@Test
+	public void testStampToolConsidersLayerOpacity() {
+		onToolBarView()
+				.performSelectTool(ToolType.SHAPE);
+
+		onShapeToolOptionsView()
+				.performSelectShape(DrawableShape.RECTANGLE);
+
+		onTopBarView()
+				.performClickCheckmark();
+
+		onToolBarView()
+				.performSelectTool(ToolType.STAMP);
+
+		LayerMenuViewInteraction.onLayerMenuView()
+				.performOpen()
+				.performSetOpacityTo(50, 0)
+				.performClose();
+
+		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+				.performCopy();
+
+		StampTool stampTool = (StampTool) toolReference.getTool();
+		int fiftyPercentOpacityBlack = Color.argb(255 / 2, 0, 0, 0);
+		int centerPixel = stampTool.drawingBitmap.getPixel(stampTool.drawingBitmap.getWidth() / 2, stampTool.drawingBitmap.getHeight() / 2);
+		assertEquals(centerPixel, Color.BLACK);
+
+		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+				.performPaste();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(fiftyPercentOpacityBlack, BitmapLocationProvider.MIDDLE);
+
+		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+				.performCut();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE);
+
+		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+				.performPaste();
+
+		onDrawingSurfaceView()
+				.checkPixelColor(fiftyPercentOpacityBlack, BitmapLocationProvider.MIDDLE);
 	}
 
 	@Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/UiInteractions.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/UiInteractions.java
@@ -20,9 +20,11 @@
 package org.catrobat.paintroid.test.espresso.util;
 
 import android.graphics.PointF;
+import android.util.Log;
 import android.view.InputDevice;
 import android.view.MotionEvent;
 import android.view.View;
+import android.widget.ProgressBar;
 import android.widget.SeekBar;
 
 import org.hamcrest.Matcher;
@@ -45,6 +47,8 @@ import androidx.test.espresso.action.Tap;
 import androidx.test.espresso.action.Tapper;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.viewpager.widget.ViewPager;
+
+import java.lang.reflect.Method;
 
 import static androidx.test.espresso.action.ViewActions.actionWithAssertions;
 import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
@@ -108,7 +112,13 @@ public final class UiInteractions {
 
 			@Override
 			public void perform(UiController uiController, View view) {
-				((SeekBar) view).setProgress(progress);
+				try {
+					Method privateSetProgressMethod = ProgressBar.class.getDeclaredMethod("setProgressInternal", Integer.TYPE, Boolean.TYPE, Boolean.TYPE);
+					privateSetProgressMethod.setAccessible(true);
+					privateSetProgressMethod.invoke(view, progress, true, true);
+				} catch (ReflectiveOperationException e) {
+					Log.e("SET PROGRESS", "could not set progress");
+				}
 			}
 		};
 	}
@@ -178,6 +188,14 @@ public final class UiInteractions {
 
 	public static ViewAction touchCenterLeft() {
 		return new GeneralClickAction(Tap.SINGLE, GeneralLocation.CENTER_LEFT, Press.FINGER, 0, 0);
+	}
+
+	public static ViewAction touchCenterTop() {
+		return new GeneralClickAction(Tap.SINGLE, GeneralLocation.TOP_CENTER, Press.FINGER, 0, 0);
+	}
+
+	public static ViewAction touchCenterBottom() {
+		return new GeneralClickAction(Tap.SINGLE, GeneralLocation.BOTTOM_CENTER, Press.FINGER, 0, 0);
 	}
 
 	public static ViewAction touchCenterMiddle() {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/DrawingSurfaceInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/DrawingSurfaceInteraction.java
@@ -62,9 +62,9 @@ public final class DrawingSurfaceInteraction extends CustomViewInteraction {
 			@Override
 			protected boolean matchesSafely(View view) {
 				MainActivity activity = getMainActivityFromView(view);
-				LayerContracts.Layer currentLayer = activity.layerModel.getCurrentLayer();
+				Bitmap currentBitmap = activity.layerModel.getBitmapOfAllLayers();
 				float[] coordinates = coordinateProvider.calculateCoordinates(view);
-				int actualColor = currentLayer.getBitmap().getPixel((int) coordinates[0], (int) coordinates[1]);
+				int actualColor = currentBitmap.getPixel((int) coordinates[0], (int) coordinates[1]);
 				return expectedColor == actualColor;
 			}
 		}));
@@ -81,8 +81,8 @@ public final class DrawingSurfaceInteraction extends CustomViewInteraction {
 			@Override
 			protected boolean matchesSafely(View view) {
 				MainActivity activity = getMainActivityFromView(view);
-				LayerContracts.Layer currentLayer = activity.layerModel.getCurrentLayer();
-				int actualColor = currentLayer.getBitmap().getPixel((int) x, (int) y);
+				Bitmap currentBitmap = activity.layerModel.getBitmapOfAllLayers();
+				int actualColor = currentBitmap.getPixel((int) x, (int) y);
 				return expectedColor == actualColor;
 			}
 		}));

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/LayerMenuViewInteraction.java
@@ -27,6 +27,7 @@ import android.view.View;
 import android.widget.ImageView;
 
 import org.catrobat.paintroid.R;
+import org.catrobat.paintroid.model.Layer;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -35,9 +36,14 @@ import static org.catrobat.paintroid.test.espresso.util.UiInteractions.assertRec
 import static org.catrobat.paintroid.test.espresso.util.wrappers.BottomNavigationViewInteraction.onBottomNavigationView;
 
 import androidx.annotation.ColorInt;
+import androidx.test.espresso.DataInteraction;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.contrib.DrawerActions;
 
+import static org.catrobat.paintroid.test.espresso.util.UiInteractions.setProgress;
+import static org.hamcrest.Matchers.instanceOf;
+
+import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -71,14 +77,23 @@ public final class LayerMenuViewInteraction extends CustomViewInteraction {
 		return this;
 	}
 
-	public androidx.test.espresso.ViewInteraction onLayerAt(int listPosition) {
-		return onView(withId(org.catrobat.paintroid.R.id.pocketpaint_layer_side_nav_list)).perform(androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition(listPosition, click()));
+	public DataInteraction onLayerAt(int listPosition) {
+		return onData(instanceOf(Layer.class))
+				.inAdapterView(withId(R.id.pocketpaint_layer_side_nav_list))
+				.atPosition(listPosition);
 	}
 
 	public LayerMenuViewInteraction performOpen() {
 		onBottomNavigationView()
 				.onLayersClicked();
 		check(matches(isDisplayed()));
+		return this;
+	}
+
+	public LayerMenuViewInteraction performSetOpacityTo(int opacityPercentage, int listPosition) {
+		onLayerAt(listPosition)
+				.onChildView(withId(R.id.pocketpaint_layer_opacity_seekbar))
+				.perform(setProgress(opacityPercentage));
 		return this;
 	}
 
@@ -92,6 +107,7 @@ public final class LayerMenuViewInteraction extends CustomViewInteraction {
 	public LayerMenuViewInteraction performSelectLayer(int listPosition) {
 		check(matches(isDisplayed()));
 		onLayerAt(listPosition)
+				.onChildView(withId(R.id.pocketpaint_layer_preview_container))
 				.perform(click());
 		return this;
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/FillCommandTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/FillCommandTest.java
@@ -54,13 +54,17 @@ public class FillCommandTest {
 	private static final float NO_TOLERANCE = 0.0f;
 	private static final float HALF_TOLERANCE = MAX_ABSOLUTE_TOLERANCE / 2.0f;
 	private static final float MAX_TOLERANCE = MAX_ABSOLUTE_TOLERANCE;
+	private static final int INITIAL_HEIGHT = 80;
+	private static final int INITIAL_WIDTH = 80;
 
 	private LayerContracts.Model layerModel;
+	private Bitmap bitmapUnderTest;
 
 	@Before
 	public void setUp() {
+		bitmapUnderTest = Bitmap.createBitmap(INITIAL_WIDTH, INITIAL_HEIGHT, Bitmap.Config.ARGB_8888);
 		layerModel = new LayerModel();
-		Layer layer = new Layer(null);
+		Layer layer = new Layer(bitmapUnderTest);
 		layerModel.addLayerAt(0, layer);
 		layerModel.setCurrentLayer(layer);
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/LoadLayerListCommandTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/LoadLayerListCommandTest.kt
@@ -20,8 +20,9 @@ package org.catrobat.paintroid.test.junit.command
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
-import org.catrobat.paintroid.command.implementation.LoadBitmapListCommand
+import org.catrobat.paintroid.command.implementation.LoadLayerListCommand
 import org.catrobat.paintroid.contract.LayerContracts
+import org.catrobat.paintroid.model.Layer
 import org.catrobat.paintroid.model.LayerModel
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert
@@ -32,29 +33,30 @@ import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
-class LoadBitmapListCommandTest {
+class LoadLayerListCommandTest {
 
     private var canvas: Canvas = Mockito.mock(Canvas::class.java)
     private var layerModel: LayerContracts.Model = LayerModel()
 
-    private lateinit var commandUnderTest: LoadBitmapListCommand
-    private lateinit var bitmapList: MutableList<Bitmap>
+    private lateinit var commandUnderTest: LoadLayerListCommand
+    private lateinit var layerList: MutableList<LayerContracts.Layer>
 
     @Before
     fun setUp() {
-        bitmapList = mutableListOf()
+        layerList = mutableListOf()
         for (i in 1..3) {
-            bitmapList.add(Bitmap.createBitmap(2 * i, 2, Bitmap.Config.ARGB_8888))
+            val layer = Layer(Bitmap.createBitmap(2 * i, 2, Bitmap.Config.ARGB_8888))
+            layerList.add(layer)
         }
-        commandUnderTest = LoadBitmapListCommand(bitmapList)
+        commandUnderTest = LoadLayerListCommand(layerList)
     }
 
     @Test
     fun testRunCopiesImage() {
         commandUnderTest.run(canvas, layerModel)
-        Assert.assertTrue(layerModel.currentLayer!!.bitmap!!.sameAs(bitmapList[0]))
-        Assert.assertTrue(layerModel.getLayerAt(1)!!.bitmap!!.sameAs(bitmapList[1]))
-        Assert.assertTrue(layerModel.getLayerAt(2)!!.bitmap!!.sameAs(bitmapList[2]))
+        Assert.assertTrue(layerModel.currentLayer!!.bitmap.sameAs(layerList[0].bitmap))
+        Assert.assertTrue(layerModel.getLayerAt(1)!!.bitmap.sameAs(layerList[1].bitmap))
+        Assert.assertTrue(layerModel.getLayerAt(2)!!.bitmap.sameAs(layerList[2].bitmap))
     }
 
     @Test

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/model/LayerTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/model/LayerTest.java
@@ -136,33 +136,6 @@ public class LayerTest {
 	}
 
 	@Test
-	public void testHideThenUnhideLayer() {
-		LayerContracts.Layer layerToHide = layerModel.getLayerAt(0);
-
-		layerToHide.getBitmap().setPixel(1, 1, Color.BLACK);
-		layerToHide.getBitmap().setPixel(2, 1, Color.BLACK);
-		layerToHide.getBitmap().setPixel(3, 1, Color.BLACK);
-		layerToHide.getBitmap().setPixel(4, 1, Color.BLACK);
-
-		Bitmap bitmapCopy = layerToHide.getTransparentBitmap();
-
-		layerToHide.switchBitmaps(false);
-		layerToHide.setBitmap(bitmapCopy);
-
-		assertThat(layerToHide.getBitmap().getPixel(1, 1), is(Color.TRANSPARENT));
-		assertThat(layerToHide.getBitmap().getPixel(2, 1), is(Color.TRANSPARENT));
-		assertThat(layerToHide.getBitmap().getPixel(3, 1), is(Color.TRANSPARENT));
-		assertThat(layerToHide.getBitmap().getPixel(4, 1), is(Color.TRANSPARENT));
-
-		layerToHide.switchBitmaps(true);
-
-		assertThat(layerToHide.getBitmap().getPixel(1, 1), is(Color.BLACK));
-		assertThat(layerToHide.getBitmap().getPixel(2, 1), is(Color.BLACK));
-		assertThat(layerToHide.getBitmap().getPixel(3, 1), is(Color.BLACK));
-		assertThat(layerToHide.getBitmap().getPixel(4, 1), is(Color.BLACK));
-	}
-
-	@Test
 	public void testGetLayerAt() {
 		for (int i = 0; i < layerModel.getLayerCount(); i++) {
 			assertNotNull(layerModel.getLayerAt(i));

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -60,7 +60,8 @@ import org.catrobat.paintroid.command.CommandManager.CommandListener
 import org.catrobat.paintroid.command.implementation.AsyncCommandManager
 import org.catrobat.paintroid.command.implementation.DefaultCommandFactory
 import org.catrobat.paintroid.command.implementation.DefaultCommandManager
-import org.catrobat.paintroid.command.serialization.CommandSerializationUtilities
+import org.catrobat.paintroid.command.implementation.LayerOpacityCommand
+import org.catrobat.paintroid.command.serialization.CommandSerializer
 import org.catrobat.paintroid.common.CommonFactory
 import org.catrobat.paintroid.common.PAINTROID_PICTURE_NAME
 import org.catrobat.paintroid.common.PAINTROID_PICTURE_PATH
@@ -69,6 +70,7 @@ import org.catrobat.paintroid.contract.MainActivityContracts
 import org.catrobat.paintroid.contract.MainActivityContracts.MainView
 import org.catrobat.paintroid.controller.DefaultToolController
 import org.catrobat.paintroid.iotasks.OpenRasterFileFormatConversion
+import org.catrobat.paintroid.listener.DrawerLayoutListener
 import org.catrobat.paintroid.listener.PresenterColorPickedListener
 import org.catrobat.paintroid.model.LayerModel
 import org.catrobat.paintroid.model.MainActivityModel
@@ -133,6 +135,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
     lateinit var bottomNavigationViewHolder: BottomNavigationViewHolder
     lateinit var model: MainActivityContracts.Model
 
+    private lateinit var commandSerializer: CommandSerializer
     private lateinit var layerPresenter: LayerPresenter
     private lateinit var drawingSurface: DrawingSurface
     private lateinit var presenterMain: MainActivityContracts.Presenter
@@ -220,20 +223,20 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         try {
             if (mimeType.equals("application/zip") || mimeType.equals("application/octet-stream")) {
                 try {
-                    val fileContent = workspace.getCommandSerializationHelper().readFromFile(receivedUri)
+                    val fileContent = commandSerializer.readFromFile(receivedUri)
                     commandManager.loadCommandsCatrobatImage(fileContent.commandModel)
                     presenterMain.setColorHistoryAfterLoadImage(fileContent.colorHistory)
                     return false
-                } catch (e: CommandSerializationUtilities.NotCatrobatImageException) {
+                } catch (e: CommandSerializer.NotCatrobatImageException) {
                     Log.e(TAG, "Image might be an ora file instead")
                     OpenRasterFileFormatConversion.mainActivity = this
                     OpenRasterFileFormatConversion.importOraFile(
                         myContentResolver,
                         receivedUri
-                    ).bitmapList?.let { bitmapList ->
+                    ).layerList?.let { layerList ->
                         commandManager.setInitialStateCommand(
                             commandFactory.createInitCommand(
-                                bitmapList
+                                layerList
                             )
                         )
                     }
@@ -303,7 +306,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                 presenterMain.initializeFromCleanState(picturePath, pictureName)
 
                 if (!model.isOpenedFromCatroid && presenterMain.checkForTemporaryFile() && (!isRunningEspressoTests || isTemporaryFileSavingTest)) {
-                    val workspaceReturnValue = presenterMain.openTemporaryFile(workspace)
+                    val workspaceReturnValue = presenterMain.openTemporaryFile()
                     commandManager.loadCommandsCatrobatImage(workspaceReturnValue?.commandManagerModel)
                     model.colorHistory = workspaceReturnValue?.colorHistory ?: ColorHistory()
                     model.colorHistory.colors.lastOrNull()?.let {
@@ -316,8 +319,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             else -> {
                 val isFullscreen = savedInstanceState.getBoolean(IS_FULLSCREEN_KEY, false)
                 val isSaved = savedInstanceState.getBoolean(IS_SAVED_KEY, false)
-                val isOpenedFromCatroid =
-                    savedInstanceState.getBoolean(IS_OPENED_FROM_CATROID_KEY, false)
+                val isOpenedFromCatroid = savedInstanceState.getBoolean(IS_OPENED_FROM_CATROID_KEY, false)
                 val isOpenedFromFormulaEditorInCatroid = savedInstanceState.getBoolean(
                     IS_OPENED_FROM_FORMULA_EDITOR_IN_CATROID_KEY, false
                 )
@@ -441,8 +443,9 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             layerModel,
             perspective,
             listener,
-            CommandSerializationUtilities(this, commandManager, model)
         )
+        commandSerializer = CommandSerializer(this, commandManager, model)
+        model = MainActivityModel()
         defaultToolController = DefaultToolController(
             toolReference,
             toolOptionsViewController,
@@ -473,7 +476,8 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             preferences,
             idlingResource,
             context,
-            filesDir
+            filesDir,
+            commandSerializer
         )
         FileIO.navigator = navigator
         defaultToolController.setOnColorPickedListener(PresenterColorPickedListener(presenterMain))
@@ -487,6 +491,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
 
     private fun onCreateLayerMenu() {
         val layerLayout = findViewById<NavigationView>(R.id.pocketpaint_nav_view_layer)
+        val drawerLayout = findViewById<DrawerLayout>(R.id.pocketpaint_drawer_layout)
         val layerListView = findViewById<DragAndDropListView>(R.id.pocketpaint_layer_side_nav_list)
         val layerMenuViewHolder = LayerMenuViewHolder(layerLayout)
         val layerNavigator = LayerNavigator(applicationContext)
@@ -497,7 +502,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         val layoutManager = LinearLayoutManager(applicationContext, RecyclerView.VERTICAL, false)
         layerListView.layoutManager = layoutManager
         layerListView.manager = layoutManager
-        val layerAdapter = LayerAdapter(layerPresenter, this, layerListView.listener)
+        val layerAdapter = LayerAdapter(layerPresenter, this)
         layerListView.setLayerAdapter(layerAdapter)
         presenterMain.setLayerAdapter(layerAdapter)
         layerPresenter.setAdapter(layerAdapter)
@@ -505,6 +510,8 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         layerListView.adapter = layerAdapter
         layerPresenter.refreshLayerMenuViewHolder()
         setLayerMenuListeners(layerMenuViewHolder)
+        val drawerLayoutListener = DrawerLayoutListener(this, layerPresenter)
+        drawerLayout.addDrawerListener(drawerLayoutListener)
     }
 
     private fun onCreateDrawingSurface() {
@@ -515,7 +522,8 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             toolReference,
             idlingResource,
             supportFragmentManager,
-            toolOptionsViewController
+            toolOptionsViewController,
+            drawerLayoutViewHolder
         )
         layerPresenter.setDrawingSurface(drawingSurface)
         appFragment.perspective = perspective
@@ -592,7 +600,9 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
 
     override fun commandPostExecute() {
         if (!finishing) {
-            layerPresenter.invalidate()
+            if (commandManager.lastExecutedCommand !is LayerOpacityCommand) {
+                layerPresenter.invalidate()
+            }
             presenterMain.onCommandPostExecute()
         }
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
@@ -28,6 +28,7 @@ import org.catrobat.paintroid.command.implementation.FlipCommand.FlipDirection
 import org.catrobat.paintroid.command.implementation.RotateCommand.RotateDirection
 import org.catrobat.paintroid.command.serialization.SerializablePath
 import org.catrobat.paintroid.command.serialization.SerializableTypeface
+import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.tools.ToolReference
 import org.catrobat.paintroid.tools.drawable.ShapeDrawable
 
@@ -36,13 +37,15 @@ interface CommandFactory {
 
     fun createInitCommand(bitmap: Bitmap): Command
 
-    fun createInitCommand(bitmapList: List<Bitmap?>): Command
+    fun createInitCommand(layers: List<LayerContracts.Layer>): Command
 
     fun createResetCommand(): Command
 
     fun createAddEmptyLayerCommand(): Command
 
     fun createSelectLayerCommand(position: Int): Command
+
+    fun createLayerOpacityCommand(position: Int, opacityPercentage: Int): Command
 
     fun createRemoveLayerCommand(index: Int): Command
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.kt
@@ -23,6 +23,7 @@ import org.catrobat.paintroid.model.CommandManagerModel
 interface CommandManager {
     val isUndoAvailable: Boolean
     val isRedoAvailable: Boolean
+    val lastExecutedCommand: Command?
     val isBusy: Boolean
     val commandManagerModel: CommandManagerModel?
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
@@ -41,6 +41,9 @@ open class AsyncCommandManager(
     override val isBusy: Boolean
         get() = mutex.isLocked
 
+    override val lastExecutedCommand: Command?
+        get() = commandManager.lastExecutedCommand
+
     override val commandManagerModel
         get() = commandManager.commandManagerModel
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/CropCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/CropCommand.kt
@@ -56,23 +56,11 @@ class CropCommand(
         val iterator = layerModel.listIterator(0)
         while (iterator.hasNext()) {
             val currentLayer = iterator.next()
-            if (currentLayer.isVisible) {
-                val currentBitmap = currentLayer.bitmap ?: Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-                val resizedBitmap = Bitmap.createBitmap(width, height, currentBitmap.config)
-                val resizedTransparentBitmap = Bitmap.createBitmap(width, height, currentBitmap.config)
-                val resizedCanvas = Canvas(resizedBitmap)
-                resizedCanvas.drawBitmap(currentBitmap, -resizeCoordinateXLeft.toFloat(), -resizeCoordinateYTop.toFloat(), null)
-                currentLayer.bitmap = resizedBitmap
-                currentLayer.transparentBitmap = resizedTransparentBitmap
-            } else {
-                val currentBitmap = currentLayer.transparentBitmap ?: Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-                val resizedBitmap = Bitmap.createBitmap(width, height, currentBitmap.config)
-                val resizedTransparentBitmap = Bitmap.createBitmap(width, height, currentBitmap.config)
-                val resizedCanvas = Canvas(resizedTransparentBitmap)
-                resizedCanvas.drawBitmap(currentBitmap, -resizeCoordinateXLeft.toFloat(), -resizeCoordinateYTop.toFloat(), null)
-                currentLayer.bitmap = resizedBitmap
-                currentLayer.transparentBitmap = resizedTransparentBitmap
-            }
+            val currentBitmap = currentLayer.bitmap ?: Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            val resizedBitmap = Bitmap.createBitmap(width, height, currentBitmap.config)
+            val resizedCanvas = Canvas(resizedBitmap)
+            resizedCanvas.drawBitmap(currentBitmap, -resizeCoordinateXLeft.toFloat(), -resizeCoordinateYTop.toFloat(), null)
+            currentLayer.bitmap = resizedBitmap
         }
         layerModel.height = height
         layerModel.width = width

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
@@ -32,6 +32,7 @@ import org.catrobat.paintroid.command.serialization.SerializablePath
 import org.catrobat.paintroid.command.serialization.SerializableTypeface
 import org.catrobat.paintroid.common.CommonFactory
 import org.catrobat.paintroid.tools.ToolReference
+import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.tools.drawable.ShapeDrawable
 import org.catrobat.paintroid.tools.helper.JavaFillAlgorithmFactory
 import org.catrobat.paintroid.tools.helper.toPoint
@@ -45,14 +46,15 @@ class DefaultCommandFactory : CommandFactory {
 
     override fun createInitCommand(bitmap: Bitmap): Command = CompositeCommand().apply {
         addCommand(SetDimensionCommand(bitmap.width, bitmap.height))
-        addCommand(LoadCommand(bitmap.copy(Bitmap.Config.ARGB_8888, false)))
+        addCommand(LoadCommand(bitmap))
     }
 
-    override fun createInitCommand(bitmapList: List<Bitmap?>): Command = CompositeCommand().apply {
-        bitmapList[0]?.let {
-            addCommand(SetDimensionCommand(it.width, it.height))
+    override fun createInitCommand(layers: List<LayerContracts.Layer>): Command = CompositeCommand().apply {
+        layers[0].let {
+            val bitmap = it.bitmap
+            addCommand(SetDimensionCommand(bitmap.width, bitmap.height))
         }
-        addCommand(LoadBitmapListCommand(bitmapList))
+        addCommand(LoadLayerListCommand(layers))
     }
 
     override fun createResetCommand(): Command = CompositeCommand().apply {
@@ -63,6 +65,8 @@ class DefaultCommandFactory : CommandFactory {
     override fun createAddEmptyLayerCommand(): Command = AddEmptyLayerCommand(commonFactory)
 
     override fun createSelectLayerCommand(position: Int): Command = SelectLayerCommand(position)
+
+    override fun createLayerOpacityCommand(position: Int, opacityPercentage: Int): Command = LayerOpacityCommand(position, opacityPercentage)
 
     override fun createRemoveLayerCommand(index: Int): Command = RemoveLayerCommand(index)
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
@@ -25,10 +25,9 @@ import org.catrobat.paintroid.command.CommandManager.CommandListener
 import org.catrobat.paintroid.common.CommonFactory
 import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.model.CommandManagerModel
+import java.util.Deque
 import java.util.ArrayDeque
 import java.util.Collections
-import java.util.Deque
-import kotlin.collections.ArrayList
 
 const val FIVE = 5
 
@@ -43,6 +42,9 @@ class DefaultCommandManager(
 
     override val isBusy: Boolean
         get() = false
+
+    override val lastExecutedCommand: Command?
+        get() = undoCommandList.firstOrNull()
 
     override val isUndoAvailable: Boolean
         get() = !undoCommandList.isEmpty()
@@ -188,12 +190,8 @@ class DefaultCommandManager(
 
         val currentLayer = layerModel.currentLayer
         val canvas = commonFactory.createCanvas()
-        if (currentLayer != null) {
-            if (currentLayer.isVisible) {
-                canvas.setBitmap(currentLayer.bitmap)
-            } else {
-                canvas.setBitmap(currentLayer.transparentBitmap)
-            }
+        currentLayer?.let {
+            canvas.setBitmap(it.bitmap)
         }
 
         command.run(canvas, layerModel)
@@ -388,7 +386,6 @@ class DefaultCommandManager(
                 val destinationLayer = layerModel.getLayerAt(index)
                 if (!checkBoxes[index]) {
                     destinationLayer?.let {
-                        it.switchBitmaps(false)
                         it.isVisible = false
                     }
                 }
@@ -396,7 +393,6 @@ class DefaultCommandManager(
         } else {
             val destinationLayer = layerModel.currentLayer
             if (destinationLayer != null && !checkBoxes[0]) {
-                destinationLayer.switchBitmaps(false)
                 destinationLayer.isVisible = false
             }
         }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FillCommand.kt
@@ -35,32 +35,17 @@ class FillCommand(private val fillAlgorithmFactory: FillAlgorithmFactory, clicke
     override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
         val currentLayer = layerModel.currentLayer
         currentLayer ?: return
-        if (currentLayer.isVisible) {
-            currentLayer.bitmap?.let { bitmap ->
-                val replacementColor = bitmap.getPixel(clickedPixel.x, clickedPixel.y)
-                val fillAlgorithm = fillAlgorithmFactory.createFillAlgorithm()
-                fillAlgorithm.setParameters(
-                    bitmap,
-                    clickedPixel,
-                    paint.color,
-                    replacementColor,
-                    colorTolerance
-                )
-                fillAlgorithm.performFilling()
-            }
-        } else {
-            currentLayer.transparentBitmap?.let { bitmap ->
-                val replacementColor = bitmap.getPixel(clickedPixel.x, clickedPixel.y)
-                val fillAlgorithm = fillAlgorithmFactory.createFillAlgorithm()
-                fillAlgorithm.setParameters(
-                    bitmap,
-                    clickedPixel,
-                    paint.color,
-                    replacementColor,
-                    colorTolerance
-                )
-                fillAlgorithm.performFilling()
-            }
+        currentLayer.bitmap?.let { bitmap ->
+            val replacementColor = bitmap.getPixel(clickedPixel.x, clickedPixel.y)
+            val fillAlgorithm = fillAlgorithmFactory.createFillAlgorithm()
+            fillAlgorithm.setParameters(
+                bitmap,
+                clickedPixel,
+                paint.color,
+                replacementColor,
+                colorTolerance
+            )
+            fillAlgorithm.performFilling()
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FlipCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/FlipCommand.kt
@@ -49,12 +49,6 @@ class FlipCommand(flipDirection: FlipDirection) : Command {
             bitmap.eraseColor(Color.TRANSPARENT)
             flipCanvas.drawBitmap(bitmapCopy, flipMatrix, Paint())
         }
-        layerModel.currentLayer?.transparentBitmap?.let { bitmap ->
-            val bitmapCopy = bitmap.copy(bitmap.config, bitmap.isMutable)
-            val flipCanvas = Canvas(bitmap)
-            bitmap.eraseColor(Color.TRANSPARENT)
-            flipCanvas.drawBitmap(bitmapCopy, flipMatrix, Paint())
-        }
     }
 
     override fun freeResources() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LayerOpacityCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LayerOpacityCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- * Copyright (C) 2010-2015 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -18,27 +18,18 @@
  */
 package org.catrobat.paintroid.command.implementation
 
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import org.catrobat.paintroid.command.Command
 import org.catrobat.paintroid.contract.LayerContracts
 
-class ResizeCommand(newWidth: Int, newHeight: Int) : Command {
-
-    var newWidth = newWidth; private set
-    var newHeight = newHeight; private set
+class LayerOpacityCommand(
+    val position: Int,
+    val opacityPercentage: Int
+) : Command {
 
     override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
-        val iterator = layerModel.listIterator(0)
-        while (iterator.hasNext()) {
-            val currentLayer = iterator.next()
-            currentLayer.bitmap?.let { currentBitmap ->
-                val resizedBitmap = Bitmap.createScaledBitmap(currentBitmap, newWidth, newHeight, true)
-                currentLayer.bitmap = resizedBitmap
-            }
-        }
-        layerModel.height = newHeight
-        layerModel.width = newWidth
+        val layer = layerModel.getLayerAt(position)
+        layer?.opacityPercentage = opacityPercentage
     }
 
     override fun freeResources() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadCommand.kt
@@ -25,12 +25,12 @@ import org.catrobat.paintroid.command.Command
 import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.model.Layer
 
-class LoadCommand(loadedImage: Bitmap) : Command {
+class LoadCommand(loadedBitmap: Bitmap) : Command {
 
-    var loadedImage = loadedImage; private set
+    var loadedBitmap = loadedBitmap; private set
 
     override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
-        val currentLayer = Layer(loadedImage.copy(Bitmap.Config.ARGB_8888, true))
+        val currentLayer = Layer(loadedBitmap.copy(Bitmap.Config.ARGB_8888, true))
         layerModel.addLayerAt(0, currentLayer)
         layerModel.currentLayer = currentLayer
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadLayerListCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/LoadLayerListCommand.kt
@@ -25,13 +25,14 @@ import org.catrobat.paintroid.command.Command
 import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.model.Layer
 
-class LoadBitmapListCommand(loadedImageList: List<Bitmap?>) : Command {
+class LoadLayerListCommand(loadedLayers: List<LayerContracts.Layer>) : Command {
 
-    var loadedImageList = loadedImageList; private set
+    var loadedLayers = loadedLayers; private set
 
     override fun run(canvas: Canvas, layerModel: LayerContracts.Model) {
-        loadedImageList.forEachIndexed { index, bitmap ->
-            val currentLayer = Layer(bitmap?.copy(Bitmap.Config.ARGB_8888, true))
+        loadedLayers.forEachIndexed { index, layer ->
+            val currentLayer = Layer(layer.bitmap.copy(Bitmap.Config.ARGB_8888, true))
+            currentLayer.opacityPercentage = layer.opacityPercentage
             layerModel.addLayerAt(index, currentLayer)
         }
         layerModel.currentLayer = layerModel.getLayerAt(0)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/RotateCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/RotateCommand.kt
@@ -43,20 +43,11 @@ class RotateCommand(rotateDirection: RotateDirection) : Command {
         val iterator: Iterator<LayerContracts.Layer> = layerModel.listIterator(0)
         while (iterator.hasNext()) {
             val currentLayer = iterator.next()
-            currentLayer.bitmap?.let {
-                val rotatedBitmap = Bitmap.createBitmap(
-                    it, 0, 0,
-                    layerModel.width, layerModel.height, rotateMatrix, true
-                )
-                currentLayer.bitmap = rotatedBitmap
-            }
-            currentLayer.transparentBitmap?.let {
-                val rotatedBitmap = Bitmap.createBitmap(
-                    it, 0, 0,
-                    layerModel.width, layerModel.height, rotateMatrix, true
-                )
-                currentLayer.transparentBitmap = rotatedBitmap
-            }
+            val rotatedBitmap = Bitmap.createBitmap(
+                currentLayer.bitmap, 0, 0,
+                layerModel.width, layerModel.height, rotateMatrix, true
+            )
+            currentLayer.bitmap = rotatedBitmap
         }
         val tmpWidth = layerModel.width
         layerModel.width = layerModel.height

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
@@ -48,7 +48,8 @@ import org.catrobat.paintroid.command.implementation.CutCommand
 import org.catrobat.paintroid.command.implementation.FillCommand
 import org.catrobat.paintroid.command.implementation.FlipCommand
 import org.catrobat.paintroid.command.implementation.GeometricFillCommand
-import org.catrobat.paintroid.command.implementation.LoadBitmapListCommand
+import org.catrobat.paintroid.command.implementation.LayerOpacityCommand
+import org.catrobat.paintroid.command.implementation.LoadLayerListCommand
 import org.catrobat.paintroid.command.implementation.LoadCommand
 import org.catrobat.paintroid.command.implementation.MergeLayersCommand
 import org.catrobat.paintroid.command.implementation.PathCommand
@@ -81,7 +82,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.OutputStream
 
-class CommandSerializationUtilities(private val activityContext: Context, private val commandManager: CommandManager, private val model: MainActivityContracts.Model) {
+open class CommandSerializer(private val activityContext: Context, private val commandManager: CommandManager, private val model: MainActivityContracts.Model) {
 
     companion object {
         const val CURRENT_IMAGE_VERSION = 1
@@ -131,7 +132,7 @@ class CommandSerializationUtilities(private val activityContext: Context, privat
             put(SerializablePath.Line::class.java, SerializablePath.PathActionLineSerializer(version))
             put(SerializablePath.Quad::class.java, SerializablePath.PathActionQuadSerializer(version))
             put(SerializablePath.Rewind::class.java, SerializablePath.PathActionRewindSerializer(version))
-            put(LoadBitmapListCommand::class.java, LoadBitmapListCommandSerializer(version))
+            put(LoadLayerListCommand::class.java, LoadLayerListCommandSerializer(version))
             put(GeometricFillCommand::class.java, GeometricFillCommandSerializer(version))
             put(HeartDrawable::class.java, GeometricFillCommandSerializer.HeartDrawableSerializer(version))
             put(OvalDrawable::class.java, GeometricFillCommandSerializer.OvalDrawableSerializer(version))
@@ -147,6 +148,7 @@ class CommandSerializationUtilities(private val activityContext: Context, privat
             put(SmudgePathCommand::class.java, SmudgePathCommandSerializer(version))
             put(ColorHistory::class.java, ColorHistorySerializer(version))
             put(ClippingCommand::class.java, ClippingCommandSerializer(version))
+            put(LayerOpacityCommand::class.java, LayerOpacityCommandSerializer(version))
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/LayerOpacityCommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/LayerOpacityCommandSerializer.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -18,28 +18,27 @@
  */
 package org.catrobat.paintroid.command.serialization
 
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
-import org.catrobat.paintroid.command.implementation.LoadCommand
+import org.catrobat.paintroid.command.implementation.LayerOpacityCommand
 
-class LoadCommandSerializer(version: Int) : VersionSerializer<LoadCommand>(version) {
-
-    companion object {
-        private const val COMPRESSION_QUALITY = 100
+class LayerOpacityCommandSerializer(version: Int) : VersionSerializer<LayerOpacityCommand>(version) {
+    override fun write(kryo: Kryo, output: Output, command: LayerOpacityCommand) {
+        with(output) {
+            writeInt(command.position)
+            writeInt(command.opacityPercentage)
+        }
     }
 
-    override fun write(kryo: Kryo, output: Output, command: LoadCommand) {
-        command.loadedBitmap.compress(Bitmap.CompressFormat.PNG, COMPRESSION_QUALITY, output)
-    }
-
-    override fun read(kryo: Kryo, input: Input, type: Class<out LoadCommand>): LoadCommand =
+    override fun read(kryo: Kryo, input: Input, type: Class<out LayerOpacityCommand>): LayerOpacityCommand =
         super.handleVersions(this, kryo, input, type)
 
-    override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out LoadCommand>): LoadCommand {
-        val bitmap = BitmapFactory.decodeStream(input)
-        return LoadCommand(bitmap)
+    override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out LayerOpacityCommand>): LayerOpacityCommand {
+        return with(input) {
+            val position = readInt()
+            val opacityPercentage = readInt()
+            LayerOpacityCommand(position, opacityPercentage)
+        }
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
@@ -37,11 +37,9 @@ interface LayerContracts {
         val layerCount: Int
         val presenter: Presenter
 
-        fun onBindLayerViewHolderAtPosition(
-            position: Int,
-            viewHolder: LayerViewHolder,
-            isOpen: Boolean
-        )
+        fun onSelectedLayerInvisible()
+
+        fun onSelectedLayerVisible()
 
         fun getListItemDragHandler(): ListItemDragHandler
 
@@ -55,9 +53,11 @@ interface LayerContracts {
 
         fun removeLayer()
 
-        fun hideLayer(position: Int)
+        fun changeLayerOpacity(position: Int, opacityPercentage: Int)
 
-        fun unhideLayer(position: Int, viewHolder: LayerViewHolder)
+        fun setLayerVisibility(position: Int, isVisible: Boolean)
+
+        fun refreshDrawingSurface()
 
         fun setAdapter(layerAdapter: Adapter)
 
@@ -74,27 +74,25 @@ interface LayerContracts {
         fun onStartDragging(position: Int, view: View)
 
         fun onStopDragging()
+
+        fun setLayerSelected(position: Int)
+
+        fun getSelectedLayer(): Layer?
     }
 
     interface LayerViewHolder {
         val bitmap: Bitmap?
         val view: View
 
-        fun setSelected(
-            position: Int,
-            bottomNavigationViewHolder: BottomNavigationViewHolder?,
-            defaultToolController: DefaultToolController?
-        )
+        fun setSelected(isSelected: Boolean)
 
-        fun setSelected()
-
-        fun setDeselected()
-
-        fun updateImageView(bitmap: Bitmap?)
+        fun updateImageView(layer: Layer)
 
         fun setMergable()
 
         fun isSelected(): Boolean
+
+        fun bindView()
 
         fun setLayerVisibilityCheckbox(setTo: Boolean)
     }
@@ -112,11 +110,11 @@ interface LayerContracts {
     }
 
     interface Layer {
-        var bitmap: Bitmap?
-        var transparentBitmap: Bitmap?
+        var bitmap: Bitmap
         var isVisible: Boolean
+        var opacityPercentage: Int
 
-        fun switchBitmaps(isUnhide: Boolean)
+        fun getValueForOpacityPercentage(): Int
     }
 
     interface Model {
@@ -139,6 +137,10 @@ interface LayerContracts {
         fun setLayerAt(position: Int, layer: Layer)
 
         fun removeLayerAt(position: Int): Boolean
+
+        fun getBitmapOfAllLayers(): Bitmap?
+
+        fun getBitmapListOfAllLayers(): List<Bitmap?>
     }
 
     interface Navigator {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/MainActivityContracts.kt
@@ -27,6 +27,7 @@ import android.util.DisplayMetrics
 import android.view.Menu
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
+import org.catrobat.paintroid.command.serialization.CommandSerializer
 import org.catrobat.paintroid.colorpicker.ColorHistory
 import org.catrobat.paintroid.common.MainActivityConstants.ActivityRequestCode
 import org.catrobat.paintroid.dialog.PermissionInfoDialog.PermissionType
@@ -35,7 +36,6 @@ import org.catrobat.paintroid.iotasks.LoadImage.LoadImageCallback
 import org.catrobat.paintroid.iotasks.SaveImage.SaveImageCallback
 import org.catrobat.paintroid.iotasks.WorkspaceReturnValue
 import org.catrobat.paintroid.tools.ToolType
-import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.ui.LayerAdapter
 import java.io.File
 
@@ -297,7 +297,7 @@ interface MainActivityContracts {
 
         fun saveNewTemporaryImage()
 
-        fun openTemporaryFile(workspace: Workspace): WorkspaceReturnValue?
+        fun openTemporaryFile(): WorkspaceReturnValue?
 
         fun checkForTemporaryFile(): Boolean
 
@@ -322,7 +322,8 @@ interface MainActivityContracts {
         fun saveCopy(
             callback: SaveImageCallback,
             requestCode: Int,
-            workspace: Workspace,
+            layerModel: LayerContracts.Model,
+            commandSerializer: CommandSerializer,
             uri: Uri?,
             context: Context
         )
@@ -332,7 +333,8 @@ interface MainActivityContracts {
         fun saveImage(
             callback: SaveImageCallback,
             requestCode: Int,
-            workspace: Workspace,
+            layerModel: LayerContracts.Model,
+            commandSerializer: CommandSerializer,
             uri: Uri?,
             context: Context
         )
@@ -343,7 +345,7 @@ interface MainActivityContracts {
             uri: Uri?,
             context: Context,
             scaling: Boolean,
-            workspace: Workspace
+            commandSerializer: CommandSerializer,
         )
     }
 
@@ -373,6 +375,8 @@ interface MainActivityContracts {
         fun closeDrawer(gravity: Int, animate: Boolean)
 
         fun isDrawerOpen(gravity: Int): Boolean
+
+        fun isDrawerVisible(gravity: Int): Boolean
 
         fun openDrawer(gravity: Int)
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/BitmapReturnValue.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/BitmapReturnValue.kt
@@ -19,6 +19,7 @@
 package org.catrobat.paintroid.iotasks
 
 import android.graphics.Bitmap
+import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.colorpicker.ColorHistory
 import org.catrobat.paintroid.model.CommandManagerModel
 
@@ -26,7 +27,7 @@ data class BitmapReturnValue(
     @JvmField
     var model: CommandManagerModel?,
     @JvmField
-    var bitmapList: List<Bitmap?>?,
+    var layerList: List<LayerContracts.Layer>?,
     @JvmField
     var bitmap: Bitmap?,
     @JvmField
@@ -34,7 +35,7 @@ data class BitmapReturnValue(
     @JvmField
     var colorHistory: ColorHistory?
 ) {
-    constructor(bitmapList: List<Bitmap?>?, bitmap: Bitmap?, toBeScaled: Boolean) : this(
+    constructor(bitmapList: List<LayerContracts.Layer>?, bitmap: Bitmap?, toBeScaled: Boolean) : this(
         null,
         bitmapList,
         bitmap,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/LoadImage.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/iotasks/LoadImage.kt
@@ -32,8 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.catrobat.paintroid.FileIO
-import org.catrobat.paintroid.command.serialization.CommandSerializationUtilities
-import org.catrobat.paintroid.tools.Workspace
+import org.catrobat.paintroid.command.serialization.CommandSerializer
 
 class LoadImage(
     callback: LoadImageCallback,
@@ -41,7 +40,7 @@ class LoadImage(
     private val uri: Uri?,
     context: Context,
     private val scaleImage: Boolean,
-    private val workspace: Workspace,
+    private val commandSerializer: CommandSerializer,
     private val scopeIO: CoroutineScope,
     private val idlingResource: CountingIdlingResource
 ) {
@@ -64,9 +63,9 @@ class LoadImage(
         val mimeType: String? = getMimeType(uri, resolver)
         return if (mimeType == "application/zip" || mimeType == "application/octet-stream") {
             try {
-                val fileContent = workspace.getCommandSerializationHelper().readFromFile(uri)
+                val fileContent = commandSerializer.readFromFile(uri)
                 BitmapReturnValue(fileContent.commandModel, fileContent.colorHistory)
-            } catch (e: CommandSerializationUtilities.NotCatrobatImageException) {
+            } catch (e: CommandSerializer.NotCatrobatImageException) {
                 Log.e(TAG, "Image might be an ora file instead")
                 OpenRasterFileFormatConversion.importOraFile(
                     resolver,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawerLayoutListener.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawerLayoutListener.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,21 +16,26 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.paintroid.ui.viewholder
+package org.catrobat.paintroid.listener
 
+import android.view.View
 import androidx.drawerlayout.widget.DrawerLayout
-import org.catrobat.paintroid.contract.MainActivityContracts
+import org.catrobat.paintroid.MainActivity
+import org.catrobat.paintroid.presenter.LayerPresenter
 
-class DrawerLayoutViewHolder(private val drawerLayout: DrawerLayout) : MainActivityContracts.DrawerLayoutViewHolder {
-    override fun closeDrawer(gravity: Int, animate: Boolean) {
-        drawerLayout.closeDrawer(gravity, animate)
+class DrawerLayoutListener(
+    private val activity: MainActivity,
+    private val layerPresenter: LayerPresenter
+) : DrawerLayout.DrawerListener {
+    override fun onDrawerSlide(drawerView: View, slideOffset: Float) {
+        activity.hideKeyboard()
     }
 
-    override fun isDrawerOpen(gravity: Int): Boolean = drawerLayout.isDrawerOpen(gravity)
-
-    override fun isDrawerVisible(gravity: Int): Boolean = drawerLayout.isDrawerVisible(gravity)
-
-    override fun openDrawer(gravity: Int) {
-        drawerLayout.openDrawer(gravity)
+    override fun onDrawerClosed(drawerView: View) {
+        layerPresenter.invalidate()
     }
+
+    override fun onDrawerOpened(drawerView: View) = Unit
+
+    override fun onDrawerStateChanged(newState: Int) = Unit
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/Layer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/Layer.kt
@@ -19,25 +19,14 @@
 package org.catrobat.paintroid.model
 
 import android.graphics.Bitmap
-import android.graphics.Color
 import org.catrobat.paintroid.contract.LayerContracts
 
-open class Layer(override var bitmap: Bitmap?) : LayerContracts.Layer {
-    override var transparentBitmap: Bitmap? = null
+const val MAX_LAYER_OPACITY_PERCENTAGE = 100
+const val MAX_LAYER_OPACITY_VALUE = 255
+
+open class Layer(override var bitmap: Bitmap) : LayerContracts.Layer {
     override var isVisible: Boolean = true
+    override var opacityPercentage: Int = MAX_LAYER_OPACITY_PERCENTAGE
 
-    init {
-        bitmap?.apply {
-            transparentBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-        }
-    }
-
-    override fun switchBitmaps(isUnhide: Boolean) {
-        val tmpBitmap = transparentBitmap?.apply { copy(config, isMutable) }
-        transparentBitmap = bitmap
-        bitmap = tmpBitmap
-        if (isUnhide) {
-            transparentBitmap?.eraseColor(Color.TRANSPARENT)
-        }
-    }
+    override fun getValueForOpacityPercentage(): Int = (opacityPercentage.toFloat() / MAX_LAYER_OPACITY_PERCENTAGE * MAX_LAYER_OPACITY_VALUE).toInt()
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
@@ -124,24 +124,15 @@ class LayerPresenter(
         this.bottomNavigationViewHolder = bottomNavigationViewHolder
     }
 
-    override fun onBindLayerViewHolderAtPosition(
-        position: Int,
-        viewHolder: LayerContracts.LayerViewHolder,
-        isOpen: Boolean
-    ) {
-        val layer = getLayerItem(position)
-        if (layer === model.currentLayer) {
-            viewHolder.setSelected(position, bottomNavigationViewHolder, defaultToolController)
-        } else {
-            viewHolder.setDeselected()
-        }
-        if (!layers[position].isVisible) {
-            viewHolder.updateImageView(layer.transparentBitmap)
-            viewHolder.setLayerVisibilityCheckbox(false)
-        } else {
-            viewHolder.updateImageView(layer.bitmap)
-            viewHolder.setLayerVisibilityCheckbox(true)
-        }
+    override fun onSelectedLayerInvisible() {
+        defaultToolController?.hideToolOptionsView()
+        defaultToolController?.switchTool(ToolType.HAND)
+        bottomNavigationViewHolder?.showCurrentTool(ToolType.HAND)
+    }
+
+    override fun onSelectedLayerVisible() {
+        defaultToolController?.switchTool(ToolType.BRUSH)
+        bottomNavigationViewHolder?.showCurrentTool(ToolType.BRUSH)
     }
 
     override fun refreshLayerMenuViewHolder() {
@@ -191,34 +182,49 @@ class LayerPresenter(
 
     private fun getDestinationLayer(
         position: Int,
-        isUnhide: Boolean
+        isVisible: Boolean
     ): LayerContracts.Layer? = model.getLayerAt(position)?.apply {
-        if (isUnhide) switchBitmaps(isUnhide)
-        val newBitmap = if (!isUnhide) transparentBitmap else bitmap
-        if (!isUnhide) switchBitmaps(isUnhide)
-        bitmap = newBitmap
-        isVisible = isUnhide
+        this.isVisible = isVisible
     }
 
-    override fun hideLayer(position: Int) {
-        drawingSurface?.refreshDrawingSurface()
-        getDestinationLayer(position, false)?.let { layer ->
-            if (model.currentLayer == layer) {
-                defaultToolController?.switchTool(ToolType.HAND)
-                bottomNavigationViewHolder?.showCurrentTool(ToolType.HAND)
+    override fun getSelectedLayer(): LayerContracts.Layer? = model.currentLayer
+
+    override fun setLayerSelected(position: Int) {
+        if (!isPositionValid(position)) {
+            Log.e(TAG, "onClickLayerAtPosition at invalid position")
+            return
+        }
+        if (position != model.currentLayer?.let { model.getLayerIndexOf(it) }) {
+            checkIfLineToolInUse()
+            commandManager.addCommand(commandFactory.createSelectLayerCommand(position))
+        }
+    }
+
+    override fun changeLayerOpacity(position: Int, opacityPercentage: Int) {
+        if (!isPositionValid(position)) {
+            Log.e(TAG, "invalid layer position to change opacity")
+            return
+        }
+
+        commandManager.addCommand(commandFactory.createLayerOpacityCommand(position, opacityPercentage))
+    }
+
+    override fun setLayerVisibility(position: Int, isVisible: Boolean) {
+        refreshDrawingSurface()
+        getDestinationLayer(position, isVisible)?.let { layer ->
+            layer.isVisible = isVisible
+            if (model.currentLayer === layer) {
+                if (isVisible) {
+                    onSelectedLayerVisible()
+                } else {
+                    onSelectedLayerInvisible()
+                }
             }
         }
     }
 
-    override fun unhideLayer(position: Int, viewHolder: LayerContracts.LayerViewHolder) {
+    override fun refreshDrawingSurface() {
         drawingSurface?.refreshDrawingSurface()
-        getDestinationLayer(position, true)?.let { layer ->
-            viewHolder.updateImageView(layer.bitmap)
-            if (model.currentLayer == layer) {
-                defaultToolController?.switchTool(ToolType.BRUSH)
-                bottomNavigationViewHolder?.showCurrentTool(ToolType.BRUSH)
-            }
-        }
     }
 
     override fun swapItemsVisually(position: Int, swapWith: Int): Int {
@@ -281,18 +287,6 @@ class LayerPresenter(
         }
     }
 
-    override fun onClickLayerAtPosition(position: Int, view: View) {
-        if (!isPositionValid(position)) {
-            Log.e(TAG, "onClickLayerAtPosition at invalid position")
-            return
-        }
-        if (position != model.currentLayer?.let { model.getLayerIndexOf(it) }) {
-            checkIfLineToolInUse()
-            commandManager.addCommand(commandFactory.createSelectLayerCommand(position))
-            checkIfClippingToolInUse()
-        }
-    }
-
     override fun invalidate() {
         synchronized(model) {
             layers.clear()
@@ -304,11 +298,10 @@ class LayerPresenter(
     }
 
     fun resetMergeColor(layerPosition: Int) {
-        if (adapter != null && adapter?.getViewHolderAt(layerPosition) != null) {
-            if (adapter?.getViewHolderAt(layerPosition)?.isSelected() == true) {
-                adapter?.getViewHolderAt(layerPosition)?.setSelected()
-            } else {
-                adapter?.getViewHolderAt(layerPosition)?.setDeselected()
+        adapter?.let { adapter ->
+            adapter.getViewHolderAt(layerPosition)?.let { layerViewHolder ->
+                val isSelected = layerViewHolder.isSelected()
+                adapter.getViewHolderAt(layerPosition)?.setSelected(isSelected)
             }
         }
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Workspace.kt
@@ -21,7 +21,7 @@ package org.catrobat.paintroid.tools
 import android.graphics.Bitmap
 import android.graphics.PointF
 import android.graphics.RectF
-import org.catrobat.paintroid.command.serialization.CommandSerializationUtilities
+import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.ui.Perspective
 
 interface Workspace {
@@ -30,12 +30,13 @@ interface Workspace {
     val surfaceWidth: Int
     val surfaceHeight: Int
     val bitmapOfAllLayers: Bitmap?
-    val bitmapLisOfAllLayers: List<Bitmap?>
+    val bitmapListOfAllLayers: List<Bitmap?>
     var bitmapOfCurrentLayer: Bitmap?
     val currentLayerIndex: Int
     val scaleForCenterBitmap: Float
     var scale: Float
     var perspective: Perspective
+    val layerModel: LayerContracts.Model
 
     fun contains(point: PointF): Boolean
 
@@ -48,6 +49,4 @@ interface Workspace {
     fun getCanvasPointFromSurfacePoint(surfacePoint: PointF): PointF
 
     fun invalidate()
-
-    fun getCommandSerializationHelper(): CommandSerializationUtilities
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -382,7 +382,14 @@ abstract class BaseToolWithRectangleShape(
         drawingBitmap?.let {
             tempDrawingRectangle.set(-boxWidth / 2, -boxHeight / 2, boxWidth / 2, boxHeight / 2)
             canvas.clipRect(tempDrawingRectangle)
-            canvas.drawBitmap(it, null, tempDrawingRectangle, null)
+
+            val alphaPaint = Paint().apply {
+                workspace.layerModel.currentLayer?.let { layer ->
+                    alpha = layer.getValueForOpacityPercentage()
+                }
+            }
+
+            canvas.drawBitmap(it, null, tempDrawingRectangle, alphaPaint)
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultWorkspace.kt
@@ -21,17 +21,14 @@ package org.catrobat.paintroid.tools.implementation
 import android.graphics.Bitmap
 import android.graphics.PointF
 import android.graphics.RectF
-import org.catrobat.paintroid.command.serialization.CommandSerializationUtilities
 import org.catrobat.paintroid.contract.LayerContracts
-import org.catrobat.paintroid.model.LayerModel
 import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.ui.Perspective
 
 class DefaultWorkspace(
-    private val layerModel: LayerContracts.Model,
+    override val layerModel: LayerContracts.Model,
     override var perspective: Perspective,
-    private val listener: Listener,
-    private val serializationHelper: CommandSerializationUtilities
+    private val listener: Listener
 ) : Workspace {
     override val height: Int
         get() = layerModel.height
@@ -46,10 +43,10 @@ class DefaultWorkspace(
         get() = perspective.surfaceHeight
 
     override val bitmapOfAllLayers: Bitmap?
-        get() = LayerModel.getBitmapOfAllLayersToSave(layerModel.layers)
+        get() = layerModel.getBitmapOfAllLayers()
 
-    override val bitmapLisOfAllLayers: List<Bitmap?>
-        get() = LayerModel.getBitmapListOfAllLayers(layerModel.layers)
+    override val bitmapListOfAllLayers: List<Bitmap?>
+        get() = layerModel.getBitmapListOfAllLayers()
 
     override var bitmapOfCurrentLayer: Bitmap? = null
         get() = layerModel.currentLayer?.bitmap?.let { Bitmap.createBitmap(it) }
@@ -76,9 +73,6 @@ class DefaultWorkspace(
         perspective.setBitmapDimensions(width, height)
         perspective.resetScaleAndTranslation()
     }
-
-    override fun getCommandSerializationHelper(): CommandSerializationUtilities =
-        serializationHelper
 
     override fun getCanvasPointFromSurfacePoint(surfacePoint: PointF): PointF =
         perspective.getCanvasPointFromSurfacePoint(surfacePoint)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -20,6 +20,10 @@ package org.catrobat.paintroid.ui
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.text.Editable
+import android.text.InputFilter
+import android.text.TextWatcher
+import android.util.Log
 import android.util.SparseArray
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -28,25 +32,27 @@ import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.LinearLayout
-import androidx.appcompat.widget.AppCompatImageView
+import android.widget.SeekBar
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.catrobat.paintroid.MainActivity
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.contract.LayerContracts
-import org.catrobat.paintroid.controller.DefaultToolController
-import org.catrobat.paintroid.tools.ToolType
-import org.catrobat.paintroid.ui.dragndrop.DragAndDropListView
-import org.catrobat.paintroid.ui.viewholder.BottomNavigationViewHolder
+import org.catrobat.paintroid.model.MAX_LAYER_OPACITY_PERCENTAGE
+import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter
+
+private const val MIN_VAL = 0
+private const val MAX_VAL = 100
 
 private const val RESIZE_LENGTH = 400f
 
 class LayerAdapter(
     val presenter: LayerContracts.Presenter,
     val mainActivity: MainActivity,
-    var listener: DragAndDropListView.OnItemClickListener
 ) : RecyclerView.Adapter<LayerAdapter.LayerViewHolder>(), LayerContracts.Adapter {
+    private val viewHolders: SparseArray<LayerContracts.LayerViewHolder> = SparseArray()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LayerViewHolder {
         val itemView = LayoutInflater.from(parent.context)
@@ -56,12 +62,10 @@ class LayerAdapter(
 
     override fun onBindViewHolder(holder: LayerViewHolder, position: Int) {
         viewHolders.put(position, holder)
-        presenter.onBindLayerViewHolderAtPosition(position, holder, presenter.isShown())
+        holder.bindView()
     }
 
     override fun getItemCount(): Int = presenter.layerCount
-
-    val viewHolders: SparseArray<LayerContracts.LayerViewHolder> = SparseArray()
 
     fun clearViewHolders() {
         viewHolders.clear()
@@ -73,41 +77,14 @@ class LayerAdapter(
         itemView: View,
         private val layerPresenter: LayerContracts.Presenter
     ) : LayerContracts.LayerViewHolder, RecyclerView.ViewHolder(itemView) {
-        private val layerBackground: LinearLayout = itemView.findViewById(R.id.pocketpaint_item_layer_background)
+        private val layerBackground: LinearLayout = itemView.findViewById(R.id.pocketpaint_item_layer)
         private val imageView: ImageView = itemView.findViewById(R.id.pocketpaint_item_layer_image)
+        private val dragHandle: ImageView = itemView.findViewById(R.id.pocketpaint_layer_drag_handle)
+        private val opacitySeekBar: SeekBar = itemView.findViewById(R.id.pocketpaint_layer_opacity_seekbar)
+        private val opacityEditText: AppCompatEditText = itemView.findViewById(R.id.pocketpaint_layer_opacity_value)
         private var currentBitmap: Bitmap? = null
         private val layerVisibilityCheckbox: CheckBox = itemView.findViewById(R.id.pocketpaint_checkbox_layer)
         private var isSelected = false
-
-        init {
-            this.view.setOnClickListener {
-                listener.onItemClick(adapterPosition, imageView)
-            }
-
-            val checkBox = itemView.findViewById<CheckBox>(R.id.pocketpaint_checkbox_layer)
-            checkBox?.setOnClickListener {
-                with(presenter) {
-                    if (checkBox.isChecked) {
-                        unhideLayer(adapterPosition, viewHolders.get(adapterPosition))
-                        getLayerItem(adapterPosition).isVisible = true
-                    } else {
-                        hideLayer(adapterPosition)
-                        getLayerItem(adapterPosition).isVisible = false
-                    }
-                }
-            }
-            val dragHandle =
-                itemView.findViewById<AppCompatImageView>(R.id.pocketpaint_layer_drag_handle)
-            dragHandle?.setOnTouchListener { _, event ->
-                when (event.action) {
-                    MotionEvent.ACTION_DOWN -> view.let {
-                        presenter.onStartDragging(adapterPosition, it)
-                    }
-                    MotionEvent.ACTION_UP -> presenter.onStopDragging()
-                }
-                true
-            }
-        }
 
         override val bitmap: Bitmap?
             get() = currentBitmap
@@ -115,35 +92,97 @@ class LayerAdapter(
         override val view: View
             get() = itemView
 
-        override fun setSelected(
-            position: Int,
-            bottomNavigationViewHolder: BottomNavigationViewHolder?,
-            defaultToolController: DefaultToolController?
-        ) {
-            if (!layerPresenter.getLayerItem(position).isVisible) {
-                defaultToolController?.switchTool(ToolType.HAND)
-                bottomNavigationViewHolder?.showCurrentTool(ToolType.HAND)
+        override fun bindView() {
+            val layer = layerPresenter.getLayerItem(position)
+            val isSelected = layer === layerPresenter.getSelectedLayer()
+            setSelected(isSelected)
+            setLayerVisibilityCheckbox(layer.isVisible)
+            updateImageView(layer)
+
+            layerVisibilityCheckbox.setOnClickListener {
+                val isVisible = layerVisibilityCheckbox.isChecked
+                layerPresenter.setLayerVisibility(position, isVisible)
             }
-            layerBackground.setBackgroundColor(Color.BLUE)
-            isSelected = true
+
+            layerBackground.setOnClickListener {
+                layerPresenter.setLayerSelected(position)
+            }
+
+            dragHandle.setOnTouchListener { _, event ->
+                when (event.action) {
+                    MotionEvent.ACTION_DOWN -> layerPresenter.onStartDragging(position, itemView)
+                    MotionEvent.ACTION_UP -> layerPresenter.onStopDragging()
+                }
+
+                true
+            }
+
+            opacitySeekBar.progress = layerPresenter.getLayerItem(position).opacityPercentage
+            opacityEditText.filters = arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
+            opacityEditText.setText(layerPresenter.getLayerItem(position).opacityPercentage.toString())
+            opacityEditText.addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+
+                override fun afterTextChanged(s: Editable?) {
+                    val opacityText = s.toString()
+                    val opacityPercentage: Int = try {
+                        opacityText.toInt()
+                    } catch (exp: NumberFormatException) {
+                        exp.localizedMessage?.let {
+                            Log.d(TAG, it)
+                        }
+                        MAX_VAL
+                    }
+
+                    if (opacityPercentage != opacitySeekBar.progress) {
+                        opacitySeekBar.progress = opacityPercentage
+                        layerPresenter.changeLayerOpacity(position, opacityPercentage)
+                    }
+
+                    layerPresenter.getLayerItem(position).opacityPercentage = opacityPercentage
+                    layerPresenter.refreshDrawingSurface()
+                }
+            })
+
+            opacitySeekBar.setOnTouchListener { view, _ ->
+                view.parent.requestDisallowInterceptTouchEvent(true)
+                false
+            }
+
+            opacitySeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                    if (fromUser) {
+                        opacityEditText.setText(progress.toString())
+                    }
+
+                    imageView.alpha = progress.toFloat() / MAX_LAYER_OPACITY_PERCENTAGE
+                }
+
+                override fun onStopTrackingTouch(seekBar: SeekBar) {
+                    layerPresenter.changeLayerOpacity(position, seekBar.progress)
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
+            })
         }
 
-        override fun setSelected() {
-            layerBackground.setBackgroundColor(Color.BLUE)
-            isSelected = true
+        override fun setSelected(isSelected: Boolean) {
+            if (isSelected) {
+                layerBackground.setBackgroundColor(Color.BLUE)
+            } else {
+                layerBackground.setBackgroundResource(R.color.pocketpaint_colorPrimary)
+            }
+            this.isSelected = isSelected
         }
 
-        override fun setDeselected() {
-            layerBackground.setBackgroundResource(R.color.pocketpaint_colorPrimary)
-            isSelected = false
-        }
+        override fun isSelected(): Boolean = isSelected
 
-        override fun isSelected() = isSelected
-
-        override fun updateImageView(bitmap: Bitmap?) {
+        override fun updateImageView(layer: LayerContracts.Layer) {
             runBlocking {
                 launch {
-                    imageView.setImageBitmap(bitmap?.let { resizeBitmap(it) })
+                    imageView.setImageBitmap(resizeBitmap(layer.bitmap))
+                    imageView.alpha = layer.opacityPercentage.toFloat() / MAX_LAYER_OPACITY_PERCENTAGE
                 }
             }
             currentBitmap = bitmap
@@ -167,5 +206,9 @@ class LayerAdapter(
         }
 
         override fun setMergable() = layerBackground.setBackgroundResource(R.color.pocketpaint_color_merge_layer)
+    }
+
+    companion object {
+        private val TAG = LayerAdapter::class.java.simpleName
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/MainActivityInteractor.kt
@@ -23,6 +23,8 @@ import android.net.Uri
 import androidx.test.espresso.idling.CountingIdlingResource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import org.catrobat.paintroid.command.serialization.CommandSerializer
+import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.contract.MainActivityContracts.Interactor
 import org.catrobat.paintroid.iotasks.CreateFile
 import org.catrobat.paintroid.iotasks.CreateFile.CreateFileCallback
@@ -30,7 +32,6 @@ import org.catrobat.paintroid.iotasks.LoadImage
 import org.catrobat.paintroid.iotasks.LoadImage.LoadImageCallback
 import org.catrobat.paintroid.iotasks.SaveImage
 import org.catrobat.paintroid.iotasks.SaveImage.SaveImageCallback
-import org.catrobat.paintroid.tools.Workspace
 
 class MainActivityInteractor(private val idlingResource: CountingIdlingResource) : Interactor {
     private val scopeIO = CoroutineScope(Dispatchers.IO)
@@ -38,11 +39,12 @@ class MainActivityInteractor(private val idlingResource: CountingIdlingResource)
     override fun saveCopy(
         callback: SaveImageCallback,
         requestCode: Int,
-        workspace: Workspace,
+        layerModel: LayerContracts.Model,
+        commandSerializer: CommandSerializer,
         uri: Uri?,
         context: Context
     ) {
-        SaveImage(callback, requestCode, workspace, uri, true, context, scopeIO, idlingResource).execute()
+        SaveImage(callback, requestCode, layerModel, commandSerializer, uri, true, context, scopeIO, idlingResource).execute()
     }
 
     override fun createFile(callback: CreateFileCallback, requestCode: Int, filename: String) {
@@ -52,11 +54,12 @@ class MainActivityInteractor(private val idlingResource: CountingIdlingResource)
     override fun saveImage(
         callback: SaveImageCallback,
         requestCode: Int,
-        workspace: Workspace,
+        layerModel: LayerContracts.Model,
+        commandSerializer: CommandSerializer,
         uri: Uri?,
         context: Context
     ) {
-        SaveImage(callback, requestCode, workspace, uri, false, context, scopeIO, idlingResource).execute()
+        SaveImage(callback, requestCode, layerModel, commandSerializer, uri, false, context, scopeIO, idlingResource).execute()
     }
 
     override fun loadFile(
@@ -65,8 +68,8 @@ class MainActivityInteractor(private val idlingResource: CountingIdlingResource)
         uri: Uri?,
         context: Context,
         scaling: Boolean,
-        workspace: Workspace
+        commandSerializer: CommandSerializer,
     ) {
-        LoadImage(callback, requestCode, uri, context, scaling, workspace, scopeIO, idlingResource).execute()
+        LoadImage(callback, requestCode, uri, context, scaling, commandSerializer, scopeIO, idlingResource).execute()
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropListView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropListView.kt
@@ -57,11 +57,6 @@ class DragAndDropListView : RecyclerView, ListItemDragHandler {
     private var scrollAmount = 0
     private lateinit var layerAdapter: LayerAdapter
     internal lateinit var manager: LinearLayoutManager
-    internal var listener: OnItemClickListener
-
-    interface OnItemClickListener {
-        fun onItemClick(position: Int, view: View)
-    }
 
     constructor(context: Context) : super(context)
 
@@ -74,12 +69,6 @@ class DragAndDropListView : RecyclerView, ListItemDragHandler {
     )
 
     init {
-        listener = object :
-            OnItemClickListener {
-            override fun onItemClick(position: Int, view: View) {
-                presenter?.onClickLayerAtPosition(position, view)
-            }
-        }
         setHasFixedSize(true)
         adapter?.setHasStableIds(true)
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/dragndrop/DragAndDropPresenter.kt
@@ -22,8 +22,6 @@
  */
 package org.catrobat.paintroid.ui.dragndrop
 
-import android.view.View
-
 interface DragAndDropPresenter {
     fun swapItemsVisually(position: Int, swapWith: Int): Int
 
@@ -32,6 +30,4 @@ interface DragAndDropPresenter {
     fun reorderItems(position: Int, swapWith: Int)
 
     fun markMergeable(position: Int, mergeWith: Int)
-
-    fun onClickLayerAtPosition(position: Int, view: View)
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/viewholder/LayerMenuViewHolder.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/viewholder/LayerMenuViewHolder.kt
@@ -23,7 +23,7 @@ import com.google.android.material.navigation.NavigationView
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.contract.LayerContracts
 
-class LayerMenuViewHolder(val layerLayout: NavigationView) : LayerContracts.LayerMenuViewHolder {
+class LayerMenuViewHolder(private val layerLayout: NavigationView) : LayerContracts.LayerMenuViewHolder {
     val layerAddButton: View = layerLayout.findViewById(R.id.pocketpaint_layer_side_nav_button_add)
     val layerDeleteButton: View = layerLayout.findViewById(R.id.pocketpaint_layer_side_nav_button_delete)
 

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_layer_opacity.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_layer_opacity.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M17.66,8L12,2.35 6.34,8C4.78,9.56 4,11.64 4,13.64s0.78,4.11 2.34,5.67 3.61,2.35 5.66,2.35 4.1,-0.79 5.66,-2.35S20,15.64 20,13.64 19.22,9.56 17.66,8zM6,14c0.01,-2 0.62,-3.27 1.76,-4.4L12,5.27l4.24,4.38C17.38,10.77 17.99,12 18,14H6z"/>
+</vector>

--- a/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout-land/activity_pocketpaint_main.xml
@@ -94,7 +94,7 @@
 
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/pocketpaint_nav_view_layer"
-        android:layout_width="150dp"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:layout_gravity="end|center">
 

--- a/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
+++ b/Paintroid/src/main/res/layout/activity_pocketpaint_main.xml
@@ -88,12 +88,12 @@
 
         <com.google.android.material.navigation.NavigationView
             android:id="@+id/pocketpaint_nav_view_layer"
-            android:layout_width="150dp"
+            android:layout_width="200dp"
             android:layout_height="wrap_content"
             android:layout_gravity="end|center">
 
             <include layout="@layout/pocketpaint_layout_main_menu_layer"
-                android:layout_width="150dp"
+                android:layout_width="200dp"
                 android:layout_height="wrap_content" />
         </com.google.android.material.navigation.NavigationView>
 

--- a/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_item_layer.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
  *  Paintroid: An image manipulation application for Android.
  *  Copyright (C) 2010-2022 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
@@ -17,21 +18,19 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/pocketpaint_item_layer_background"
-    android:layout_width="150dp"
-    android:layout_height="wrap_content"
+    android:id="@+id/pocketpaint_item_layer"
+    android:layout_width="200dp"
+    android:layout_height="170dp"
     android:background="@drawable/pocketpaint_attribute_button_selector"
-    android:descendantFocusability="blocksDescendants"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingStart="8dp"
     android:paddingTop="10dp"
-    android:paddingEnd="8dp"
     android:paddingBottom="10dp"
     android:baselineAligned="false">
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="50dp"
+        android:descendantFocusability="blocksDescendants"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
         android:orientation="vertical">
@@ -40,6 +39,10 @@
             android:id="@+id/pocketpaint_checkbox_layer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
+
+        <Space
+            android:layout_width="wrap_content"
+            android:layout_height="20dp" />
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/pocketpaint_layer_drag_handle"
@@ -52,25 +55,72 @@
 
     </LinearLayout>
 
-    <FrameLayout
+    <LinearLayout
+        android:layout_width="50dp"
+        android:layout_height="match_parent"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.AppCompatSeekBar
+            android:id="@+id/pocketpaint_layer_opacity_seekbar"
+            android:layout_width="120dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:max="100"
+            android:progressBackgroundTint="#ccc"
+            android:progressTint="#fff"
+            android:rotation="270"
+            android:thumbTint="#fff" />
+
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/pocketpaint_layer_opacity_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionDone"
+            android:importantForAutofill="no"
+            android:inputType="number"
+            android:textAlignment="center"
+            android:textColor="?attr/colorAccent"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <RelativeLayout
+        android:id="@+id/pocketpaint_layer_preview_container"
+        android:descendantFocusability="blocksDescendants"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:layout_weight="1">
 
         <ImageView
-            android:id="@+id/pocketpaint_item_layer_image"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
+            android:id="@+id/pocketpaint_item_layer_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            android:layout_centerHorizontal="true"
+            android:layout_toStartOf="@id/pocketpaint_item_layer_image"
+            android:layout_toEndOf="@id/pocketpaint_item_layer_image"
+            android:layout_alignTop="@id/pocketpaint_item_layer_image"
+            android:layout_alignBottom="@id/pocketpaint_item_layer_image"
             android:adjustViewBounds="true"
             android:background="@drawable/pocketpaint_checkeredbg_repeat"
             android:contentDescription="@string/layer_background"
             android:focusable="false"
-            android:maxHeight="100dp"
             android:scaleType="fitXY" />
 
-    </FrameLayout>
+        <ImageView
+            android:id="@+id/pocketpaint_item_layer_image"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/layer_preview"
+            android:focusable="false"
+            android:scaleType="fitXY" />
+
+    </RelativeLayout>
 
 </LinearLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_main_menu_layer.xml
@@ -32,13 +32,29 @@
 
         <ImageButton
             style="?borderlessButtonStyle"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:alpha="0.3"
             android:contentDescription="@string/layer_new"
             android:id="@+id/pocketpaint_layer_side_nav_button_visibility"
-            android:layout_height="wrap_content"
-            android:layout_width="50dp"
             android:padding="5dp"
+            android:clickable="false"
             android:scaleType="fitXY"
             android:src="@drawable/ic_pocketpaint_layers_visibility"
+            android:theme="@style/PocketPaintHighlightColorTheme"
+            android:tint="@android:color/white" />
+
+        <ImageButton
+            android:id="@+id/pocketpaint_layer_side_nav_button_opacity"
+            style="?borderlessButtonStyle"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:alpha="0.3"
+            android:clickable="false"
+            android:contentDescription="@string/layer_new"
+            android:padding="5dp"
+            android:scaleType="fitXY"
+            android:src="@drawable/ic_pocketpaint_layer_opacity"
             android:theme="@style/PocketPaintHighlightColorTheme"
             android:tint="@android:color/white" />
 
@@ -78,7 +94,7 @@
             android:scrollbars="vertical"
             android:splitMotionEvents="true"
             android:layout_marginTop="45dp"
-            android:layout_marginStart="-147dp"
+            android:layout_marginStart="-197dp"
             tools:listitem="@layout/pocketpaint_item_layer"
             />
 

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -153,6 +153,7 @@
     <string name="layer_too_many_layers">Too many layers</string>
     <string name="layer_merged">Layers merged</string>
     <string name="layer_background">Layer background</string>
+    <string name="layer_preview">Layer preview</string>
 
     <string name="dialog_loading_image_failed_title">Error on loading image</string>
     <string name="dialog_loading_image_failed_text">Not a valid image</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/AddLayerCommandTest.kt
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/AddLayerCommandTest.kt
@@ -30,6 +30,8 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import org.junit.Assert
 import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
@@ -48,6 +50,8 @@ class AddLayerCommandTest {
 
     @Test
     fun testAddOneLayer() {
+        `when`(commonFactory!!.createBitmap(3, 5, Bitmap.Config.ARGB_8888)).thenReturn(mock(Bitmap::class.java))
+
         val layerModel = LayerModel()
         layerModel.width = 3
         layerModel.height = 5
@@ -63,13 +67,17 @@ class AddLayerCommandTest {
 
     @Test
     fun testAddTwoLayersAddsToFront() {
-        val layerModel = LayerModel()
+        `when`(commonFactory!!.createBitmap(3, 5, Bitmap.Config.ARGB_8888)).thenReturn(mock(Bitmap::class.java))
 
-        if (canvas != null) { command?.run(canvas, layerModel) }
+        val layerModel = LayerModel()
+        layerModel.width = 3
+        layerModel.height = 5
+
+        canvas?.let { command?.run(it, layerModel) }
 
         val firstLayer = layerModel.getLayerAt(0)
 
-        if (canvas != null) { command?.run(canvas, layerModel) }
+        canvas?.let { command?.run(it, layerModel) }
 
         Assert.assertEquals(2, layerModel.layerCount.toLong())
 
@@ -80,6 +88,7 @@ class AddLayerCommandTest {
 
     @Test
     fun testAddMultipleLayersWillUseSameArguments() {
+        `when`(commonFactory!!.createBitmap(7, 11, Bitmap.Config.ARGB_8888)).thenReturn(mock(Bitmap::class.java))
         val layerModel = LayerModel()
 
         layerModel.width = 7

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/ResetCommandTest.kt
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/ResetCommandTest.kt
@@ -19,18 +19,20 @@
 
 package org.catrobat.paintroid.test.command.implementation
 
+import android.graphics.Bitmap
 import android.graphics.Canvas
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.InjectMocks
 import org.catrobat.paintroid.command.implementation.ResetCommand
 import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.model.Layer
-import org.junit.Before
 import org.catrobat.paintroid.model.LayerModel
 import org.hamcrest.CoreMatchers
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
@@ -47,8 +49,8 @@ class ResetCommandTest {
 
     @Test
     fun testRunClearsLayers() {
-        layerModel?.addLayerAt(0, Layer(null))
-        layerModel?.addLayerAt(1, Layer(null))
+        layerModel?.addLayerAt(0, Layer(mock(Bitmap::class.java)))
+        layerModel?.addLayerAt(1, Layer(mock(Bitmap::class.java)))
         canvas?.let { layerModel?.let { it1 -> command?.run(it, it1) } }
         Assert.assertThat(layerModel?.layerCount, CoreMatchers.`is`(0))
     }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/model/LayerTest.kt
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/model/LayerTest.kt
@@ -19,12 +19,12 @@
 
 package org.catrobat.paintroid.test.model
 
-import org.junit.runner.RunWith
-import org.mockito.Mock
 import android.graphics.Bitmap
 import org.catrobat.paintroid.model.Layer
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 
@@ -38,8 +38,8 @@ class LayerTest {
 
     @Test
     fun testGetBitmap() {
-        val firstLayer = Layer(firstBitmap)
-        val secondLayer = Layer(secondBitmap)
+        val firstLayer = Layer(firstBitmap!!)
+        val secondLayer = Layer(secondBitmap!!)
 
         Assert.assertEquals(firstBitmap, firstLayer.bitmap)
         Assert.assertEquals(secondBitmap, secondLayer.bitmap)
@@ -53,8 +53,8 @@ class LayerTest {
 
     @Test
     fun testSetBitmap() {
-        val layer = Layer(firstBitmap)
-        layer.bitmap = secondBitmap
+        val layer = Layer(firstBitmap!!)
+        layer.bitmap = secondBitmap!!
 
         Assert.assertEquals(secondBitmap, layer.bitmap)
         Assert.assertTrue(layer.isVisible)

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/LayerPresenterTest.java
@@ -91,50 +91,6 @@ public class LayerPresenterTest {
 	}
 
 	@Test
-	public void testOnBindLayerViewHolderAtSelectedPosition() {
-		LayerViewHolder layerViewHolder = mock(LayerViewHolder.class);
-		Layer firstLayer = mock(Layer.class);
-
-		Bitmap firstLayerBitmap = mock(Bitmap.class);
-		when(firstLayer.getTransparentBitmap()).thenReturn(firstLayerBitmap);
-
-		layerModel.addLayerAt(0, firstLayer);
-		layerModel.setCurrentLayer(firstLayer);
-
-		createPresenter();
-		layerPresenter.onBindLayerViewHolderAtPosition(0, layerViewHolder, false);
-
-		verify(layerViewHolder).setSelected(0, null, null);
-		verify(layerViewHolder).updateImageView(firstLayerBitmap);
-		verify(layerViewHolder).setLayerVisibilityCheckbox(false);
-		verifyNoMoreInteractions(layerViewHolder);
-		verifyZeroInteractions(commandManager, commandFactory, layerAdapter,
-				listItemDragHandler, layerMenuViewHolder);
-	}
-
-	@Test
-	public void testOnBindLayerViewHolderAtDeselectedPosition() {
-		LayerViewHolder layerViewHolder = mock(LayerViewHolder.class);
-		Layer firstLayer = mock(Layer.class);
-		Layer secondLayer = mock(Layer.class);
-		Bitmap secondLayerBitmap = mock(Bitmap.class);
-		when(secondLayer.getTransparentBitmap()).thenReturn(secondLayerBitmap);
-		layerModel.addLayerAt(0, firstLayer);
-		layerModel.addLayerAt(1, secondLayer);
-		layerModel.setCurrentLayer(firstLayer);
-
-		createPresenter();
-		layerPresenter.onBindLayerViewHolderAtPosition(1, layerViewHolder, false);
-
-		verify(layerViewHolder).setDeselected();
-		verify(layerViewHolder).updateImageView(secondLayer.getTransparentBitmap());
-		verify(layerViewHolder).setLayerVisibilityCheckbox(false);
-		verifyNoMoreInteractions(layerViewHolder);
-		verifyZeroInteractions(firstLayer, commandManager, layerAdapter,
-				listItemDragHandler, layerMenuViewHolder);
-	}
-
-	@Test
 	public void testRefreshLayerMenuViewHolder() {
 		layerModel.addLayerAt(0, mock(Layer.class));
 		layerModel.addLayerAt(1, mock(Layer.class));
@@ -265,8 +221,8 @@ public class LayerPresenterTest {
 	@Test
 	public void testOnDragLayerAtPosition() {
 		View view = mock(View.class);
-		Layer firstLayer = new Layer(null);
-		Layer secondLayer = new Layer(null);
+		Layer firstLayer = new Layer(mock(Bitmap.class));
+		Layer secondLayer = new Layer(mock(Bitmap.class));
 		assertTrue(firstLayer.isVisible());
 		assertTrue(secondLayer.isVisible());
 		layerModel.addLayerAt(0, firstLayer);
@@ -303,7 +259,6 @@ public class LayerPresenterTest {
 
 	@Test
 	public void testOnClickLayerAtPositionWhenDeselected() {
-		View view = mock(View.class);
 		layerModel.addLayerAt(0, mock(Layer.class));
 		layerModel.addLayerAt(1, mock(Layer.class));
 		layerModel.setCurrentLayer(layerModel.getLayerAt(1));
@@ -311,27 +266,25 @@ public class LayerPresenterTest {
 		when(commandFactory.createSelectLayerCommand(0)).thenReturn(command);
 
 		createPresenter();
-		layerPresenter.onClickLayerAtPosition(0, view);
+		layerPresenter.setLayerSelected(0);
 
 		verify(commandManager).addCommand(command);
 	}
 
 	@Test
 	public void testOnClickLayerAtPositionWhenAlreadySelected() {
-		View view = mock(View.class);
 		Layer layer = mock(Layer.class);
 		layerModel.addLayerAt(0, layer);
 		layerModel.setCurrentLayer(layer);
 
 		createPresenter();
-		layerPresenter.onClickLayerAtPosition(0, view);
+		layerPresenter.setLayerSelected(0);
 
 		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
 	}
 
 	@Test
 	public void testOnClickLayerAtPositionWhenPositionOutOfBounds() {
-		View view = mock(View.class);
 		Layer firstLayer = mock(Layer.class);
 		Layer secondLayer = mock(Layer.class);
 		layerModel.addLayerAt(0, firstLayer);
@@ -339,7 +292,7 @@ public class LayerPresenterTest {
 		layerModel.setCurrentLayer(firstLayer);
 
 		createPresenter();
-		layerPresenter.onClickLayerAtPosition(2, view);
+		layerPresenter.setLayerSelected(2);
 
 		verifyZeroInteractions(commandManager, commandFactory, layerMenuViewHolder, layerAdapter);
 	}


### PR DESCRIPTION
added opacity for each layer. 
repaced transparentbitmap in layer by a simple flag.
added new layeropacity command

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
