### PR TITLE
PAINTROID-482 Watercolor paths loose their translucent mask after load

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/PaintSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/PaintSerializer.kt
@@ -19,13 +19,16 @@
 package org.catrobat.paintroid.command.serialization
 
 import android.content.Context
+import android.graphics.BlurMaskFilter
 import android.graphics.Paint
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint
+import org.catrobat.paintroid.tools.implementation.WatercolorTool
 
 class PaintSerializer(version: Int, private val activityContext: Context) : VersionSerializer<Paint>(version) {
+
     override fun write(kryo: Kryo, output: Output, paint: Paint) {
         with(output) {
             writeInt(paint.color)
@@ -34,6 +37,8 @@ class PaintSerializer(version: Int, private val activityContext: Context) : Vers
             writeBoolean(paint.isAntiAlias)
             writeInt(paint.style.ordinal)
             writeInt(paint.strokeJoin.ordinal)
+            writeBoolean(paint.maskFilter != null)
+            writeInt(paint.alpha)
         }
     }
 
@@ -48,11 +53,15 @@ class PaintSerializer(version: Int, private val activityContext: Context) : Vers
                 strokeCap = Paint.Cap.values()[readInt()]
             }
         }
+
         return toolPaint.paint.apply {
             with(input) {
                 isAntiAlias = readBoolean()
                 style = Paint.Style.values()[readInt()]
                 strokeJoin = Paint.Join.values()[readInt()]
+                var hadFilter: Boolean = input.readBoolean()
+                alpha = input.readInt()
+                if (hadFilter) maskFilter = BlurMaskFilter(WatercolorTool.calcRange(alpha), BlurMaskFilter.Blur.INNER)
             }
         }
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
@@ -28,9 +28,9 @@ import org.catrobat.paintroid.tools.Workspace
 import org.catrobat.paintroid.tools.options.BrushToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 
-private const val MAX_ALPHA_VALUE = 255
-private const val MAX_NEW_RANGE = 150
-private const val MIN_NEW_RANGE = 20
+const val MAX_ALPHA_VALUE = 255
+const val MAX_NEW_RANGE = 150
+const val MIN_NEW_RANGE = 20
 
 class WatercolorTool(
     brushToolOptionsView: BrushToolOptionsView,
@@ -66,13 +66,14 @@ class WatercolorTool(
         bitmapPaint.maskFilter = BlurMaskFilter(calcRange(bitmapPaint.alpha), BlurMaskFilter.Blur.INNER)
         previewPaint.maskFilter = BlurMaskFilter(calcRange(previewPaint.alpha), BlurMaskFilter.Blur.INNER)
     }
+    companion object {
+        fun calcRange(value: Int): Float {
+            val oldRange = MAX_ALPHA_VALUE
+            val newRange = MAX_NEW_RANGE - MIN_NEW_RANGE
+            var newValue = value * newRange / oldRange + MIN_NEW_RANGE
 
-    private fun calcRange(value: Int): Float {
-        val oldRange = MAX_ALPHA_VALUE
-        val newRange = MAX_NEW_RANGE - MIN_NEW_RANGE
-        var newValue = value * newRange / oldRange + MIN_NEW_RANGE
-
-        newValue = MAX_NEW_RANGE - newValue + MIN_NEW_RANGE
-        return newValue.toFloat()
+            newValue = MAX_NEW_RANGE - newValue + MIN_NEW_RANGE
+            return newValue.toFloat()
+        }
     }
 }


### PR DESCRIPTION
The cause of this issue was that during serializing process of the paint no information about the maskFilter was saved. After closing and opening the app again the correct pathcommand was executed, but due to lack of information the maskFilter was not applied. 

Fix: added boolean value to indicate whether the path had a maskFilter and one int value (alpha) to calculate the range of the maskFilter in the serialization process. After deserializing, this data can be read and the maskFilter can be applied.

[PAINTROID-482](https://jira.catrob.at/browse/PAINTROID-482) 

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
