### PR TITLE
PAINTROID-525 toolspecific options are hidden after leaving fullscree…

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/LandscapeIntegrationTest.kt
@@ -362,8 +362,8 @@ class LandscapeIntegrationTest {
         setOrientation(SCREEN_ORIENTATION_LANDSCAPE)
         pressBack()
         onToolBarView()
-            .performOpenToolOptionsView()
             .performCloseToolOptionsView()
+            .performOpenToolOptionsView()
     }
 
     @Test
@@ -386,8 +386,8 @@ class LandscapeIntegrationTest {
         setOrientation(SCREEN_ORIENTATION_LANDSCAPE)
         pressBack()
         onToolBarView()
-            .performOpenToolOptionsView()
             .performCloseToolOptionsView()
+            .performOpenToolOptionsView()
     }
 
     @Test
@@ -401,8 +401,8 @@ class LandscapeIntegrationTest {
         setOrientation(SCREEN_ORIENTATION_PORTRAIT)
         pressBack()
         onToolBarView()
-            .performOpenToolOptionsView()
             .performCloseToolOptionsView()
+            .performOpenToolOptionsView()
     }
 
     @Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -148,6 +148,7 @@ open class MainActivityPresenter(
 
     var clippingToolInUseAndUndoRedoClicked = false
     var clippingToolPaint = Paint()
+    var toolOptionsViewWasShown = false
 
     override fun replaceImageClicked() {
         checkIfClippingToolNeedsAdjustment()
@@ -716,9 +717,16 @@ open class MainActivityPresenter(
         bottomNavigationViewHolder.show()
         toolController.enableToolOptionsView()
         perspective.exitFullscreen()
+        if (toolOptionsViewWasShown) {
+            toolController.showToolOptionsView()
+            toolOptionsViewWasShown = false
+        }
     }
 
     private fun enterFullscreen() {
+        if (toolController.toolOptionsViewVisible()) {
+            toolOptionsViewWasShown = true
+        }
         view.hideKeyboard()
         view.enterFullscreen()
         topBarViewHolder.hide()


### PR DESCRIPTION
showToolOptions  is called when exiting fullscreen, if they were shown before entering fullscreen.

[PAINTROID-525](https://jira.catrob.at/browse/PAINTROID-525)

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
