### PR TITLE
PAINTROID-498  Line Color Changing

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
@@ -113,7 +113,7 @@ class DefaultCommandManager(
         notifyCommandExecuted()
     }
 
-    private fun handleUndo(command: Command) {
+    private fun handleUndo(command: Command, ignoreColorCommand: Boolean = false) {
         var success = true
         var layerCount = layerModel.layerCount
         val currentCommandName = command.javaClass.simpleName
@@ -153,9 +153,13 @@ class DefaultCommandManager(
 
         val iterator = undoCommandList.descendingIterator()
         while (iterator.hasNext()) {
+            var nextCommand = iterator.next()
+            if (nextCommand is ColorChangedCommand && ignoreColorCommand) {
+                continue
+            }
             val currentLayer = layerModel.currentLayer
             canvas.setBitmap(currentLayer?.bitmap)
-            iterator.next().run(canvas, layerModel)
+            nextCommand.run(canvas, layerModel)
         }
 
         if (!currentCommandName.matches(mergeLayerCommandRegex)) {
@@ -231,7 +235,7 @@ class DefaultCommandManager(
         if (undoCommandList.isNotEmpty() && undoCommandList.first != null) {
             val command = undoCommandList.pop()
             redoCommandList.addFirst(command)
-            handleUndo(command)
+            handleUndo(command, true)
         }
         return colorCommandList
     }


### PR DESCRIPTION
[PAINTROID-498](https://jira.catrob.at/browse/PAINTROID-498)

Bug:
When chaning StrokeWidth of LineTool, the methode `commandManager.undoIgnoringColorChangesAndAddCommand(command) ` (LineTool.kt) is called.  `undoIgnoringColorChangesAndAddCommand` then calls ` separateColorCommandsAndUndo()` in order to remove the (only most recent?) `ColorChangedCommands`. But since only the commands from top of the deque are removed, there still can potentially be other "older" `ColorChangedCommands` left in the `undoCommandList`. So when ` separateColorCommandsAndUndo()`  calls `handleUndo()`, the older `ColorChangedCommands` are executed and the color property of `ToolPaint` is changed.  And due to many triggers of `CommonBrushChangedListener` while changing the StrokeWidth, `commandManager.undoIgnoringColorChangesAndAddCommand(command) ` is also called many times.
This leads to a racecondition, because executing old commands in `handleUndo()` while still changing StrokeWidth intereferes with the newly created Commands for changing StrokeWidth. 

`commandManager.undoIgnoringColorChangesAndAddCommand(command) ` was never really ignoring `ColorChangedCommands`. 

Fix:
added second parameter for `HandleUndo()`, so colorChangedCommands can be ignored properly when needed.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
