### PR TITLE
PAINTROID-426 fixed very high frequency crash in the Smudge Tool

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
@@ -269,7 +269,7 @@ class LayerPresenter(
 
     fun resetMergeColor(layerPosition: Int) {
         if (adapter != null && adapter?.getViewHolderAt(layerPosition) != null) {
-            if (adapter?.getViewHolderAt(layerPosition)!!.isSelected()) {
+            if (adapter?.getViewHolderAt(layerPosition)?.isSelected() == true) {
                 adapter?.getViewHolderAt(layerPosition)?.setSelected()
             } else {
                 adapter?.getViewHolderAt(layerPosition)?.setDeselected()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -47,11 +47,11 @@ import org.catrobat.paintroid.common.CREATE_FILE_DEFAULT
 import org.catrobat.paintroid.common.LOAD_IMAGE_CATROID
 import org.catrobat.paintroid.common.LOAD_IMAGE_DEFAULT
 import org.catrobat.paintroid.common.LOAD_IMAGE_IMPORT_PNG
-import org.catrobat.paintroid.common.MainActivityConstants.PermissionRequestCode
+import org.catrobat.paintroid.common.MainActivityConstants.ActivityRequestCode
 import org.catrobat.paintroid.common.MainActivityConstants.CreateFileRequestCode
 import org.catrobat.paintroid.common.MainActivityConstants.LoadImageRequestCode
+import org.catrobat.paintroid.common.MainActivityConstants.PermissionRequestCode
 import org.catrobat.paintroid.common.MainActivityConstants.SaveImageRequestCode
-import org.catrobat.paintroid.common.MainActivityConstants.ActivityRequestCode
 import org.catrobat.paintroid.common.PERMISSION_EXTERNAL_STORAGE_SAVE
 import org.catrobat.paintroid.common.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_FINISH
 import org.catrobat.paintroid.common.PERMISSION_EXTERNAL_STORAGE_SAVE_CONFIRMED_LOAD_NEW
@@ -293,7 +293,8 @@ open class MainActivityPresenter(
         FileIO.fileType = FileIO.FileType.PNG
         FileIO.isCatrobatImage = false
         FileIO.deleteTempFile(internalMemoryPath)
-        val initCommand = commandFactory.createInitCommand(metrics.widthPixels, metrics.heightPixels)
+        val initCommand =
+            commandFactory.createInitCommand(metrics.widthPixels, metrics.heightPixels)
         commandManager.setInitialStateCommand(initCommand)
         commandManager.reset()
     }
@@ -885,7 +886,7 @@ open class MainActivityPresenter(
         if (bottomBarViewHolder.isVisible) {
             bottomBarViewHolder.hide()
         } else {
-            if (!layerAdapter!!.presenter.getLayerItem(workspace.currentLayerIndex).isVisible) {
+            if (layerAdapter?.presenter?.getLayerItem(workspace.currentLayerIndex)?.isVisible == false) {
                 navigator.showToast(R.string.no_tools_on_hidden_layer, Toast.LENGTH_SHORT)
                 return
             }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
@@ -169,16 +169,14 @@ open class BrushTool(
             return false
         }
 
-        val distance = sqrt(
-            (
-                (coordinate.x - initialEventCoordinate!!.x) *
-                    (coordinate.x - initialEventCoordinate!!.x) +
-                    (coordinate.y - initialEventCoordinate!!.y)
-                ).toDouble()
-        )
-        val speed = distance / drawTime
+        var distance: Double? = null
+        initialEventCoordinate?.apply {
+            distance =
+                sqrt(((coordinate.x - x) * (coordinate.x - x) + (coordinate.y - y) * (coordinate.y - y)).toDouble())
+        }
+        val speed = distance?.div(drawTime)
 
-        if (!smoothing || speed < threshold) {
+        if (!smoothing || speed != null && speed < threshold) {
             val command = commandFactory.createPathCommand(bitmapPaint, pathToDraw)
             commandManager.addCommand(command)
         } else {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
@@ -18,6 +18,7 @@ import org.catrobat.paintroid.tools.common.CommonBrushChangedListener
 import org.catrobat.paintroid.tools.common.CommonBrushPreviewListener
 import org.catrobat.paintroid.tools.options.SmudgeToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
+import kotlin.math.sqrt
 
 const val PERCENT_100 = 100f
 const val BITMAP_ROTATION_FACTOR = -0.0f
@@ -114,12 +115,14 @@ class SmudgeTool(
             Canvas(it).apply {
                 translate(-coordinate.x + maxSmudgeSize / 2f, -coordinate.y + maxSmudgeSize / 2f)
                 rotate(BITMAP_ROTATION_FACTOR, coordinate.x, coordinate.y)
-                drawBitmap(layerBitmap!!, 0f, 0f, null)
+                layerBitmap?.let { bitmap ->
+                    drawBitmap(bitmap, 0f, 0f, null)
+                }
             }
-        }
 
-        if (toolPaint.strokeCap == Paint.Cap.ROUND) {
-            currentBitmap = getBitmapClippedCircle(currentBitmap!!)
+            if (toolPaint.strokeCap == Paint.Cap.ROUND) {
+                currentBitmap = getBitmapClippedCircle(it)
+            }
         }
 
         if (!currentBitmapHasColor()) {
@@ -129,35 +132,37 @@ class SmudgeTool(
         }
 
         prevPoint = PointF(coordinate.x, coordinate.y)
-        pointArray.add(PointF(prevPoint!!.x, prevPoint!!.y))
+        prevPoint?.apply {
+            pointArray.add(PointF(x, y))
+        }
 
         return true
     }
 
     override fun handleMove(coordinate: PointF?): Boolean {
         coordinate ?: return false
+
         if (currentBitmap != null) {
             if (pressure < DRAW_THRESHOLD) { // Needed to stop drawing preview when bitmap becomes too transparent. Has no effect on final drawing.
                 return false
             }
 
-            val x = coordinate.x - prevPoint!!.x
-            val y = coordinate.y - prevPoint!!.y
+            prevPoint?.apply {
+                val x1 = coordinate.x - x
+                val y1 = coordinate.y - y
 
-            val distance = kotlin.math.floor(kotlin.math.sqrt(x * x + y * y) / DISTANCE_SMOOTHING)
-            val xInterval = x / distance
-            val yInterval = y / distance
+                val distance = (sqrt(x1 * x1 + y1 * y1) / DISTANCE_SMOOTHING).toInt()
+                val xInterval = x1 / distance
+                val yInterval = y1 / distance
 
-            var i = 0
-            while (i < distance) {
-                prevPoint!!.x += xInterval
-                prevPoint!!.y += yInterval
+                repeat(distance) {
+                    x += xInterval
+                    y += yInterval
 
-                pressure -= PRESSURE_UPDATE_STEP
+                    pressure -= PRESSURE_UPDATE_STEP
 
-                pointArray.add(PointF(prevPoint!!.x, prevPoint!!.y))
-
-                i++
+                    pointArray.add(PointF(x, y))
+                }
             }
             return true
         } else {
@@ -183,10 +188,12 @@ class SmudgeTool(
     }
 
     private fun currentBitmapHasColor(): Boolean {
-        for (x in 0 until currentBitmap!!.width) {
-            for (y in 0 until currentBitmap!!.height) {
-                if (currentBitmap!!.getPixel(x, y) != 0) {
-                    return true
+        currentBitmap?.apply {
+            for (x in 0 until width) {
+                for (y in 0 until height) {
+                    if (getPixel(x, y) != 0) {
+                        return true
+                    }
                 }
             }
         }
@@ -195,15 +202,17 @@ class SmudgeTool(
 
     override fun handleUp(coordinate: PointF?): Boolean {
         coordinate ?: return false
-        if (!pointArray.isEmpty() && currentBitmap != null) {
-            val command = commandFactory.createSmudgePathCommand(
-                currentBitmap!!,
-                pointArray,
-                maxPressure,
-                maxSmudgeSize,
-                minSmudgeSize
-            )
-            commandManager.addCommand(command)
+        if (pointArray.isNotEmpty() && currentBitmap != null) {
+            currentBitmap?.let {
+                val command = commandFactory.createSmudgePathCommand(
+                    it,
+                    pointArray,
+                    maxPressure,
+                    maxSmudgeSize,
+                    minSmudgeSize
+                )
+                commandManager.addCommand(command)
+            }
 
             numOfPointsOnPath = if (numOfPointsOnPath < 0) {
                 pointArray.size
@@ -235,7 +244,7 @@ class SmudgeTool(
             var pressure = maxPressure
             val colorMatrix = ColorMatrix()
             val paint = Paint()
-            var bitmap = currentBitmap!!.copy(Bitmap.Config.ARGB_8888, false)
+            var bitmap = currentBitmap?.copy(Bitmap.Config.ARGB_8888, false)
 
             pointPath.forEach {
                 colorMatrix.setScale(1f, 1f, 1f, pressure)
@@ -248,10 +257,12 @@ class SmudgeTool(
                 )
 
                 Canvas(newBitmap).apply {
-                    drawBitmap(bitmap, 0f, 0f, paint)
+                    bitmap?.let { currentBitmap ->
+                        drawBitmap(currentBitmap, 0f, 0f, paint)
+                    }
                 }
 
-                bitmap.recycle()
+                bitmap?.recycle()
                 bitmap = newBitmap
 
                 val rect = RectF(-size / 2f, -size / 2f, size / 2f, size / 2f)
@@ -259,14 +270,16 @@ class SmudgeTool(
                     save()
                     clipRect(0, 0, workspace.width, workspace.height)
                     translate(it.x, it.y)
-                    drawBitmap(bitmap, null, rect, Paint(Paint.DITHER_FLAG))
+                    bitmap?.let { currentBitmap ->
+                        drawBitmap(currentBitmap, null, rect, Paint(Paint.DITHER_FLAG))
+                    }
                     restore()
                 }
                 size -= step
                 pressure -= PRESSURE_UPDATE_STEP
             }
 
-            bitmap.recycle()
+            bitmap?.recycle()
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -82,7 +82,9 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
         val dragHandle = localConvertView?.findViewById<AppCompatImageView>(R.id.pocketpaint_layer_drag_handle)
         dragHandle?.setOnTouchListener { _, event ->
             when (event.action) {
-                MotionEvent.ACTION_DOWN -> presenter.onStartDragging(position, localConvertView!!)
+                MotionEvent.ACTION_DOWN -> localConvertView?.let {
+                    presenter.onStartDragging(position, it)
+                }
                 MotionEvent.ACTION_UP -> presenter.onStopDragging()
             }
 

--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/AlphaSlider.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/AlphaSlider.kt
@@ -174,16 +174,16 @@ class AlphaSlider(
     }
 
     private fun moveTrackersIfNeeded(event: MotionEvent): Boolean {
-        if (startTouchPoint == null) {
-            return false
-        }
-        var update = true
-        val startX = startTouchPoint!!.x
-        val startY = startTouchPoint!!.y
-        if (alphaRectangle.contains(startX.toFloat(), startY.toFloat())) {
-            alphaValue = pointToAlpha(event.x.toInt())
-        } else {
-            update = false
+        var update = false
+        startTouchPoint?.apply {
+            update = true
+            val startX = x
+            val startY = y
+            if (alphaRectangle.contains(startX.toFloat(), startY.toFloat())) {
+                alphaValue = pointToAlpha(event.x.toInt())
+            } else {
+                update = false
+            }
         }
         return update
     }


### PR DESCRIPTION
The crash was due to the use of the `!!` operator. `!!` operator was used in multiple places, so removed them from this file and some other files that somehow also contained the `!!` operator from the recent changes in the code.

This should fix this crash and many other crashes that could have occurred otherwise.

Also fixed the distance formula in `BrushTool` line 174 which I noticed was not correctly written (based on the Euclidian distance formula).

Did some other minor refactoring.

https://jira.catrob.at/browse/PAINTROID-426

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
