### PR TITLE
PAINTROID-507 Fix ToolOnBackPressedIntegrationTests

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/ToolOnBackPressedIntegrationTest.java
@@ -118,6 +118,14 @@ public class ToolOnBackPressedIntegrationTest {
 			saveFile.delete();
 			saveFile = null;
 		}
+
+		String imagesDirectory = String.valueOf(
+				Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES));
+		String pathToFile = imagesDirectory + File.separator + defaultPictureName + FILE_ENDING;
+		File imageFile = new File(pathToFile);
+		if (imageFile.exists()) {
+			imageFile.delete();
+		}
 	}
 
 	@Test
@@ -152,7 +160,7 @@ public class ToolOnBackPressedIntegrationTest {
 	}
 
 	@Test
-	public void testBrushToolBackPressedWithSaveAndOverride() throws IOException {
+	public void testBrushToolBackPressedWithSaveAndOverride() throws IOException, InterruptedException {
 		TopBarViewInteraction.onTopBarView()
 				.performOpenMoreOptions();
 		onView(withText(R.string.menu_save_image))
@@ -172,7 +180,7 @@ public class ToolOnBackPressedIntegrationTest {
 		onView(withText(R.string.save_button_text))
 				.perform(click());
 
-		onView(isRoot()).perform(waitFor(200));
+		onView(isRoot()).perform(waitFor(3000));
 
 		String filename = defaultPictureName + FILE_ENDING;
 		ContentResolver resolver = launchActivityRule.getActivity().getContentResolver();
@@ -181,6 +189,8 @@ public class ToolOnBackPressedIntegrationTest {
 		assertNotNull(uri);
 		InputStream inputStream = resolver.openInputStream(uri);
 		Bitmap oldBitmap = BitmapFactory.decodeStream(inputStream, null, options);
+
+		onView(isRoot()).perform(waitFor(2000));
 
 		onDrawingSurfaceView()
 				.perform(touchAt(DrawingSurfaceLocationProvider.MIDDLE));
@@ -204,10 +214,12 @@ public class ToolOnBackPressedIntegrationTest {
 		onView(withText(R.string.save_button_text))
 				.perform(click());
 
-		onView(isRoot()).perform(waitFor(200));
 		onView(withText(R.string.overwrite_button_text))
 				.perform(click());
-		onView(isRoot()).perform(waitFor(200));
+
+		while (!launchActivityRule.getActivity().isFinishing()) {
+			Thread.sleep(1000);
+		}
 
 		uri = FileIO.INSTANCE.getUriForFilenameInPicturesFolder(filename, resolver);
 		assertNotNull(uri);
@@ -258,7 +270,9 @@ public class ToolOnBackPressedIntegrationTest {
 
 		Espresso.pressBackUnconditionally();
 
-		onView(isRoot()).perform(waitFor(2000));
+		while (!launchActivityRule.getActivity().isFinishing()) {
+			Thread.sleep(1000);
+		}
 
 		assertTrue(launchActivityRule.getActivity().isFinishing());
 		assertTrue(saveFile.exists());


### PR DESCRIPTION
[PAINTROID-507](https://jira.catrob.at/browse/PAINTROID-507)
Both Tests work locally and on Jenkins now too.

1) testBrushToolBackPressedFromCatroidAndUsePicture:
There was a problem with the waitFor()'s being too short or not consistent on Jenkins so the test didn't reach the state that it was supposed to reach before performing an action. Also had problems with performing actions too quickly after a file save, so the file save was probably not done yet, because the time was too short.

2) testBrushToolBackPressedWithSaveAndOverride:
Basically same problem as described above.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
