### PR TITLE
PAINTROID-548 : Selecting the already selected stroke type unselects it

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/BrushPickerIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/BrushPickerIntegrationTest.java
@@ -50,8 +50,8 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.isSelected;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
@@ -111,10 +111,10 @@ public class BrushPickerIntegrationTest {
 				.check(matches(withText(Integer.toString(DEFAULT_STROKE_WIDTH))));
 		onView(withId(R.id.pocketpaint_stroke_ibtn_rect))
 				.check(matches(isDisplayed()))
-				.check(matches(not(isSelected())));
+				.check(matches(not(isChecked())));
 		onView(withId(R.id.pocketpaint_stroke_ibtn_circle))
 				.check(matches(isDisplayed()))
-				.check(matches(isSelected()));
+				.check(matches(isChecked()));
 
 		setStrokeWidth(MIN_STROKE_WIDTH);
 		setStrokeWidth(MIDDLE_STROKE_WIDTH);
@@ -124,9 +124,9 @@ public class BrushPickerIntegrationTest {
 
 		onView(withId(R.id.pocketpaint_stroke_ibtn_rect))
 				.perform(click())
-				.check(matches(isSelected()));
+				.check(matches(isChecked()));
 		onView(withId(R.id.pocketpaint_stroke_ibtn_circle))
-				.check(matches(not(isSelected())));
+				.check(matches(not(isChecked())));
 
 		assertStrokePaint(getCurrentToolCanvasPaint(), MAX_STROKE_WIDTH, Cap.SQUARE);
 
@@ -248,16 +248,16 @@ public class BrushPickerIntegrationTest {
 	@Test
 	public void brushPickerDialogRadioButtonsBehaviour() {
 		onView(withId(R.id.pocketpaint_stroke_ibtn_rect))
-				.check(matches(not(isSelected())));
+				.check(matches(not(isChecked())));
 		onView(withId(R.id.pocketpaint_stroke_ibtn_circle))
-				.check(matches(isSelected()));
+				.check(matches(isChecked()));
 
 		onView(withId(R.id.pocketpaint_stroke_ibtn_rect))
 				.perform(click())
-				.check(matches(isSelected()));
+				.check(matches(isChecked()));
 
 		onView(withId(R.id.pocketpaint_stroke_ibtn_circle))
-				.check(matches(not(isSelected())));
+				.check(matches(not(isChecked())));
 
 		onToolBarView()
 				.performCloseToolOptionsView();
@@ -269,10 +269,10 @@ public class BrushPickerIntegrationTest {
 
 		onView(withId(R.id.pocketpaint_stroke_ibtn_circle))
 				.perform(click())
-				.check(matches(isSelected()));
+				.check(matches(isChecked()));
 
 		onView(withId(R.id.pocketpaint_stroke_ibtn_rect))
-				.check(matches(not(isSelected())));
+				.check(matches(not(isChecked())));
 
 		assertStrokePaint(getCurrentToolCanvasPaint(), DEFAULT_STROKE_WIDTH, Cap.ROUND);
 

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/BrushToolOptionsViewInteraction.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/BrushToolOptionsViewInteraction.kt
@@ -1,0 +1,60 @@
+/*
+* Paintroid: An image manipulation application for Android.
+* Copyright (C) 2010-2015 The Catrobat Team
+* (<http://developer.catrobat.org/credits>)
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.catrobat.paintroid.test.espresso.util.wrappers
+
+import android.graphics.Paint.Cap
+import org.catrobat.paintroid.R
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import org.hamcrest.core.IsNot.not
+
+class BrushToolOptionsViewInteraction private constructor() :
+    CustomViewInteraction(onView(withId(R.id.pocketpaint_layout_tool_options))) {
+
+    companion object {
+        fun onBrushToolOptionsView(): BrushToolOptionsViewInteraction =
+            BrushToolOptionsViewInteraction()
+    }
+
+    private fun getButtonIdFromShapeDrawType(strokeCapType: Cap): Int {
+        return when (strokeCapType) {
+            Cap.ROUND -> R.id.pocketpaint_stroke_ibtn_circle
+            Cap.SQUARE -> R.id.pocketpaint_stroke_ibtn_rect
+            else -> throw IllegalArgumentException("Unsupported Cap type: $strokeCapType")
+        }
+    }
+
+    fun performSelectStrokeCapType(strokeCapType: Cap): BrushToolOptionsViewInteraction {
+        onView(withId(getButtonIdFromShapeDrawType(strokeCapType)))
+            .perform(click())
+        return this
+    }
+
+    fun checkIfStrokeCapIsChecked(strokeCapType: Cap) {
+        onView(withId(getButtonIdFromShapeDrawType(strokeCapType))).check(matches(isChecked()))
+    }
+
+    fun checkIfStrokeCapIsNotChecked(strokeCapType: Cap) {
+        onView(withId(getButtonIdFromShapeDrawType(strokeCapType))).check(matches(not(isChecked())))
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultBrushToolOptionsView.kt
@@ -97,8 +97,8 @@ class DefaultBrushToolOptionsView(rootView: ViewGroup) : BrushToolOptionsView {
 
     private fun onRectButtonClicked() {
         updateStrokeCap(Cap.SQUARE)
-        buttonRect.isSelected = true
-        buttonCircle.isSelected = false
+        buttonRect.isChecked = true
+        buttonCircle.isChecked = false
         invalidate()
     }
 
@@ -108,8 +108,8 @@ class DefaultBrushToolOptionsView(rootView: ViewGroup) : BrushToolOptionsView {
 
     private fun onCircleButtonClicked() {
         updateStrokeCap(Cap.ROUND)
-        buttonCircle.isSelected = true
-        buttonRect.isSelected = false
+        buttonCircle.isChecked = true
+        buttonRect.isChecked = false
         invalidate()
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultSmudgeToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultSmudgeToolOptionsView.kt
@@ -151,15 +151,15 @@ class DefaultSmudgeToolOptionsView(rootView: ViewGroup) : SmudgeToolOptionsView 
 
     private fun onRectButtonClicked() {
         updateStrokeCap(Cap.SQUARE)
-        buttonRect.isSelected = true
-        buttonCircle.isSelected = false
+        buttonRect.isChecked = true
+        buttonCircle.isChecked = false
         invalidate()
     }
 
     private fun onCircleButtonClicked() {
         updateStrokeCap(Cap.ROUND)
-        buttonCircle.isSelected = true
-        buttonRect.isSelected = false
+        buttonCircle.isChecked = true
+        buttonRect.isChecked = false
         invalidate()
     }
 


### PR DESCRIPTION
[PAINTROID-548](https://jira.catrob.at/browse/PAINTROID-548)

Fixed the bug using isChecked value from button element instead of isSelected. IsSelected is [inherited from the View](https://developer.android.com/reference/android/view/View) and does not update the checked state of the Chip correctly. Created a new wrapper BrushToolOptionsViewInteraction for writing new tests and updated old tests to use isChecked instead of isSelected.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
