### PR TITLE
PAINTROID-530 LineToolBug

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -27,7 +27,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
 import android.graphics.Bitmap
-import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.PointF
 import android.net.Uri
@@ -570,20 +569,14 @@ open class MainActivityPresenter(
         if (view.isKeyboardShown) {
             view.hideKeyboard()
         } else {
-            setBottomNavigationColor(Color.BLACK)
-            if (toolController.currentTool is LineTool) {
-                (toolController.currentTool as LineTool).undoChangePaintColor(Color.BLACK)
-            } else {
                 if (toolController.currentTool is ClippingTool) {
                     val clippingTool = toolController.currentTool as ClippingTool
                     clippingToolPaint = clippingTool.drawPaint
                     commandManager.undo()
                     clippingToolInUseAndUndoRedoClicked = true
                 } else {
-                    toolController.currentTool?.changePaintColor(Color.BLACK)
                     commandManager.undo()
                 }
-            }
         }
         idlingResource.decrement()
     }


### PR DESCRIPTION
When the line tool is selected. We draw a line and then change colors a few times. When clicking the undo, the black color flashes for a couple of  frames. [Jira-Ticket](https://jira.catrob.at/browse/PAINTROID-530)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
