### PR TITLE
PAINTROID-406 Set exact slider value

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TransformToolIntegrationTest.kt
@@ -1172,6 +1172,24 @@ class TransformToolIntegrationTest {
     }
 
     @Test
+    fun testResizeTextChangesSeekbar() {
+        onToolBarView()
+            .performSelectTool(ToolType.TRANSFORM)
+        var seekBar =
+            mainActivity.findViewById<SeekBar>(R.id.pocketpaint_transform_resize_seekbar)
+        var progress = seekBar.progress
+        onTransformToolOptionsView()
+            .checkPercentageTextMatches(progress)
+            .performEditResizeTextField("50")
+
+        seekBar =
+            launchActivityRule.activity.findViewById(R.id.pocketpaint_transform_resize_seekbar)
+        progress = seekBar.progress
+
+        assertEquals(progress, 50)
+    }
+
+    @Test
     fun testTransformToolDoesNotResetPerspectiveScale() {
         val scale = 2.0f
         perspective.scale = scale

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/TransformToolOptionsViewInteraction.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/TransformToolOptionsViewInteraction.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.not;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -98,6 +99,12 @@ public final class TransformToolOptionsViewInteraction extends CustomViewInterac
 	public TransformToolOptionsViewInteraction performApplyResize() {
 		onView(withId(R.id.pocketpaint_transform_apply_resize_btn))
 				.perform(click());
+		return this;
+	}
+
+	public TransformToolOptionsViewInteraction performEditResizeTextField(String size) {
+		onView(withId(R.id.pocketpaint_transform_resize_percentage_text))
+				.perform(replaceText(size));
 		return this;
 	}
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.kt
@@ -71,6 +71,7 @@ class DefaultToolOptionsViewController(
         idlingResource.increment()
         toolOptionsShown = false
         mainToolOptions.animate().y(bottomNavigation.y + bottomNavigation.height)
+        mainToolOptions.visibility = View.GONE
         notifyHide()
         idlingResource.decrement()
     }

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_transform_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_transform_tool.xml
@@ -157,7 +157,7 @@
                 android:progress="100"
                 android:minHeight="30dip" />
 
-            <TextView
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/pocketpaint_transform_resize_percentage_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -165,9 +165,12 @@
                 android:textColor="?attr/colorAccent"
                 android:textSize="14sp"
                 android:textStyle="bold"
-                android:gravity="end"
-                android:text="100"
-                tools:ignore="HardCodedText" />
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:layoutDirection="ltr"
+                android:gravity="center"
+                tools:text="100"
+                android:importantForAutofill="no" />
 
             <TextView
                 android:layout_width="wrap_content"


### PR DESCRIPTION
-changed the text field next to the seekbar in the transformtool to edittext. 
The user now can change the exact percentage value.

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
