### PR TITLE
PAINTROID-504 Fix CatrobatImageIOIntegrationTests

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/CatrobatImageIOIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/CatrobatImageIOIntegrationTest.kt
@@ -21,6 +21,7 @@
 package org.catrobat.paintroid.test.espresso
 
 import android.net.Uri
+import android.os.Environment
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
@@ -37,6 +38,7 @@ import org.catrobat.paintroid.FileIO
 import org.catrobat.paintroid.MainActivity
 import org.catrobat.paintroid.command.serialization.CommandSerializer
 import org.catrobat.paintroid.R
+import org.catrobat.paintroid.common.CATROBAT_IMAGE_ENDING
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider
 import org.catrobat.paintroid.test.espresso.util.EspressoUtils
 import org.catrobat.paintroid.test.espresso.util.UiInteractions
@@ -77,10 +79,12 @@ class CatrobatImageIOIntegrationTest {
 
     @After
     fun tearDown() {
-        with(uriFile?.path?.let { File(it) }) {
-            if (this?.exists() == true) {
-                delete()
-            }
+        val imagesDirectory =
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).toString()
+        val pathToFile = imagesDirectory + File.separator + IMAGE_NAME + "." + CATROBAT_IMAGE_ENDING
+        val imageFile = File(pathToFile)
+        if (imageFile.exists()) {
+            imageFile.delete()
         }
     }
 
@@ -103,8 +107,6 @@ class CatrobatImageIOIntegrationTest {
         onView(withId(R.id.pocketpaint_image_name_save_text))
             .perform(replaceText(IMAGE_NAME))
         onView(withText(R.string.save_button_text)).check(matches(isDisplayed()))
-            .perform(ViewActions.click())
-        onView(withText(R.string.overwrite_button_text)).check(matches(isDisplayed()))
             .perform(ViewActions.click())
         uriFile = activity.model.savedPictureUri!!
         Assert.assertNotNull(uriFile)


### PR DESCRIPTION
[PAINTROID-504](https://jira.catrob.at/browse/PAINTROID-504)

The problem was that the test assumed that the overwrite view will pop up but it won't happen because before the test, there shouldn't be the same file already on jenkins, so there won't be a pop up asking if you want to overwrite. It just saves it and is done.
File also gets cleaned up now after executing the test.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
