### PR TITLE
PAINTROID-399 Fix contrast of text color to background color

### DIFF
--- a/Paintroid/src/main/res/color/background_color_chip_state_list.xml
+++ b/Paintroid/src/main/res/color/background_color_chip_state_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/pocketpaint_colorAccent" android:state_checked="true" />
+    <item android:color="@color/pocketpaint_chip_selected_background_color" android:state_checked="true" />
     <item android:color="@color/design_default_color_background" />
 </selector>

--- a/Paintroid/src/main/res/values/colors.xml
+++ b/Paintroid/src/main/res/values/colors.xml
@@ -20,10 +20,10 @@
 -->
 <resources>
     <!-- PocketPaint theme colors -->
-    <color name="pocketpaint_colorPrimary">#0097A7</color>
-    <color name="pocketpaint_colorPrimaryDark">#00838F</color>
-    <color name="pocketpaint_colorAccent">#33B5E5</color>
-    <color name="pocketpaint_text_color_link">#E68B00</color>
+    <color name="pocketpaint_colorPrimary">#138293</color>
+    <color name="pocketpaint_colorPrimaryDark">#0D6775</color>
+    <color name="pocketpaint_colorAccent">#157DA2</color>
+    <color name="pocketpaint_text_color_link">#BD5800</color>
 
     <!-- PocketPaint main activity -->
     <color name="pocketpaint_main_separator_color">#c8e8ff</color>
@@ -43,4 +43,6 @@
     <color name="pocketpaint_lighter_gray">#DFDADA</color>
     <!-- PocketPaint Highlight Merge Layer -->
     <color name="pocketpaint_color_merge_layer">#33ac86</color>
+    <!-- PocketPaint Tool Highlights -->
+    <color name="pocketpaint_chip_selected_background_color">#33B5E5</color>
 </resources>

--- a/colorpicker/src/main/res/values/colors.xml
+++ b/colorpicker/src/main/res/values/colors.xml
@@ -18,10 +18,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <resources>
-    <color name="pocketpaint_color_picker_rgb_red">#FFEB4618</color>
-    <color name="pocketpaint_color_picker_rgb_green">#FF078707</color>
-    <color name="pocketpaint_color_picker_rgb_blue">#FF0284e7</color>
-    <color name="pocketpaint_color_picker_rgb_alpha">@color/pocketpaint_color_picker_hex_black</color>
+    <color name="pocketpaint_color_picker_rgb_red">#DA3D0E</color>
+    <color name="pocketpaint_color_picker_rgb_green">#138913</color>
+    <color name="pocketpaint_color_picker_rgb_blue">#0C78CB</color>
+    <color name="pocketpaint_color_picker_rgb_alpha">#787676</color>
     <color name="pocketpaint_color_picker_blue1">#FF0074CD</color>
     <color name="pocketpaint_color_picker_blue2">#FF00B4F1</color>
     <color name="pocketpaint_color_picker_green1">#FF078707</color>


### PR DESCRIPTION
https://jira.catrob.at/browse/PAINTROID-399

Added new colors according to the ticket. However it was not possible to change the color of the Color Picker Tab Icon with this since the icon is an image must be dealt separately. Furthermore the Color Picker Transparent Color which used a checkered grey-white image, which was also noticed by Google for contrast issues, was not adressed in the mock-ups in the ticket. However it is worth mentioning for future tickets.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
