### PR TITLE
PAINTROID-505 Fixed MenuFileActivityIntegrationTests

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -51,7 +51,7 @@ emulators {
 }
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.7"
 }
 
 jacocoAndroidUnitTestReport {

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
@@ -629,7 +629,6 @@ class MenuFileActivityIntegrationTest {
             .perform(replaceText(name))
         onView(withText(R.string.save_button_text)).perform(click())
         onView(isRoot()).perform(waitFor(500))
-        val uri = activity.model.savedPictureUri
         onDrawingSurfaceView().perform(touchAt(MIDDLE))
         onTopBarView().performOpenMoreOptions()
         onView(withText(R.string.menu_save_image)).perform(click())
@@ -639,16 +638,28 @@ class MenuFileActivityIntegrationTest {
         onView(withText(R.string.overwrite_button_text)).perform(click())
         onView(isRoot()).perform(waitFor(500))
 
+        val uri = activity.model.savedPictureUri
         val oldFileName = uri?.path?.let { File(it).name }
         val newFileName = activity.model.savedPictureUri?.path?.let { File(it).name }
 
         assertEquals(oldFileName, newFileName)
-        addUriToDeletionFileList(activity.model.savedPictureUri)
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q){
+            addFileToDeletionFileList(name, FileIO.fileType.value)
+        }else{
+            addUriToDeletionFileList(activity.model.savedPictureUri)
+        }
     }
 
     private fun addUriToDeletionFileList(uri: Uri?) {
         uri?.path?.let {
             deletionFileList.add(File(it))
         }
+    }
+
+    private fun addFileToDeletionFileList(fileName: String?, extension: String?){
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val file = File(dir, "$fileName.$extension")
+        deletionFileList.add(file)
     }
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
@@ -664,7 +664,7 @@ class MenuFileActivityIntegrationTest {
         }
     }
 
-    private fun addFileToDeletionFileList(fileName: String?, extension: String?){
+    private fun addFileToDeletionFileList(fileName: String?, extension: String?) {
         val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val file = File(dir, "$fileName.$extension")
         deletionFileList.add(file)

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
@@ -625,6 +625,8 @@ class MenuFileActivityIntegrationTest {
         FileIO.compressFormat = Bitmap.CompressFormat.PNG
         onTopBarView().performOpenMoreOptions()
         onView(withText(R.string.menu_save_image)).perform(click())
+        onView(withId(R.id.pocketpaint_image_name_save_text))
+            .perform(replaceText(name))
         onView(withText(R.string.save_button_text)).perform(click())
         onView(isRoot()).perform(waitFor(500))
         onDrawingSurfaceView().perform(touchAt(MIDDLE))
@@ -653,12 +655,18 @@ class MenuFileActivityIntegrationTest {
         }
 
         assertEquals(newFileName, "testCI.catrobat-image")
-        addUriToDeletionFileList(activity.model.savedPictureUri)
+        addFileToDeletionFileList(name, FileIO.fileType.value)
     }
 
     private fun addUriToDeletionFileList(uri: Uri?) {
         uri?.path?.let {
             deletionFileList.add(File(it))
         }
+    }
+
+    private fun addFileToDeletionFileList(fileName: String?, extension: String?){
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val file = File(dir, "$fileName.$extension")
+        deletionFileList.add(file)
     }
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
@@ -629,6 +629,7 @@ class MenuFileActivityIntegrationTest {
             .perform(replaceText(name))
         onView(withText(R.string.save_button_text)).perform(click())
         onView(isRoot()).perform(waitFor(500))
+        val uri = activity.model.savedPictureUri
         onDrawingSurfaceView().perform(touchAt(MIDDLE))
         onTopBarView().performOpenMoreOptions()
         onView(withText(R.string.menu_save_image)).perform(click())
@@ -638,35 +639,16 @@ class MenuFileActivityIntegrationTest {
         onView(withText(R.string.overwrite_button_text)).perform(click())
         onView(isRoot()).perform(waitFor(500))
 
-        var newFileName = "new"
-        val uri = activity.model.savedPictureUri
-        if (uri != null) {
-            val cursor = activity.contentResolver.query(
-                uri,
-                arrayOf(MediaStore.Images.ImageColumns.DISPLAY_NAME),
-                null, null, null
-            )
-            cursor?.use {
-                if (cursor.moveToFirst()) {
-                    newFileName =
-                        cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.DISPLAY_NAME))
-                }
-            }
-        }
+        val oldFileName = uri?.path?.let { File(it).name }
+        val newFileName = activity.model.savedPictureUri?.path?.let { File(it).name }
 
-        assertEquals(newFileName, "testCI.catrobat-image")
-        addFileToDeletionFileList(name, FileIO.fileType.value)
+        assertEquals(oldFileName, newFileName)
+        addUriToDeletionFileList(activity.model.savedPictureUri)
     }
 
     private fun addUriToDeletionFileList(uri: Uri?) {
         uri?.path?.let {
             deletionFileList.add(File(it))
         }
-    }
-
-    private fun addFileToDeletionFileList(fileName: String?, extension: String?) {
-        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-        val file = File(dir, "$fileName.$extension")
-        deletionFileList.add(file)
     }
 }

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/MenuFileActivityIntegrationTest.kt
@@ -644,9 +644,9 @@ class MenuFileActivityIntegrationTest {
 
         assertEquals(oldFileName, newFileName)
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             addFileToDeletionFileList(name, FileIO.fileType.value)
-        }else{
+        } else {
             addUriToDeletionFileList(activity.model.savedPictureUri)
         }
     }
@@ -657,7 +657,7 @@ class MenuFileActivityIntegrationTest {
         }
     }
 
-    private fun addFileToDeletionFileList(fileName: String?, extension: String?){
+    private fun addFileToDeletionFileList(fileName: String?, extension: String?) {
         val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val file = File(dir, "$fileName.$extension")
         deletionFileList.add(file)

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.5.30'
     repositories {
         mavenCentral()
         google()


### PR DESCRIPTION
### PAINTROID-505 

### Cause
The MediaStore content provider failed to retrieve the latest file name in the android API 28. Which caused the "ComparisonFailure" exception.

### Fix
Fixed it by replicating from testSameFileNameAfterOverwritePng where the URI is directly extracted from the savedPictureUri and File class and thereby eliminating the reliability on the content provider.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
