### PR TITLE
PAINTROID-545 Zooming while cursor tool is down deletes the already drawn line

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
@@ -147,6 +147,7 @@ open class DrawingSurfaceListener(
         } else {
             disableAutoScroll()
             if (touchMode == TouchMode.DRAW) {
+                saveToolActionBeforeZoom(PointF(event.x, event.y))
                 currentTool?.resetInternalState(StateChange.MOVE_CANCELED)
             }
             touchMode = TouchMode.PINCH
@@ -163,6 +164,15 @@ open class DrawingSurfaceListener(
                 callback.translatePerspective(xMidPoint - xOld, yMidPoint - yOld)
             }
             zoomController.dismissOnPinch()
+        }
+    }
+
+    private fun saveToolActionBeforeZoom(point: PointF) {
+        val currentTool = callback.getCurrentTool()
+        if (currentTool?.toolType?.name.equals(ToolType.CURSOR.name) ||
+            currentTool?.toolType?.name.equals(ToolType.LINE.name)) {
+            currentTool?.handleUp(point)
+            currentTool?.handleDown(point)
         }
     }
 


### PR DESCRIPTION
[PAINTROID-545](https://jira.catrob.at/browse/PAINTROID-545)

Fixed the bug, zooming while drawing with cursor does not delete the already drawn line anymore

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
