### PR TITLE
PAINTROID-445 Give feedback of changed canvas when changing tools

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -736,7 +736,7 @@ public class ColorDialogIntegrationTest {
 				.onPositiveButton()
 				.perform(click());
 		onToolProperties()
-				.checkMatchesColor(Color.parseColor("#80000000"));
+				.checkMatchesColor(Color.parseColor("#7F000000"));
 		IdlingRegistry.getInstance().unregister(idlingResource);
 	}
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClippingToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClippingToolIntegrationTest.kt
@@ -207,7 +207,7 @@ class ClippingToolIntegrationTest {
             .performOpen()
             .performClose()
 
-        val bitmapColor = workspace.bitmapOfCurrentLayer?.getPixel(middle.x.toInt(), middle.y.toInt())
+        val bitmapColor = workspace.bitmapOfCurrentLayer?.getPixel(middleTop.x.toInt(), middleTop.y.toInt())
         assertEquals(bitmapColor, Color.BLACK)
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -33,7 +33,6 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolReference
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
-import org.catrobat.paintroid.tools.implementation.BaseToolWithShape
 import org.catrobat.paintroid.tools.implementation.ClippingTool
 import org.catrobat.paintroid.tools.implementation.ImportTool
 import org.catrobat.paintroid.tools.implementation.LineTool
@@ -50,14 +49,6 @@ class DefaultToolController(
     private val contextCallback: ContextCallback
 ) : ToolController {
     private lateinit var onColorPickedListener: OnColorPickedListener
-    private val toolList =
-        hashSetOf(
-            ToolType.TEXT,
-            ToolType.TRANSFORM,
-            ToolType.IMPORTPNG,
-            ToolType.SHAPE,
-            ToolType.LINE
-        )
 
     override val isDefaultTool: Boolean
         get() = toolReference.tool?.toolType == ToolType.BRUSH
@@ -103,8 +94,8 @@ class DefaultToolController(
         this.onColorPickedListener = onColorPickedListener
     }
 
-    override fun switchTool(toolType: ToolType, backPressed: Boolean) {
-        switchTool(createAndSetupTool(toolType), backPressed)
+    override fun switchTool(toolType: ToolType) {
+        switchTool(createAndSetupTool(toolType))
     }
 
     override fun hideToolOptionsView() {
@@ -125,20 +116,12 @@ class DefaultToolController(
         toolReference.tool?.resetInternalState(StateChange.NEW_IMAGE_LOADED)
     }
 
-    private fun switchTool(tool: Tool, backPressed: Boolean) {
+    private fun switchTool(tool: Tool) {
         val currentTool = toolReference.tool
         val currentToolType = currentTool?.toolType
-        if (toolList.contains(currentToolType)) {
-            if (!backPressed) {
-                val toolToApply = currentTool as BaseToolWithShape
-                toolToApply.onClickOnButton()
-            }
-        } else if (currentToolType == ToolType.CLIP) {
-            adjustClippingTool(backPressed)
-        }
         currentToolType?.let { hidePlusIfShown(it) }
 
-        if (currentTool?.toolType == tool.toolType) {
+        if (currentToolType == tool.toolType) {
             val toolBundle = Bundle()
             currentTool.onSaveInstanceState(toolBundle)
             tool.onRestoreInstanceState(toolBundle)
@@ -147,7 +130,7 @@ class DefaultToolController(
         workspace.invalidate()
     }
 
-    private fun adjustClippingTool(backPressed: Boolean) {
+    override fun adjustClippingToolOnBackPressed(backPressed: Boolean) {
         val clippingTool = currentTool as ClippingTool
         if (backPressed) {
             if (clippingTool.areaClosed) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
@@ -22,16 +22,25 @@ import android.graphics.Bitmap
 import org.catrobat.paintroid.colorpicker.OnColorPickedListener
 import org.catrobat.paintroid.tools.Tool
 import org.catrobat.paintroid.tools.ToolType
+import java.util.HashSet
 
 interface ToolController {
     val isDefaultTool: Boolean
     val toolType: ToolType?
     val toolColor: Int?
     val currentTool: Tool?
+    val toolList: HashSet<ToolType>
+        get() = hashSetOf(
+            ToolType.TEXT,
+            ToolType.TRANSFORM,
+            ToolType.IMPORTPNG,
+            ToolType.SHAPE,
+            ToolType.LINE
+        )
 
     fun setOnColorPickedListener(onColorPickedListener: OnColorPickedListener)
 
-    fun switchTool(toolType: ToolType, backPressed: Boolean)
+    fun switchTool(toolType: ToolType)
 
     fun hideToolOptionsView()
 
@@ -54,4 +63,6 @@ interface ToolController {
     fun hasToolOptionsView(): Boolean
 
     fun setBitmapFromSource(bitmap: Bitmap?)
+
+    fun adjustClippingToolOnBackPressed(backPressed: Boolean)
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
@@ -194,7 +194,7 @@ class LayerPresenter(
         drawingSurface?.refreshDrawingSurface()
         getDestinationLayer(position, false)?.let { layer ->
             if (model.currentLayer == layer) {
-                defaultToolController?.switchTool(ToolType.HAND, false)
+                defaultToolController?.switchTool(ToolType.HAND)
                 bottomNavigationViewHolder?.showCurrentTool(ToolType.HAND)
             }
         }
@@ -205,7 +205,7 @@ class LayerPresenter(
         getDestinationLayer(position, true)?.let { layer ->
             viewHolder.updateImageView(layer.bitmap)
             if (model.currentLayer == layer) {
-                defaultToolController?.switchTool(ToolType.BRUSH, false)
+                defaultToolController?.switchTool(ToolType.BRUSH)
                 bottomNavigationViewHolder?.showCurrentTool(ToolType.BRUSH)
             }
         }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -31,6 +31,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.PointF
 import android.net.Uri
+import android.os.CountDownTimer
 import android.os.Environment
 import android.provider.DocumentsContract
 import android.provider.MediaStore
@@ -85,6 +86,9 @@ import org.catrobat.paintroid.model.CommandManagerModel
 import org.catrobat.paintroid.tools.Tool
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
+import org.catrobat.paintroid.tools.implementation.BaseToolWithShape
+import org.catrobat.paintroid.tools.implementation.CLICK_TIMEOUT_MILLIS
+import org.catrobat.paintroid.tools.implementation.CONSTANT_3
 import org.catrobat.paintroid.tools.implementation.ClippingTool
 import org.catrobat.paintroid.tools.implementation.LineTool
 import org.catrobat.paintroid.ui.LayerAdapter
@@ -112,6 +116,7 @@ open class MainActivityPresenter(
     override val context: Context,
     private val internalMemoryPath: File
 ) : MainActivityContracts.Presenter, SaveImageCallback, LoadImageCallback, CreateFileCallback {
+    private var downTimer: CountDownTimer? = null
     private var layerAdapter: LayerAdapter? = null
     private var resetPerspectiveAfterNextCommand = false
     private var isExport = false
@@ -420,7 +425,7 @@ open class MainActivityPresenter(
                     return
                 }
                 setTool(ToolType.IMPORTPNG)
-                toolController.switchTool(ToolType.IMPORTPNG, false)
+                toolController.switchTool(ToolType.IMPORTPNG)
                 interactor.loadFile(
                     this,
                     LOAD_IMAGE_IMPORT_PNG,
@@ -532,7 +537,8 @@ open class MainActivityPresenter(
         } else if (model.isFullscreen) {
             exitFullscreenClicked()
         } else if (!toolController.isDefaultTool) {
-            switchTool(ToolType.BRUSH, true)
+            if (toolController.currentTool?.toolType == ToolType.CLIP) toolController.adjustClippingToolOnBackPressed(true)
+            switchTool(ToolType.BRUSH)
         } else {
             showSecurityQuestionBeforeExit()
         }
@@ -757,21 +763,44 @@ open class MainActivityPresenter(
         if (toolController.toolType === toolType && toolController.hasToolOptionsView()) {
             toolController.toggleToolOptionsView()
         } else {
+            checkForImplicitToolApplication()
             switchTool(toolType)
         }
         idlingResource.decrement()
     }
 
-    private fun switchTool(type: ToolType, backPressed: Boolean = false) {
+    private fun checkForImplicitToolApplication() {
+        val currentTool = toolController.currentTool
+        val currentToolType = currentTool?.toolType
+        if (toolController.toolList.contains(currentToolType)) {
+            val toolToApply = currentTool as BaseToolWithShape
+            toolToApply.onClickOnButton()
+        } else if (currentToolType == ToolType.CLIP) (currentTool as ClippingTool).onClickOnButton()
+    }
+
+    private fun switchTool(type: ToolType) {
         navigator.setMaskFilterToNull()
         view.hideKeyboard()
-        setTool(type)
-        toolController.switchTool(type, backPressed)
-        if (type === ToolType.IMPORTPNG) {
-            showImportDialog()
-        } else if (type == ToolType.CLIP) {
-            (toolController.currentTool as ClippingTool).copyBitmapOfCurrentLayer()
-        }
+        downTimer = object :
+            CountDownTimer(
+                if (toolController.toolList.contains(toolController.currentTool?.toolType)) CLICK_TIMEOUT_MILLIS else 0L,
+                CLICK_TIMEOUT_MILLIS / CONSTANT_3
+            ) {
+            override fun onTick(millisUntilFinished: Long) {
+                workspace.invalidate()
+            }
+            override fun onFinish() {
+                downTimer?.cancel()
+                workspace.invalidate()
+                setTool(type)
+                toolController.switchTool(type)
+                if (type === ToolType.IMPORTPNG) {
+                    showImportDialog()
+                } else if (type == ToolType.CLIP) {
+                    (toolController.currentTool as ClippingTool).copyBitmapOfCurrentLayer()
+                }
+            }
+        }.start()
     }
 
     private fun setTool(toolType: ToolType) {
@@ -799,7 +828,7 @@ open class MainActivityPresenter(
         when (requestCode) {
             LOAD_IMAGE_IMPORT_PNG -> {
                 setTool(ToolType.IMPORTPNG)
-                toolController.switchTool(ToolType.IMPORTPNG, false)
+                toolController.switchTool(ToolType.IMPORTPNG)
                 interactor.loadFile(
                     this,
                     LOAD_IMAGE_IMPORT_PNG,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -74,14 +74,14 @@ private const val DEFAULT_ROTATION_ENABLED = false
 private const val DEFAULT_RESIZE_POINTS_VISIBLE = true
 private const val DEFAULT_RESPECT_MAXIMUM_BORDER_RATIO = true
 private const val DEFAULT_RESPECT_MAXIMUM_BOX_RESOLUTION = false
-private const val CLICK_TIMEOUT_MILLIS = 250
+internal const val CLICK_TIMEOUT_MILLIS = 250L
 private const val RIGHT_ANGLE = 90f
 private const val STRAIGHT_ANGLE = 180f
 private const val COMPLETE_ANGLE = 360f
 private const val SIDES = 4
 private const val CONSTANT_1 = 10
 private const val CONSTANT_2 = 8
-private const val CONSTANT_3 = 3
+internal const val CONSTANT_3 = 3
 private const val BUNDLE_BOX_WIDTH = "BOX_WIDTH"
 private const val BUNDLE_BOX_HEIGHT = "BOX_HEIGHT"
 private const val BUNDLE_BOX_ROTATION = "BOX_ROTATION"
@@ -674,8 +674,8 @@ abstract class BaseToolWithRectangleShape(
     fun highlightBox() {
         downTimer = object :
             CountDownTimer(
-                CLICK_TIMEOUT_MILLIS.toLong(),
-                (CLICK_TIMEOUT_MILLIS / CONSTANT_3).toLong()
+                CLICK_TIMEOUT_MILLIS,
+                CLICK_TIMEOUT_MILLIS / CONSTANT_3
             ) {
             override fun onTick(millisUntilFinished: Long) {
                 highlightBoxWhenClickInBox(true)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -115,7 +115,7 @@ class LayerAdapter(val presenter: LayerContracts.Presenter) : BaseAdapter(), Lay
 
         override fun setSelected(position: Int, bottomNavigationViewHolder: BottomNavigationViewHolder?, defaultToolController: DefaultToolController?) {
             if (!layerPresenter.getLayerItem(position).isVisible) {
-                defaultToolController?.switchTool(ToolType.HAND, false)
+                defaultToolController?.switchTool(ToolType.HAND)
                 bottomNavigationViewHolder?.showCurrentTool(ToolType.HAND)
             }
             layerBackground.setBackgroundColor(Color.BLUE)

--- a/colorpicker/src/main/res/values/colors.xml
+++ b/colorpicker/src/main/res/values/colors.xml
@@ -21,7 +21,7 @@
     <color name="pocketpaint_color_picker_rgb_red">#FFEB4618</color>
     <color name="pocketpaint_color_picker_rgb_green">#FF078707</color>
     <color name="pocketpaint_color_picker_rgb_blue">#FF0284e7</color>
-    <color name="pocketpaint_color_picker_rgb_alpha">#FFCCCCCC</color>
+    <color name="pocketpaint_color_picker_rgb_alpha">#FF000000</color>
 
     <color name="pocketpaint_color_picker_blue1">#FF0074CD</color>
     <color name="pocketpaint_color_picker_blue2">#FF00B4F1</color>


### PR DESCRIPTION
Rewrote some parts of switchTool structure in order to highlight(set the color border to orange) the box (of BaseToolWithRectangleShape) for 300 milliseconds before actually switching the tool.

https://jira.catrob.at/browse/PAINTROID-445

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
