### PR TITLE
PAINTROID-224 Access failed test pictures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,10 +121,17 @@ pipeline {
                     }
                     post {
                         always {
-                            sh '/home/user/android/sdk/platform-tools/adb logcat -d > logcat.txt'
-                            sh './gradlew stopEmulator'
                             junitAndCoverage "$reports/coverage/debug/report.xml", 'device', javaSrc
                             archiveArtifacts 'logcat.txt'
+                        }
+                        failure {
+                            sh 'rm -rf /home/user/androidData; mkdir /home/user/androidData'
+                            sh '/home/user/android/sdk/platform-tools/adb pull /storage/emulated/0/Android/data/org.catrobat.paintroid.test/files /home/user/androidData'
+                            archiveArtifacts "/home/user/androidData/**/*"
+                            archiveArtifacts "/home/user/androidData/*"
+                        }
+                        cleanup {
+                            sh './gradlew stopEmulator'
                         }
                     }
                 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/utils/ScreenshotOnFailRule.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/utils/ScreenshotOnFailRule.java
@@ -80,6 +80,7 @@ public class ScreenshotOnFailRule extends TestWatcher {
 		}
 
 		String filename = description.getClassName() + "-" + description.getMethodName() + ".png";
+		Log.i(LOG_TAG, "Saving screenshot under " + path + "/" + filename);
 		saveScreenshot(screenshot, new File(path, filename));
 	}
 


### PR DESCRIPTION
Added shell commands to correctly pull screenshots from the device and archive artifacts

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
