### PR TITLE
PAINTROID 484 Migrate to targetSDKVersion 31

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.18.3'
 
     androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test:rules:1.1.1'
     androidTestImplementation 'org.mockito:mockito-android:2.18.3'
     androidTestImplementation 'tools.fastlane:screengrab:2.1.0'

--- a/Paintroid/src/main/AndroidManifest.xml
+++ b/Paintroid/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
         </provider>
 
         <activity
+            android:exported="false"
             android:name=".WelcomeActivity"
             android:screenOrientation="portrait"
             android:theme="@style/PocketPaintSplashTheme" />

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ plugins {
 ext {
     androidCompileSdkVersion = 30
     androidMinSdkVersion = 21
-    androidTargetSdkVersion = 30
+    androidTargetSdkVersion = 31
 
     androidSupportLibraryVersion = '28.0.0'
 

--- a/colorpicker/src/main/AndroidManifest.xml
+++ b/colorpicker/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <application>
         <activity
+            android:exported="false"
             android:name=".ColorPickerPreviewActivity"
             android:theme="@style/Theme.MaterialComponents.Light.NoActionBar.Bridge" />
     </application>


### PR DESCRIPTION
In order to update the AndroidTargetSdkVersion to 31, the android:exported needed to be set explicitly in the AndroidManifest.xml files and androidx.test.ext:junit had to be updated from v1.1.1 to v1.1.3.
Jira Ticket: https://jira.catrob.at/browse/PAINTROID-484

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
