### PR TITLE
PAINTROID-494 Change toolbaricon of stamp tool

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.kt
@@ -203,7 +203,7 @@ class LandscapeIntegrationTest {
 
     @Test
     fun testCorrectSelectionInBothOrientationsStampTool() {
-        val toolType = ToolType.STAMP
+        val toolType = ToolType.CLIPBOARD
         onToolBarView()
             .performSelectTool(toolType)
         setOrientation(SCREEN_ORIENTATION_LANDSCAPE)

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOptionsIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOptionsIntegrationTest.kt
@@ -74,7 +74,7 @@ class ToolOptionsIntegrationTest(
                 arrayOf(ToolType.CURSOR, true, true),
                 arrayOf(ToolType.FILL, true, true),
                 arrayOf(ToolType.PIPETTE, false, false),
-                arrayOf(ToolType.STAMP, true, true),
+                arrayOf(ToolType.CLIPBOARD, true, true),
                 arrayOf(ToolType.ERASER, true, true),
                 arrayOf(ToolType.TEXT, true, true),
                 arrayOf(ToolType.HAND, false, false),

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClipboardToolIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClipboardToolIntegrationTest.java
@@ -27,8 +27,7 @@ import android.graphics.PointF;
 import org.catrobat.paintroid.MainActivity;
 import org.catrobat.paintroid.test.espresso.util.BitmapLocationProvider;
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider;
-import org.catrobat.paintroid.test.espresso.util.wrappers.LayerMenuViewInteraction;
-import org.catrobat.paintroid.test.espresso.util.wrappers.StampToolViewInteraction;
+import org.catrobat.paintroid.test.espresso.util.wrappers.ClipboardToolViewInteraction;
 import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.tools.ToolType;
@@ -36,7 +35,7 @@ import org.catrobat.paintroid.tools.Workspace;
 import org.catrobat.paintroid.tools.drawable.DrawableShape;
 import org.catrobat.paintroid.tools.drawable.DrawableStyle;
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape;
-import org.catrobat.paintroid.tools.implementation.StampTool;
+import org.catrobat.paintroid.tools.implementation.ClipboardTool;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,7 +57,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
-public class StampToolIntegrationTest {
+public class ClipboardToolIntegrationTest {
 
 	private static final float SCALE_25 = 0.25f;
 	private static final float STAMP_RESIZE_FACTOR = 1.5f;
@@ -96,19 +95,19 @@ public class StampToolIntegrationTest {
 				.performClickCheckmark();
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
-		StampTool stampTool = (StampTool) toolReference.getTool();
-		stampTool.boxHeight -= 25;
-		stampTool.boxWidth -= 25;
+		ClipboardTool clipboardTool = (ClipboardTool) toolReference.getTool();
+		clipboardTool.boxHeight -= 25;
+		clipboardTool.boxWidth -= 25;
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performCopy();
 
-		int topLeft = stampTool.drawingBitmap.getPixel(0, 0);
-		int topRight = stampTool.drawingBitmap.getPixel(stampTool.drawingBitmap.getWidth() - 1, 0);
-		int bottomLeft = stampTool.drawingBitmap.getPixel(0, stampTool.drawingBitmap.getHeight() - 1);
-		int bottomRight = stampTool.drawingBitmap.getPixel(stampTool.drawingBitmap.getWidth() - 1, stampTool.drawingBitmap.getHeight() - 1);
+		int topLeft = clipboardTool.drawingBitmap.getPixel(0, 0);
+		int topRight = clipboardTool.drawingBitmap.getPixel(clipboardTool.drawingBitmap.getWidth() - 1, 0);
+		int bottomLeft = clipboardTool.drawingBitmap.getPixel(0, clipboardTool.drawingBitmap.getHeight() - 1);
+		int bottomRight = clipboardTool.drawingBitmap.getPixel(clipboardTool.drawingBitmap.getWidth() - 1, clipboardTool.drawingBitmap.getHeight() - 1);
 
 		assertEquals(topLeft, Color.BLACK);
 		assertEquals(topRight, Color.BLACK);
@@ -117,7 +116,7 @@ public class StampToolIntegrationTest {
 	}
 
 	@Test
-	public void testStampToolConsidersLayerOpacity() {
+	public void testClipboardToolConsidersLayerOpacity() {
 		onToolBarView()
 				.performSelectTool(ToolType.SHAPE);
 
@@ -128,34 +127,34 @@ public class StampToolIntegrationTest {
 				.performClickCheckmark();
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
-		LayerMenuViewInteraction.onLayerMenuView()
+		org.catrobat.paintroid.test.espresso.util.wrappers.LayerMenuViewInteraction.onLayerMenuView()
 				.performOpen()
 				.performSetOpacityTo(50, 0)
 				.performClose();
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performCopy();
 
-		StampTool stampTool = (StampTool) toolReference.getTool();
+		ClipboardTool clipboardTool = (ClipboardTool) toolReference.getTool();
 		int fiftyPercentOpacityBlack = Color.argb(255 / 2, 0, 0, 0);
-		int centerPixel = stampTool.drawingBitmap.getPixel(stampTool.drawingBitmap.getWidth() / 2, stampTool.drawingBitmap.getHeight() / 2);
+		int centerPixel = clipboardTool.drawingBitmap.getPixel(clipboardTool.drawingBitmap.getWidth() / 2, clipboardTool.drawingBitmap.getHeight() / 2);
 		assertEquals(centerPixel, Color.BLACK);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performPaste();
 
 		onDrawingSurfaceView()
 				.checkPixelColor(fiftyPercentOpacityBlack, BitmapLocationProvider.MIDDLE);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performCut();
 
 		onDrawingSurfaceView()
 				.checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performPaste();
 
 		onDrawingSurfaceView()
@@ -169,19 +168,19 @@ public class StampToolIntegrationTest {
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performCopy();
 
-		StampTool stampTool = (StampTool) toolReference.getTool();
-		stampTool.toolPosition.set(stampTool.toolPosition.x, stampTool.toolPosition.y * .5f);
+		ClipboardTool clipboardTool = (ClipboardTool) toolReference.getTool();
+		clipboardTool.toolPosition.set(clipboardTool.toolPosition.x, clipboardTool.toolPosition.y * .5f);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performPaste();
 
 		onDrawingSurfaceView()
-				.checkPixelColor(Color.BLACK, stampTool.toolPosition.x, stampTool.toolPosition.y);
+				.checkPixelColor(Color.BLACK, clipboardTool.toolPosition.x, clipboardTool.toolPosition.y);
 	}
 
 	@Test
@@ -191,30 +190,30 @@ public class StampToolIntegrationTest {
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performCut();
 
-		StampTool stampTool = (StampTool) toolReference.getTool();
+		ClipboardTool clipboardTool = (ClipboardTool) toolReference.getTool();
 
 		onDrawingSurfaceView()
-				.checkPixelColor(Color.TRANSPARENT, stampTool.toolPosition.x, stampTool.toolPosition.y);
+				.checkPixelColor(Color.TRANSPARENT, clipboardTool.toolPosition.x, clipboardTool.toolPosition.y);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performPaste();
 
 		onDrawingSurfaceView()
-				.checkPixelColor(Color.BLACK, stampTool.toolPosition.x, stampTool.toolPosition.y);
+				.checkPixelColor(Color.BLACK, clipboardTool.toolPosition.x, clipboardTool.toolPosition.y);
 	}
 
 	@Test
-	public void testStampToolNotCapturingOtherLayers() {
+	public void testClipboardToolNotCapturingOtherLayers() {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
 		onLayerMenuView()
 				.performOpen()
@@ -223,21 +222,21 @@ public class StampToolIntegrationTest {
 		onLayerMenuView()
 				.performClose();
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performCopy();
 
-		StampTool stampTool = (StampTool) toolReference.getTool();
-		stampTool.toolPosition.set(stampTool.toolPosition.x, stampTool.toolPosition.y * .5f);
+		ClipboardTool clipboardTool = (ClipboardTool) toolReference.getTool();
+		clipboardTool.toolPosition.set(clipboardTool.toolPosition.x, clipboardTool.toolPosition.y * .5f);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performPaste();
 
 		onDrawingSurfaceView()
-				.checkPixelColor(Color.TRANSPARENT, stampTool.toolPosition.x, stampTool.toolPosition.y * .5f);
+				.checkPixelColor(Color.TRANSPARENT, clipboardTool.toolPosition.x, clipboardTool.toolPosition.y * .5f);
 	}
 
 	@Test
-	public void testStampOutsideDrawingSurface() {
+	public void testClipboardToolOutsideDrawingSurface() {
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
@@ -246,18 +245,18 @@ public class StampToolIntegrationTest {
 		perspective.setScale(SCALE_25);
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
-		StampTool stampTool = (StampTool) toolReference.getTool();
+		ClipboardTool clipboardTool = (ClipboardTool) toolReference.getTool();
 		PointF toolPosition = new PointF(perspective.surfaceCenterX, perspective.surfaceCenterY);
-		stampTool.toolPosition.set(toolPosition);
-		stampTool.boxWidth = (int) (bitmapWidth * STAMP_RESIZE_FACTOR);
-		stampTool.boxHeight = (int) (bitmapHeight * STAMP_RESIZE_FACTOR);
+		clipboardTool.toolPosition.set(toolPosition);
+		clipboardTool.boxWidth = (int) (bitmapWidth * STAMP_RESIZE_FACTOR);
+		clipboardTool.boxHeight = (int) (bitmapHeight * STAMP_RESIZE_FACTOR);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performPaste();
 
-		assertNotNull(stampTool.drawingBitmap);
+		assertNotNull(clipboardTool.drawingBitmap);
 	}
 
 	@Test
@@ -266,12 +265,12 @@ public class StampToolIntegrationTest {
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
 		Bitmap emptyBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
 				toolReference.getTool()).drawingBitmap);
 
-		StampToolViewInteraction.Companion.onStampToolViewInteraction()
+		ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction()
 				.performCopy();
 
 		Bitmap expectedBitmap = Bitmap.createBitmap(((BaseToolWithRectangleShape)
@@ -288,7 +287,7 @@ public class StampToolIntegrationTest {
 	}
 
 	@Test
-	public void testStampToolDoesNotResetPerspectiveScale() {
+	public void testClipboardToolDoesNotResetPerspectiveScale() {
 		float scale = 2.0f;
 
 		perspective.setScale(scale);
@@ -297,7 +296,7 @@ public class StampToolIntegrationTest {
 		mainActivity.refreshDrawingSurface();
 
 		onToolBarView()
-				.performSelectTool(ToolType.STAMP);
+				.performSelectTool(ToolType.CLIPBOARD);
 
 		assertEquals(scale, perspective.getScale(), 0.0001f);
 	}

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ClipboardToolViewInteraction.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ClipboardToolViewInteraction.kt
@@ -24,27 +24,27 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.catrobat.paintroid.R
 
-class StampToolViewInteraction(viewInteraction: ViewInteraction) :
+class ClipboardToolViewInteraction(viewInteraction: ViewInteraction) :
     CustomViewInteraction(viewInteraction) {
 
     companion object {
-        fun onStampToolViewInteraction(): StampToolViewInteraction =
-            StampToolViewInteraction(onView(withId(R.id.pocketpaint_layout_tool_specific_options)))
+        fun onClipboardToolViewInteraction(): ClipboardToolViewInteraction =
+            ClipboardToolViewInteraction(onView(withId(R.id.pocketpaint_layout_tool_specific_options)))
     }
 
-    fun performCopy(): StampToolViewInteraction {
+    fun performCopy(): ClipboardToolViewInteraction {
         onView(withId(R.id.action_copy))
             .perform(click())
         return this
     }
 
-    fun performCut(): StampToolViewInteraction {
+    fun performCut(): ClipboardToolViewInteraction {
         onView(withId(R.id.action_cut))
             .perform(click())
         return this
     }
 
-    fun performPaste(): StampToolViewInteraction {
+    fun performPaste(): ClipboardToolViewInteraction {
         onView(withId(R.id.action_paste))
             .perform(click())
         return this

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/ClipboardCommandTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/command/ClipboardCommandTest.java
@@ -28,7 +28,7 @@ import android.graphics.Point;
 import android.graphics.PointF;
 
 import org.catrobat.paintroid.PaintroidApplication;
-import org.catrobat.paintroid.command.implementation.StampCommand;
+import org.catrobat.paintroid.command.implementation.ClipboardCommand;
 import org.catrobat.paintroid.model.Layer;
 import org.catrobat.paintroid.model.LayerModel;
 import org.catrobat.paintroid.test.utils.PaintroidAsserts;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class StampCommandTest {
+public class ClipboardCommandTest {
 
 	private Bitmap stampBitmapUnderTest;
 
@@ -53,7 +53,7 @@ public class StampCommandTest {
 	private static final int INITIAL_HEIGHT = 80;
 	private static final int INITIAL_WIDTH = 80;
 
-	private StampCommand commandUnderTest;
+	private ClipboardCommand commandUnderTest;
 	private PointF pointUnderTest;
 	private Canvas canvasUnderTest;
 	private Bitmap canvasBitmapUnderTest;
@@ -79,7 +79,7 @@ public class StampCommandTest {
 
 		stampBitmapUnderTest = canvasBitmapUnderTest.copy(Config.ARGB_8888, true);
 		stampBitmapUnderTest.eraseColor(BITMAP_REPLACE_COLOR);
-		commandUnderTest = new StampCommand(stampBitmapUnderTest, new Point(canvasBitmapUnderTest.getWidth() / 2,
+		commandUnderTest = new ClipboardCommand(stampBitmapUnderTest, new Point(canvasBitmapUnderTest.getWidth() / 2,
 				canvasBitmapUnderTest.getHeight() / 2), canvasBitmapUnderTest.getWidth(),
 				canvasBitmapUnderTest.getHeight(), 0);
 	}
@@ -106,7 +106,7 @@ public class StampCommandTest {
 	@Test
 	public void testRunRotateStamp() {
 		stampBitmapUnderTest.setPixel(0, 0, Color.GREEN);
-		commandUnderTest = new StampCommand(stampBitmapUnderTest, new Point((int) pointUnderTest.x,
+		commandUnderTest = new ClipboardCommand(stampBitmapUnderTest, new Point((int) pointUnderTest.x,
 				(int) pointUnderTest.y), canvasBitmapUnderTest.getWidth(), canvasBitmapUnderTest.getHeight(), 180);
 		commandUnderTest.run(canvasUnderTest, new LayerModel());
 		stampBitmapUnderTest.setPixel(0, 0, Color.CYAN);

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/serialization/CommandSerializationTest.kt
@@ -50,7 +50,7 @@ import org.catrobat.paintroid.command.implementation.RotateCommand
 import org.catrobat.paintroid.command.implementation.SelectLayerCommand
 import org.catrobat.paintroid.command.implementation.SetDimensionCommand
 import org.catrobat.paintroid.command.implementation.SprayCommand
-import org.catrobat.paintroid.command.implementation.StampCommand
+import org.catrobat.paintroid.command.implementation.ClipboardCommand
 import org.catrobat.paintroid.command.implementation.TextToolCommand
 import org.catrobat.paintroid.command.implementation.SmudgePathCommand
 import org.catrobat.paintroid.command.implementation.LayerOpacityCommand
@@ -348,7 +348,7 @@ class CommandSerializationTest {
     @Test
     fun testSerializeStampCommand() {
         expectedModel.commands.add(
-            commandFactory.createStampCommand(
+            commandFactory.createClipboardCommand(
                 Bitmap.createBitmap(WORKSPACE_WIDTH, WORKSPACE_HEIGHT, Bitmap.Config.ARGB_8888),
                 PointF(20f, 30f), 40f, 50f, 60f
             )
@@ -438,8 +438,8 @@ class CommandSerializationTest {
             is LoadCommand -> equalsLoadCommand(
                 expectedCommand, actualCommand as LoadCommand
             )
-            is StampCommand -> equalsStampCommand(
-                expectedCommand, actualCommand as StampCommand
+            is ClipboardCommand -> equalsStampCommand(
+                expectedCommand, actualCommand as ClipboardCommand
             )
             is LoadLayerListCommand -> equalsLoadBitmapListCommand(
                 expectedCommand, actualCommand as LoadLayerListCommand
@@ -570,7 +570,7 @@ class CommandSerializationTest {
         return true
     }
 
-    private fun equalsStampCommand(expectedCommand: StampCommand, actualCommand: StampCommand) =
+    private fun equalsStampCommand(expectedCommand: ClipboardCommand, actualCommand: ClipboardCommand) =
         expectedCommand.bitmap!!.sameAs(actualCommand.bitmap) && expectedCommand.coordinates == actualCommand.coordinates &&
             expectedCommand.boxWidth == actualCommand.boxWidth && expectedCommand.boxHeight == actualCommand.boxHeight &&
             expectedCommand.boxRotation == actualCommand.boxRotation

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ClipboardToolTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ClipboardToolTest.java
@@ -32,8 +32,8 @@ import org.catrobat.paintroid.tools.ContextCallback;
 import org.catrobat.paintroid.tools.ToolPaint;
 import org.catrobat.paintroid.tools.ToolType;
 import org.catrobat.paintroid.tools.Workspace;
-import org.catrobat.paintroid.tools.implementation.StampTool;
-import org.catrobat.paintroid.tools.options.StampToolOptionsView;
+import org.catrobat.paintroid.tools.implementation.ClipboardTool;
+import org.catrobat.paintroid.tools.options.ClipboardToolOptionsView;
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController;
 import org.catrobat.paintroid.ui.Perspective;
 import org.junit.After;
@@ -56,7 +56,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class StampToolTest {
+public class ClipboardToolTest {
 	@Mock
 	private ToolPaint toolPaint;
 	@Mock
@@ -64,7 +64,7 @@ public class StampToolTest {
 	@Mock
 	private Workspace workspace;
 	@Mock
-	private StampToolOptionsView stampToolOptions;
+	private ClipboardToolOptionsView clipboardToolOptionsView;
 	@Mock
 	private ToolOptionsViewController toolOptionsViewController;
 	@Mock
@@ -72,7 +72,7 @@ public class StampToolTest {
 	@Mock
 	private DisplayMetrics displayMetrics;
 
-	private StampTool tool;
+	private ClipboardTool tool;
 	private CountingIdlingResource idlingResource;
 
 	@Rule
@@ -96,7 +96,7 @@ public class StampToolTest {
 			}
 		});
 
-		tool = new StampTool(stampToolOptions, contextCallback, toolOptionsViewController, toolPaint, workspace, idlingResource, commandManager, 0);
+		tool = new ClipboardTool(clipboardToolOptionsView, contextCallback, toolOptionsViewController, toolPaint, workspace, idlingResource, commandManager, 0);
 	}
 
 	@After
@@ -131,7 +131,7 @@ public class StampToolTest {
 
 	@Test
 	public void testShouldReturnCorrectToolType() {
-		assertEquals(ToolType.STAMP, tool.getToolType());
+		assertEquals(ToolType.CLIPBOARD, tool.getToolType());
 	}
 
 	@Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandFactory.kt
@@ -100,7 +100,7 @@ interface CommandFactory {
 
     fun createResizeCommand(newWidth: Int, newHeight: Int): Command
 
-    fun createStampCommand(
+    fun createClipboardCommand(
         bitmap: Bitmap,
         toolPosition: PointF,
         boxWidth: Float,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ClipboardCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ClipboardCommand.kt
@@ -32,7 +32,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.util.Random
 
-class StampCommand(bitmap: Bitmap, position: Point, width: Float, height: Float, rotation: Float) :
+class ClipboardCommand(bitmap: Bitmap, position: Point, width: Float, height: Float, rotation: Float) :
     Command {
 
     var bitmap: Bitmap? = bitmap.copy(Bitmap.Config.ARGB_8888, false); private set

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandFactory.kt
@@ -166,13 +166,13 @@ class DefaultCommandFactory : CommandFactory {
     override fun createResizeCommand(newWidth: Int, newHeight: Int): Command =
         ResizeCommand(newWidth, newHeight)
 
-    override fun createStampCommand(
+    override fun createClipboardCommand(
         bitmap: Bitmap,
         toolPosition: PointF,
         boxWidth: Float,
         boxHeight: Float,
         boxRotation: Float
-    ): Command = StampCommand(
+    ): Command = ClipboardCommand(
         bitmap,
         toPoint(toolPosition),
         boxWidth,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/ClipboardCommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/ClipboardCommandSerializer.kt
@@ -26,15 +26,15 @@ import com.esotericsoftware.kryo.KryoException
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import org.catrobat.paintroid.FileIO
-import org.catrobat.paintroid.command.implementation.StampCommand
+import org.catrobat.paintroid.command.implementation.ClipboardCommand
 
-class StampCommandSerializer(version: Int) : VersionSerializer<StampCommand>(version) {
+class ClipboardCommandSerializer(version: Int) : VersionSerializer<ClipboardCommand>(version) {
 
     companion object {
         private const val COMPRESSION_QUALITY = 100
     }
 
-    override fun write(kryo: Kryo, output: Output, command: StampCommand) {
+    override fun write(kryo: Kryo, output: Output, command: ClipboardCommand) {
         with(kryo) {
             with(output) {
                 var bitmap = command.fileToStoredBitmap?.let { file ->
@@ -50,10 +50,10 @@ class StampCommandSerializer(version: Int) : VersionSerializer<StampCommand>(ver
         }
     }
 
-    override fun read(kryo: Kryo, input: Input, type: Class<out StampCommand>): StampCommand =
+    override fun read(kryo: Kryo, input: Input, type: Class<out ClipboardCommand>): ClipboardCommand =
         super.handleVersions(this, kryo, input, type)
 
-    override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out StampCommand>): StampCommand {
+    override fun readCurrentVersion(kryo: Kryo, input: Input, type: Class<out ClipboardCommand>): ClipboardCommand {
         return with(kryo) {
             with(input) {
                 val bitmap = BitmapFactory.decodeStream(input)
@@ -61,7 +61,7 @@ class StampCommandSerializer(version: Int) : VersionSerializer<StampCommand>(ver
                 val width = readFloat()
                 val height = readFloat()
                 val rotation = readFloat()
-                StampCommand(bitmap, coordinates, width, height, rotation)
+                ClipboardCommand(bitmap, coordinates, width, height, rotation)
             }
         }
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
@@ -62,7 +62,7 @@ import org.catrobat.paintroid.command.implementation.RotateCommand
 import org.catrobat.paintroid.command.implementation.SelectLayerCommand
 import org.catrobat.paintroid.command.implementation.SetDimensionCommand
 import org.catrobat.paintroid.command.implementation.SprayCommand
-import org.catrobat.paintroid.command.implementation.StampCommand
+import org.catrobat.paintroid.command.implementation.ClipboardCommand
 import org.catrobat.paintroid.command.implementation.TextToolCommand
 import org.catrobat.paintroid.command.implementation.SmudgePathCommand
 import org.catrobat.paintroid.common.Constants.DOWNLOADS_DIRECTORY
@@ -140,7 +140,7 @@ open class CommandSerializer(private val activityContext: Context, private val c
             put(StarDrawable::class.java, GeometricFillCommandSerializer.StarDrawableSerializer(version))
             put(ShapeDrawable::class.java, null)
             put(RectF::class.java, DataStructuresSerializer.RectFSerializer(version))
-            put(StampCommand::class.java, StampCommandSerializer(version))
+            put(ClipboardCommand::class.java, ClipboardCommandSerializer(version))
             put(SerializableTypeface::class.java, SerializableTypeface.TypefaceSerializer(version))
             put(PointCommand::class.java, PointCommandSerializer(version))
             put(SerializablePath.Cube::class.java, SerializablePath.PathActionCubeSerializer(version))

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/ToolType.kt
@@ -80,10 +80,10 @@ enum class ToolType(
         INVALID_RESOURCE_ID,
         true
     ),
-    STAMP(
-        R.string.button_stamp,
-        R.string.help_content_stamp,
-        R.drawable.ic_pocketpaint_tool_stamp,
+    CLIPBOARD(
+        R.string.button_clipboard,
+        R.string.help_content_clipboard,
+        R.drawable.ic_pocketpaint_tool_clipboard,
         EnumSet.of(StateChange.ALL),
         R.id.pocketpaint_tools_stamp,
         INVALID_RESOURCE_ID,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
@@ -30,14 +30,14 @@ import org.catrobat.paintroid.tools.ContextCallback
 import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
-import org.catrobat.paintroid.tools.options.StampToolOptionsView
+import org.catrobat.paintroid.tools.options.ClipboardToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
 private const val BUNDLE_TOOL_READY_FOR_PASTE = "BUNDLE_TOOL_READY_FOR_PASTE"
 private const val BUNDLE_TOOL_DRAWING_BITMAP = "BUNDLE_TOOL_DRAWING_BITMAP"
 
-class StampTool(
-    stampToolOptionsView: StampToolOptionsView,
+class ClipboardTool(
+    clipboardToolOptionsView: ClipboardToolOptionsView,
     contextCallback: ContextCallback,
     toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
@@ -48,7 +48,7 @@ class StampTool(
 ) : BaseToolWithRectangleShape(
     contextCallback, toolOptionsViewController, toolPaint, workspace, idlingResource, commandManager
 ) {
-    private val stampToolOptionsView: StampToolOptionsView
+    private val clipboardToolOptionsView: ClipboardToolOptionsView
     private var readyForPaste = false
     private val isDrawingBitmapReusable: Boolean
         get() {
@@ -59,26 +59,26 @@ class StampTool(
         }
 
     override val toolType: ToolType
-        get() = ToolType.STAMP
+        get() = ToolType.CLIPBOARD
 
     override fun toolPositionCoordinates(coordinate: PointF): PointF = coordinate
 
     init {
         rotationEnabled = true
-        this.stampToolOptionsView = stampToolOptionsView
+        this.clipboardToolOptionsView = clipboardToolOptionsView
         setBitmap(Bitmap.createBitmap(boxWidth.toInt(), boxHeight.toInt(), Bitmap.Config.ARGB_8888))
-        val callback: StampToolOptionsView.Callback = object : StampToolOptionsView.Callback {
+        val callback: ClipboardToolOptionsView.Callback = object : ClipboardToolOptionsView.Callback {
             override fun copyClicked() {
                 highlightBox()
                 copyBoxContent()
-                this@StampTool.stampToolOptionsView.enablePaste(true)
+                this@ClipboardTool.clipboardToolOptionsView.enablePaste(true)
             }
 
             override fun cutClicked() {
                 highlightBox()
                 copyBoxContent()
                 cutBoxContent()
-                this@StampTool.stampToolOptionsView.enablePaste(true)
+                this@ClipboardTool.clipboardToolOptionsView.enablePaste(true)
             }
 
             override fun pasteClicked() {
@@ -86,7 +86,7 @@ class StampTool(
                 pasteBoxContent()
             }
         }
-        stampToolOptionsView.setCallback(callback)
+        clipboardToolOptionsView.setCallback(callback)
         toolOptionsViewController.showDelayed()
     }
 
@@ -112,7 +112,7 @@ class StampTool(
 
     private fun pasteBoxContent() {
         drawingBitmap?.let {
-            val command = commandFactory.createStampCommand(
+            val command = commandFactory.createClipboardCommand(
                 it,
                 toolPosition,
                 boxWidth,
@@ -131,7 +131,7 @@ class StampTool(
 
     override fun onClickOnButton() {
         if (!readyForPaste || drawingBitmap == null) {
-            contextCallback.showNotification(R.string.stamp_tool_copy_hint)
+            contextCallback.showNotification(R.string.clipboard_tool_copy_hint)
         } else if (boxIntersectsWorkspace()) {
             pasteBoxContent()
             highlightBox()
@@ -151,6 +151,6 @@ class StampTool(
             readyForPaste = getBoolean(BUNDLE_TOOL_READY_FOR_PASTE, readyForPaste)
             drawingBitmap = getParcelable(BUNDLE_TOOL_DRAWING_BITMAP)
         }
-        stampToolOptionsView.enablePaste(readyForPaste)
+        clipboardToolOptionsView.enablePaste(readyForPaste)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.kt
@@ -33,7 +33,7 @@ import org.catrobat.paintroid.ui.tools.DefaultBrushToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultFillToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultShapeToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultSprayToolOptionsView
-import org.catrobat.paintroid.ui.tools.DefaultStampToolOptionsView
+import org.catrobat.paintroid.ui.tools.DefaultClipboardToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultTextToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultTransformToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultSmudgeToolOptionsView
@@ -65,8 +65,8 @@ class DefaultToolFactory(mainActivity: MainActivity) : ToolFactory {
                 commandManager,
                 DRAW_TIME_INIT
             )
-            ToolType.STAMP -> StampTool(
-                DefaultStampToolOptionsView(toolLayout),
+            ToolType.CLIPBOARD -> ClipboardTool(
+                DefaultClipboardToolOptionsView(toolLayout),
                 contextCallback,
                 toolOptionsViewController,
                 toolPaint,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.kt
@@ -75,7 +75,7 @@ class ImportTool(
     override fun onClickOnButton() {
         drawingBitmap?.let {
             highlightBox()
-            val command = commandFactory.createStampCommand(
+            val command = commandFactory.createClipboardCommand(
                 it,
                 toolPosition,
                 boxWidth,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ClipboardToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ClipboardToolOptionsView.kt
@@ -18,7 +18,7 @@
  */
 package org.catrobat.paintroid.tools.options
 
-interface StampToolOptionsView {
+interface ClipboardToolOptionsView {
     fun setCallback(callback: Callback)
 
     fun enablePaste(enable: Boolean)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
@@ -23,13 +23,13 @@ import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.chip.Chip
 import org.catrobat.paintroid.R
-import org.catrobat.paintroid.tools.options.StampToolOptionsView
+import org.catrobat.paintroid.tools.options.ClipboardToolOptionsView
 
-class DefaultStampToolOptionsView(rootView: ViewGroup) : StampToolOptionsView {
+class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOptionsView {
     private val pasteChip: Chip
     private val copyChip: Chip
     private val cutChip: Chip
-    private var callback: StampToolOptionsView.Callback? = null
+    private var callback: ClipboardToolOptionsView.Callback? = null
 
     private fun initializeListeners() {
         copyChip.setOnClickListener {
@@ -45,7 +45,7 @@ class DefaultStampToolOptionsView(rootView: ViewGroup) : StampToolOptionsView {
         }
     }
 
-    override fun setCallback(callback: StampToolOptionsView.Callback) {
+    override fun setCallback(callback: ClipboardToolOptionsView.Callback) {
         this.callback = callback
     }
 
@@ -56,7 +56,7 @@ class DefaultStampToolOptionsView(rootView: ViewGroup) : StampToolOptionsView {
     init {
         val inflater = LayoutInflater.from(rootView.context)
         val stampToolOptionsView: View =
-            inflater.inflate(R.layout.dialog_pocketpaint_stamp_tool, rootView)
+            inflater.inflate(R.layout.dialog_pocketpaint_clipboard_tool, rootView)
         copyChip = stampToolOptionsView.findViewById(R.id.action_copy)
         pasteChip = stampToolOptionsView.findViewById(R.id.action_paste)
         cutChip = stampToolOptionsView.findViewById(R.id.action_cut)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/zoomwindow/DefaultZoomWindowController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/zoomwindow/DefaultZoomWindowController.kt
@@ -217,7 +217,7 @@ class DefaultZoomWindowController
         if (
             tool?.toolType?.name.equals(ToolType.HAND.name) ||
             tool?.toolType?.name.equals(ToolType.FILL.name) ||
-            tool?.toolType?.name.equals(ToolType.STAMP.name) ||
+            tool?.toolType?.name.equals(ToolType.CLIPBOARD.name) ||
             tool?.toolType?.name.equals(ToolType.TRANSFORM.name)
         ) {
             return Constants.NOT_COMPATIBLE

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_clipboard.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_clipboard.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="48"
+  android:viewportHeight="48">
+<path
+    android:fillColor="@android:color/white"
+    android:pathData="M39,40H13Q11.8,40 10.9,39.1Q10,38.2 10,37V5Q10,3.8 10.9,2.9Q11.8,2 13,2H30.4L42,13.6V37Q42,38.2 41.1,39.1Q40.2,40 39,40ZM28.9,14.9V5H13Q13,5 13,5Q13,5 13,5V37Q13,37 13,37Q13,37 13,37H39Q39,37 39,37Q39,37 39,37V14.9ZM7,46Q5.8,46 4.9,45.1Q4,44.2 4,43V12.05H7V43Q7,43 7,43Q7,43 7,43H31.9V46ZM13,5V14.9V5V14.9V37Q13,37 13,37Q13,37 13,37Q13,37 13,37Q13,37 13,37V5Q13,5 13,5Q13,5 13,5Z"/>
+</vector>

--- a/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_stamp.xml
+++ b/Paintroid/src/main/res/drawable/ic_pocketpaint_tool_stamp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M12,3A3,3 0,0 0,9 6C9,9 14,13 6,13A2,2 0,0 0,4 15V17H20V15A2,2 0,0 0,18 13C10,13 15,9 15,6C15,4 13.66,3 12,3M6,19V21H18V19H6Z"/>
-</vector>

--- a/Paintroid/src/main/res/layout-land/pocketpaint_layout_bottom_bar.xml
+++ b/Paintroid/src/main/res/layout-land/pocketpaint_layout_bottom_bar.xml
@@ -155,11 +155,11 @@
             style="@style/PocketPaintToolSelectionButton">
             <ImageView
                 style="@style/PocketPaintToolSelectionButtonImageView"
-                android:src="@drawable/ic_pocketpaint_tool_stamp"
-                android:contentDescription="@string/button_stamp"/>
+                android:src="@drawable/ic_pocketpaint_tool_clipboard"
+                android:contentDescription="@string/button_clipboard"/>
             <TextView
                 style="@style/PocketPaintToolSelectionButtonTextView"
-                android:text="@string/button_stamp"/>
+                android:text="@string/button_clipboard"/>
         </LinearLayout>
 
         <LinearLayout

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_clipboard_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_clipboard_tool.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_alignParentStart="true"
-        android:text="@string/stamptool_copy"
+        android:text="@string/clipboard_tool_copy"
         android:theme="@style/Theme.MaterialComponents.Light"
         app:chipIcon="@drawable/ic_pocketpaint_copy"
         app:chipStartPadding="8dp" />
@@ -29,7 +29,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_toEndOf="@+id/space_one"
-        android:text="@string/stamptool_cut"
+        android:text="@string/clipboard_tool_cut"
         android:theme="@style/Theme.MaterialComponents.Light"
         app:chipIcon="@drawable/ic_pocketpaint_cut"
         app:chipStartPadding="8dp" />
@@ -46,7 +46,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_toEndOf="@+id/space_two"
-        android:text="@string/stamptool_paste"
+        android:text="@string/clipboard_tool_paste"
         android:theme="@style/Theme.MaterialComponents.Light"
         app:chipIcon="@drawable/ic_pocketpaint_paste_chip_icon_selector"
         app:chipStartPadding="8dp" />

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_bottom_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_bottom_bar.xml
@@ -159,11 +159,11 @@
             style="@style/PocketPaintToolSelectionButton">
             <ImageView
                 style="@style/PocketPaintToolSelectionButtonImageView"
-                android:src="@drawable/ic_pocketpaint_tool_stamp"
-                android:contentDescription="@string/button_stamp"/>
+                android:src="@drawable/ic_pocketpaint_tool_clipboard"
+                android:contentDescription="@string/button_clipboard"/>
             <TextView
                 style="@style/PocketPaintToolSelectionButtonTextView"
-                android:text="@string/button_stamp"/>
+                android:text="@string/button_clipboard"/>
         </LinearLayout>
 
         <LinearLayout

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_help_bottom_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_help_bottom_bar.xml
@@ -178,12 +178,12 @@
             style="@style/PocketPaintToolSelectionButton">
             <ImageView
                 style="@style/PocketPaintToolSelectionButtonImageView"
-                android:src="@drawable/ic_pocketpaint_tool_stamp"
-                android:contentDescription="@string/button_stamp"
+                android:src="@drawable/ic_pocketpaint_tool_clipboard"
+                android:contentDescription="@string/button_clipboard"
                 app:tint="@color/pocketpaint_color_picker_white"/>
             <TextView
                 style="@style/PocketPaintToolSelectionButtonTextView"
-                android:text="@string/button_stamp"
+                android:text="@string/button_clipboard"
                 android:textColor="@color/pocketpaint_color_picker_white"/>
         </LinearLayout>
 

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -26,7 +26,7 @@
     <string name="button_undo">Undo</string>
     <string name="button_redo">Redo</string>
     <string name="button_info">Information</string>
-    <string name="button_stamp">Stamp</string>
+    <string name="button_clipboard">Clipboard</string>
     <string name="button_import_image">Import image</string>
     <string name="button_eraser">Eraser</string>
     <string name="button_transform">Transform</string>
@@ -45,9 +45,9 @@
 
     <string name="gallery">Gallery</string>
 
-    <string name="stamptool_paste">Paste</string>
-    <string name="stamptool_copy">Copy</string>
-    <string name="stamptool_cut">Cut</string>
+    <string name="clipboard_tool_paste">Paste</string>
+    <string name="clipboard_tool_copy">Copy</string>
+    <string name="clipboard_tool_cut">Cut</string>
 
     <string name="stickers">Stickers</string>
     <string name="dialog_import_image_title" translatable="false">@string/button_import_image</string>
@@ -67,8 +67,8 @@
     <string name="help_content_fill">Tap on the image to fill an area with the selected color.</string>
     <string name="help_content_cursor">Position the cursor where you want to draw. Tap to activate the cursor. Move your finger to draw. Tap again to deactivate.</string>
     <string name="help_content_transform">Use to transform the image.</string>
-    <string name="help_content_stamp">Move and resize the rectangle to cover the area you want to stamp. Tap on copy or cut to select the area. Move it, then tap on paste to stamp.</string>
-    <string name="help_content_import_png">Import an image from the gallery to the stamp tool.</string>
+    <string name="help_content_clipboard">Move and resize the rectangle to cover the area you want to stamp. Tap on copy or cut to select the area. Move it, then tap on paste to stamp.</string>
+    <string name="help_content_import_png">Import an image from the gallery to the clipboard.</string>
     <string name="help_content_line">Draw a straight line.</string>
     <string name="help_content_text">Write text and format it. Resize the text box afterwards. Tap on the checkmark to insert the text on the image.</string>
     <string name="help_content_shape">Choose a shape and tap on the checkmark to insert the selected shape.</string>
@@ -145,7 +145,7 @@
     <string name="transform_set_center_text">Set center</string>
     <string name="pixel">px</string>
 
-    <string name="stamp_tool_copy_hint">Tap on copy to copy content</string>
+    <string name="clipboard_tool_copy_hint">Tap on copy to copy content</string>
 
     <string name="layers_title">Layers</string>
     <string name="layer_new">New layer</string>

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/controller/ToolControllerTest.java
@@ -103,7 +103,7 @@ public class ToolControllerTest {
 				ToolType.UNDO,
 				ToolType.REDO,
 				ToolType.FILL,
-				ToolType.STAMP,
+				ToolType.CLIPBOARD,
 				ToolType.LINE,
 				ToolType.CURSOR,
 				ToolType.IMPORTPNG,


### PR DESCRIPTION
PAINTROID-494 Change toolbaricon of stamp tool

Refactor project and adapt to renaming of stamp tool to clipboard.

[PAINTROID-494](https://jira.catrob.at/browse/PAINTROID-494)

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
