### PR TITLE
HOTFIX-Fix_Jenkins_Build

### DIFF
--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.java
@@ -615,7 +615,7 @@ public class MainActivityPresenterTest {
 
 	@Test
 	public void testRestoreStateThenRestoreFragmentListeners() {
-		presenter.restoreState(false, false, false, false, false, null, null);
+		presenter.restoreState(false, false, false, false, null, null);
 
 		verify(navigator).restoreFragmentListeners();
 	}
@@ -625,13 +625,12 @@ public class MainActivityPresenterTest {
 		Uri savedPictureUri = mock(Uri.class);
 		Uri cameraImageUri = mock(Uri.class);
 
-		presenter.restoreState(false, false, false, false, false, savedPictureUri, cameraImageUri);
+		presenter.restoreState(false, false, false, false, savedPictureUri, cameraImageUri);
 
 		verify(model).setFullscreen(false);
 		verify(model).setSaved(false);
 		verify(model).setOpenedFromCatroid(false);
 		verify(model).setOpenedFromFormulaEditorInCatroid(false);
-		verify(model).setInitialAnimationPlayed(false);
 		verify(model).setSavedPictureUri(savedPictureUri);
 		verify(model).setCameraImageUri(cameraImageUri);
 	}
@@ -641,20 +640,19 @@ public class MainActivityPresenterTest {
 		Uri savedPictureUri = mock(Uri.class);
 		Uri cameraImageUri = mock(Uri.class);
 
-		presenter.restoreState(true, true, true, true, true, savedPictureUri, cameraImageUri);
+		presenter.restoreState(true, true, true, true, savedPictureUri, cameraImageUri);
 
 		verify(model).setFullscreen(true);
 		verify(model).setSaved(true);
 		verify(model).setOpenedFromCatroid(true);
 		verify(model).setOpenedFromFormulaEditorInCatroid(true);
-		verify(model).setInitialAnimationPlayed(true);
 		verify(model).setSavedPictureUri(savedPictureUri);
 		verify(model).setCameraImageUri(cameraImageUri);
 	}
 
 	@Test
 	public void testRestoreStateThenResetTool() {
-		presenter.restoreState(false, false, false, false, false, null, null);
+		presenter.restoreState(false, false, false, false, null, null);
 
 		verify(toolController).resetToolInternalStateOnImageLoaded();
 	}
@@ -1348,7 +1346,6 @@ public class MainActivityPresenterTest {
 		verify(model, never()).setCameraImageUri(any(Uri.class));
 		verify(model, never()).setSaved(anyBoolean());
 		verify(model, never()).setOpenedFromCatroid(anyBoolean());
-		verify(model, never()).setInitialAnimationPlayed(anyBoolean());
 		verify(model, never()).setFullscreen(anyBoolean());
 	}
 


### PR DESCRIPTION
Removed all setInitialAnimationPlayed as well as 1 parameter for each presenter.restoreState() function in the MainActivityPresenterTest class as the initialAnimationPlayed boolean was still in there but signature of function was already changed.

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
