### PR TITLE
PAINTROID-523 - Image not persistent after closing app

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/TemporaryFileSavingTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/TemporaryFileSavingTest.kt
@@ -86,6 +86,16 @@ class TemporaryFileSavingTest {
     }
 
     @Test
+    fun testNoWaitingTime() {
+        onDrawingSurfaceView()
+                .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+        launchActivityRule.finishActivity()
+        launchActivityRule.launchActivity(intent)
+        onDrawingSurfaceView()
+                .checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE)
+    }
+
+    @Test
     fun testTooShortWaitingTime() {
         onDrawingSurfaceView()
             .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
@@ -93,7 +103,7 @@ class TemporaryFileSavingTest {
         launchActivityRule.finishActivity()
         launchActivityRule.launchActivity(intent)
         onDrawingSurfaceView()
-            .checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.MIDDLE)
+            .checkPixelColor(Color.BLACK, BitmapLocationProvider.MIDDLE)
     }
 
     @Test
@@ -117,7 +127,7 @@ class TemporaryFileSavingTest {
         onDrawingSurfaceView()
             .checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_BOTTOM_RIGHT)
         onDrawingSurfaceView()
-            .checkPixelColor(Color.TRANSPARENT, BitmapLocationProvider.HALFWAY_BOTTOM_LEFT)
+            .checkPixelColor(Color.BLACK, BitmapLocationProvider.HALFWAY_BOTTOM_LEFT)
     }
 
     @Test

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -355,6 +355,11 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
+        if (!hasFocus) {
+            presenterMain.saveNewTemporaryImage()
+            minuteTemporaryCopiesCounter = 0
+            userInteraction = false
+        }
         this.window.decorView.apply {
             systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE or View.SYSTEM_UI_FLAG_FULLSCREEN
         }
@@ -634,6 +639,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
 
     override fun onDestroy() {
         commandManager.removeCommandListener(this)
+        presenterMain.saveNewTemporaryImage()
         if (finishing) {
             commandManager.shutdown()
             appFragment.currentTool = null


### PR DESCRIPTION
[PAINTROID-523](https://jira.catrob.at/browse/PAINTROID-523)

Called `presenterMain.saveNewTemporaryImage()` in the `onWindowFocusChanged`  and `onDestroy` callback. Now everytime the app is closed the temporary is saved an no progress is lost for the user. Also added new test case.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
