### PR TITLE
PAINTROID-418 Fullscreen mode should zoom to fit

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -31,6 +31,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.webkit.MimeTypeMap
@@ -300,6 +301,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                         )
                     )
                 }
+                workspace.perspective.setBitmapDimensions(layerModel.width, layerModel.height)
             }
             else -> {
                 val isFullscreen = savedInstanceState.getBoolean(IS_FULLSCREEN_KEY, false)
@@ -349,7 +351,10 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             R.id.pocketpaint_options_open_image -> presenterMain.loadImageClicked()
             R.id.pocketpaint_options_new_image -> presenterMain.newImageClicked()
             R.id.pocketpaint_options_discard_image -> presenterMain.discardImageClicked()
-            R.id.pocketpaint_options_fullscreen_mode -> presenterMain.enterFullscreenClicked()
+            R.id.pocketpaint_options_fullscreen_mode -> {
+                perspective.mainActivity = this
+                presenterMain.enterFullscreenClicked()
+            }
             R.id.pocketpaint_options_rate_us -> presenterMain.rateUsClicked()
             R.id.pocketpaint_options_help -> presenterMain.showHelpClicked()
             R.id.pocketpaint_options_about -> presenterMain.showAboutClicked()
@@ -644,8 +649,12 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
 
     override fun enterFullscreen() {
         drawingSurface.disableAutoScroll()
-        window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-        window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+        if (VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.insetsController?.hide(WindowInsets.Type.statusBars())
+        } else {
+            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+        }
     }
 
     override fun exitFullscreen() {


### PR DESCRIPTION
After this ticket when user clicks fullscreen, the bitmap is maxed out as good as possible. Also fixed bug where the bitmap was not centered after exiting fullscreen mode. Also fixed bug of loading temporary image, as developer forgot to set the according bitmap width and height and those were always set to the default display ratios which messed up the perspective/zoom level.

https://jira.catrob.at/browse/PAINTROID-418

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
