### PR TITLE
PAINTROID-497 Tool stroke-tip type

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
@@ -79,6 +79,7 @@ open class BrushTool(
             )
         )
         brushToolOptionsView.setCurrentPaint(toolPaint.paint)
+        brushToolOptionsView.setStrokeCapButtonChecked(toolPaint.strokeCap)
     }
 
     override fun draw(canvas: Canvas) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
@@ -101,6 +101,7 @@ open class CursorTool(
             setBrushPreviewListener(CommonBrushPreviewListener(toolPaint, toolType))
             setCurrentPaint(toolPaint.paint)
         }
+        brushToolOptionsView.setStrokeCapButtonChecked(toolPaint.strokeCap)
     }
 
     override fun changePaintColor(color: Int) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
@@ -82,6 +82,7 @@ class LineTool(
             )
         )
         brushToolOptionsView.setCurrentPaint(toolPaint.paint)
+        brushToolOptionsView.setStrokeCapButtonChecked(toolPaint.strokeCap)
         if (topBarViewHolder != null && topBarViewHolder?.plusButton?.visibility == View.VISIBLE) {
             topBarViewHolder?.hidePlusButton()
         }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
@@ -73,7 +73,7 @@ class SmudgeTool(
             )
         )
         smudgeToolOptionsView.setCurrentPaint(toolPaint.paint)
-
+        smudgeToolOptionsView.setStrokeCapButtonChecked(toolPaint.strokeCap)
         smudgeToolOptionsView.setCallback(object : SmudgeToolOptionsView.Callback {
             override fun onPressureChanged(pressure: Int) {
                 updatePressure(pressure)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/BrushToolOptionsView.kt
@@ -28,6 +28,8 @@ interface BrushToolOptionsView {
 
     fun setCurrentPaint(paint: Paint)
 
+    fun setStrokeCapButtonChecked(strokeCap: Cap)
+
     fun setBrushChangedListener(onBrushChangedListener: OnBrushChangedListener)
 
     fun setBrushPreviewListener(onBrushPreviewListener: OnBrushPreviewListener)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptionsView.kt
@@ -31,6 +31,7 @@ import android.widget.EditText
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
@@ -47,12 +48,12 @@ private const val MAX_VAL = 100
 class DefaultBrushToolOptionsView(rootView: ViewGroup) : BrushToolOptionsView {
     private var brushSizeText: EditText
     private var brushWidthSeekBar: SeekBar
+    private var strokeCapButtonsGroup: ChipGroup
     private var buttonCircle: Chip
     private val buttonRect: Chip
     private var brushToolPreview: BrushToolPreview
     private var brushChangedListener: OnBrushChangedListener? = null
     private var currentView = rootView
-    private val capsView: View
 
     companion object {
         private val TAG = DefaultBrushToolOptionsView::class.java.simpleName
@@ -62,13 +63,13 @@ class DefaultBrushToolOptionsView(rootView: ViewGroup) : BrushToolOptionsView {
         val inflater = LayoutInflater.from(rootView.context)
         val brushPickerView = inflater.inflate(R.layout.dialog_pocketpaint_stroke, rootView, true)
         brushPickerView.apply {
+            strokeCapButtonsGroup = findViewById(R.id.pocketpaint_stroke_types)
             buttonCircle = findViewById(R.id.pocketpaint_stroke_ibtn_circle)
             buttonRect = findViewById(R.id.pocketpaint_stroke_ibtn_rect)
             brushWidthSeekBar = findViewById(R.id.pocketpaint_stroke_width_seek_bar)
             brushWidthSeekBar.setOnSeekBarChangeListener(OnBrushChangedWidthSeekBarListener())
             brushSizeText = findViewById(R.id.pocketpaint_stroke_width_width_text)
             brushToolPreview = findViewById(R.id.pocketpaint_brush_tool_preview)
-            capsView = findViewById(R.id.pocketpaint_stroke_types)
         }
         brushSizeText.filters = arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
         buttonCircle.setOnClickListener { onCircleButtonClicked() }
@@ -102,7 +103,7 @@ class DefaultBrushToolOptionsView(rootView: ViewGroup) : BrushToolOptionsView {
     }
 
     override fun hideCaps() {
-        capsView.visibility = View.GONE
+        strokeCapButtonsGroup.visibility = View.GONE
     }
 
     private fun onCircleButtonClicked() {
@@ -139,6 +140,13 @@ class DefaultBrushToolOptionsView(rootView: ViewGroup) : BrushToolOptionsView {
                     .toInt()
             )
         )
+    }
+
+    override fun setStrokeCapButtonChecked(strokeCap: Cap) {
+        when (strokeCap) {
+            Cap.ROUND -> strokeCapButtonsGroup.check(buttonCircle.id)
+            Cap.SQUARE -> strokeCapButtonsGroup.check(buttonRect.id)
+        }
     }
 
     override fun setBrushChangedListener(onBrushChangedListener: OnBrushChangedListener) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultSmudgeToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultSmudgeToolOptionsView.kt
@@ -30,6 +30,7 @@ import android.widget.EditText
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter
 import org.catrobat.paintroid.tools.implementation.DEFAULT_PRESSURE_IN_PERCENT
@@ -48,6 +49,7 @@ private const val MAX_VAL = 100
 class DefaultSmudgeToolOptionsView(rootView: ViewGroup) : SmudgeToolOptionsView {
     private val brushSizeText: EditText
     private val brushWidthSeekBar: SeekBar
+    private var strokeButtonsGroup: ChipGroup
     private val buttonCircle: Chip
     private val buttonRect: Chip
     private val brushToolPreview: BrushToolPreview
@@ -68,6 +70,7 @@ class DefaultSmudgeToolOptionsView(rootView: ViewGroup) : SmudgeToolOptionsView 
         val inflater = LayoutInflater.from(rootView.context)
         val brushPickerView = inflater.inflate(R.layout.dialog_pocketpaint_smudge_tool, rootView, true)
         brushPickerView.apply {
+            strokeButtonsGroup = findViewById(R.id.pocketpaint_stroke_types)
             buttonCircle = findViewById(R.id.pocketpaint_stroke_ibtn_circle)
             buttonRect = findViewById(R.id.pocketpaint_stroke_ibtn_rect)
             brushWidthSeekBar = findViewById(R.id.pocketpaint_stroke_width_seek_bar)
@@ -175,6 +178,13 @@ class DefaultSmudgeToolOptionsView(rootView: ViewGroup) : SmudgeToolOptionsView 
                 paint.strokeWidth.toInt()
             )
         )
+    }
+
+    override fun setStrokeCapButtonChecked(strokeCap: Cap) {
+        when (strokeCap) {
+            Cap.ROUND -> strokeButtonsGroup.check(buttonCircle.id)
+            Cap.SQUARE -> strokeButtonsGroup.check(buttonRect.id)
+        }
     }
 
     override fun setBrushChangedListener(onBrushChangedListener: OnBrushChangedListener) {


### PR DESCRIPTION
Added functionallity to set the correct chip of the stroke ChipGroup when choosing a tool.

[PAINTROID-497](https://jira.catrob.at/browse/PAINTROID-497)

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
