### PR TITLE
PAINTROID-416 Layout gets broken when changing tools

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -701,8 +701,6 @@ open class MainActivityPresenter(
         bottomBarViewHolder.hide()
         if (toolController.toolType === toolType && toolController.hasToolOptionsView()) {
             toolController.toggleToolOptionsView()
-        } else if (view.isKeyboardShown) {
-            view.hideKeyboard()
         } else {
             switchTool(toolType)
         }
@@ -711,6 +709,7 @@ open class MainActivityPresenter(
 
     private fun switchTool(type: ToolType, backPressed: Boolean = false) {
         navigator.setMaskFilterToNull()
+        view.hideKeyboard()
         setTool(type)
         toolController.switchTool(type, backPressed)
         if (type === ToolType.IMPORTPNG) {


### PR DESCRIPTION
-implemented a line in switch Tools in the MainActivityPresenter where the keyboard will be hidden if it is still shown.

https://jira.catrob.at/browse/PAINTROID-416

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
