### PR TITLE
PAINTROID-185: Visibility of the text tool settings

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.kt
@@ -33,11 +33,10 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.withHint
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.google.android.material.button.MaterialButton
@@ -70,6 +69,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.math.roundToInt
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withHint
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import org.hamcrest.CoreMatchers.not
 
 @RunWith(AndroidJUnit4::class)
 @Suppress("LargeClass")
@@ -118,13 +122,12 @@ class TextToolIntegrationTest {
     }
 
     @Test
-    fun testTextToolStillEditableAfterClosingTextTool() {
+    fun testTextToolStillEditableAfterClickingInsideTheCanvasTextToolOptionsVisible() {
         selectFormatting(FormattingOptions.ITALIC)
         selectFormatting(FormattingOptions.BOLD)
         selectFormatting(FormattingOptions.UNDERLINE)
         enterTestText()
-        onDrawingSurfaceView()
-            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_input_text)).perform(click())
         onView(withId(R.id.pocketpaint_text_tool_dialog_input_text)).perform(
             ViewActions.replaceText(
                 TEST_TEXT_ADVANCED
@@ -134,6 +137,39 @@ class TextToolIntegrationTest {
         boldToggleButton?.let { Assert.assertTrue(it.isChecked) }
         underlinedToggleButton?.let { Assert.assertTrue(it.isChecked) }
         Assert.assertEquals(TEST_TEXT_ADVANCED, textEditText?.text?.toString())
+        onView(withId(R.id.pocketpaint_text_tool_dialog_input_text)).check(matches(isDisplayed()))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_list_font)).check(matches(isDisplayed()))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_underlined)).check(matches(isDisplayed()))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_italic)).check(matches(isDisplayed()))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_bold)).check(matches(isDisplayed()))
+        onView(withId(R.id.pocketpaint_font_size_text)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testTextToolNotEditableAfterClickingOutsideTheCanvasTextToolOptionsHidden() {
+        selectFormatting(FormattingOptions.ITALIC)
+        selectFormatting(FormattingOptions.BOLD)
+        selectFormatting(FormattingOptions.UNDERLINE)
+        enterTestText()
+        onDrawingSurfaceView()
+            .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+
+        italicToggleButton?.let { Assert.assertTrue(it.isChecked) }
+        boldToggleButton?.let { Assert.assertTrue(it.isChecked) }
+        underlinedToggleButton?.let { Assert.assertTrue(it.isChecked) }
+        Assert.assertEquals(TEST_TEXT, textEditText?.text?.toString())
+        onView(withId(R.id.pocketpaint_text_tool_dialog_input_text))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_list_font))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_underlined))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_italic))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.pocketpaint_text_tool_dialog_toggle_bold))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.pocketpaint_font_size_text))
+            .check(matches(not(isDisplayed())))
     }
 
     @Ignore("Fix bug in own ticket , focus is not correctly implemented in google play either")

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -166,6 +166,14 @@ abstract class BaseToolWithRectangleShape(
     private var touchDownPositionX = 0f
     private var touchDownPositionY = 0f
 
+    enum class OptionsViewStates {
+        HIDDEN,
+        VISIBLE,
+    }
+
+    private var optionsViewState = OptionsViewStates.VISIBLE
+
+
     init {
         val orientation = contextCallback.orientation
         val boxSize =
@@ -249,21 +257,33 @@ abstract class BaseToolWithRectangleShape(
     }
 
     private fun hideToolSpecificLayout() {
-        toolOptionsViewController.slideDown(
-            toolOptionsViewController.toolSpecificOptionsLayout, true
-        )
+        if (optionsViewState == OptionsViewStates.VISIBLE) {
+            if (this !is TextTool) {
+                toolOptionsViewController.slideDown(
+                    toolOptionsViewController.toolSpecificOptionsLayout, true
+                )
+            }
+            toolOptionsViewController.animateBottomAndTopNavigation(true)
+            optionsViewState = OptionsViewStates.HIDDEN
+        }
     }
 
     private fun showToolSpecificLayout() {
-        toolOptionsViewController.slideUp(
-            toolOptionsViewController.toolSpecificOptionsLayout, false
-        )
+        if (optionsViewState == OptionsViewStates.HIDDEN) {
+            if (this !is TextTool) {
+                toolOptionsViewController.slideUp(
+                    toolOptionsViewController.toolSpecificOptionsLayout, false
+                )
+            }
+
+            toolOptionsViewController.animateBottomAndTopNavigation(false)
+            optionsViewState = OptionsViewStates.VISIBLE
+        }
     }
 
     override fun handleDown(coordinate: PointF?): Boolean {
         movedDistance.set(0f, 0f)
-        super.handleDown(coordinate)
-        hideToolSpecificLayout()
+
         coordinate?.apply {
             previousEventCoordinate = PointF(x, y)
             currentAction = getAction(x, y)
@@ -277,6 +297,7 @@ abstract class BaseToolWithRectangleShape(
         if (previousEventCoordinate == null || currentAction == null) {
             return false
         }
+        hideToolSpecificLayout()
         ifNotNull(coordinate, previousEventCoordinate) { (coordinate, previousEventCoordinate) ->
             val delta = PointF(
                 coordinate.x - previousEventCoordinate.x,
@@ -299,7 +320,6 @@ abstract class BaseToolWithRectangleShape(
             return false
         }
         showToolSpecificLayout()
-        super.handleUp(coordinate)
         ifNotNull(coordinate, previousEventCoordinate) { (coordinate, previousEventCoordinate) ->
             movedDistance.x += abs(coordinate.x - previousEventCoordinate.x)
             movedDistance.y += abs(coordinate.y - previousEventCoordinate.y)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.kt
@@ -33,6 +33,10 @@ interface TextToolOptionsView {
 
     fun setCallback(listener: Callback)
 
+    fun hideKeyboard()
+
+    fun showKeyboard()
+
     fun getTopLayout(): View
 
     fun getBottomLayout(): View

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.kt
@@ -177,9 +177,14 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
         callback = listener
     }
 
-    private fun hideKeyboard() {
+    override fun hideKeyboard() {
         val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(textEditText.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
+    }
+
+    override fun showKeyboard() {
+        val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.toggleSoftInputFromWindow(textEditText.windowToken, InputMethodManager.SHOW_IMPLICIT, InputMethodManager.HIDE_NOT_ALWAYS)
     }
 
     override fun getTopLayout(): View = topLayout


### PR DESCRIPTION
Implemented the hiding/showing of text tool settings:

- tapping anywhere on the canvas (except on the settings) hides the settings and also the keyboard if it's open
- tapping or long-pressing on the text-placing rectangle, when setting are hidden, shows them and opens the keyboard

Also implemented the tests for it.

JIRA ticket: https://jira.catrob.at/browse/PAINTROID-185

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
