### PR TITLE
PAINTROID-486 Keyboad does not hide after leaving RGB-View

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorPickerView.kt
@@ -139,7 +139,7 @@ class ColorPickerView : LinearLayoutCompat {
             context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         inputMethodManager.toggleSoftInputFromWindow(
             rootView.applicationWindowToken,
-            InputMethodManager.SHOW_FORCED,
+            InputMethodManager.SHOW_IMPLICIT,
             0
         )
     }


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer



![untitled](https://user-images.githubusercontent.com/99678760/207670645-6bf92c68-43ac-46cf-887b-c9981eec6218.gif)



Fixed Keyboad does not hide after leaving RGB-View

