### PR TITLE
PAINTROID-486 Keyboard is hidden after RGB view

### DIFF
--- a/Paintroid/src/main/AndroidManifest.xml
+++ b/Paintroid/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         <activity
             android:name=".MainActivity"
             android:theme="@style/PocketPaintSplashTheme"
+            android:windowSoftInputMode="stateAlwaysHidden"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.GET_CONTENT" />


### PR DESCRIPTION

Fixes: PAINTROID-486

Keyboard is made hidden after RGB view is closed

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed
- [X] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
