### PR TITLE
PAINTROID-572: (LayerAdapter.kt) getter for position: Int' is deprecated. Deprecated…

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -92,7 +92,7 @@ class LayerAdapter(
             get() = itemView
 
         override fun bindView() {
-            val layer = layerPresenter.getLayerItem(position)
+            val layer = layerPresenter.getLayerItem(adapterPosition)
             val isSelected = layer === layerPresenter.getSelectedLayer()
             setSelected(isSelected)
             setLayerVisibilityCheckbox(layer.isVisible)
@@ -100,25 +100,25 @@ class LayerAdapter(
 
             layerVisibilityCheckbox.setOnClickListener {
                 val isVisible = layerVisibilityCheckbox.isChecked
-                layerPresenter.setLayerVisibility(position, isVisible)
+                layerPresenter.setLayerVisibility(adapterPosition, isVisible)
             }
 
             layerBackground.setOnClickListener {
-                layerPresenter.setLayerSelected(position)
+                layerPresenter.setLayerSelected(adapterPosition)
             }
 
             dragHandle.setOnTouchListener { _, event ->
                 when (event.action) {
-                    MotionEvent.ACTION_DOWN -> layerPresenter.onStartDragging(position, itemView)
+                    MotionEvent.ACTION_DOWN -> layerPresenter.onStartDragging(adapterPosition, itemView)
                     MotionEvent.ACTION_UP -> layerPresenter.onStopDragging()
                 }
 
                 true
             }
 
-            opacitySeekBar.progress = layerPresenter.getLayerItem(position).opacityPercentage
+            opacitySeekBar.progress = layerPresenter.getLayerItem(adapterPosition).opacityPercentage
             opacityEditText.filters = arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
-            opacityEditText.setText(layerPresenter.getLayerItem(position).opacityPercentage.toString())
+            opacityEditText.setText(layerPresenter.getLayerItem(adapterPosition).opacityPercentage.toString())
             opacityEditText.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
@@ -136,10 +136,10 @@ class LayerAdapter(
 
                     if (opacityPercentage != opacitySeekBar.progress) {
                         opacitySeekBar.progress = opacityPercentage
-                        layerPresenter.changeLayerOpacity(position, opacityPercentage)
+                        layerPresenter.changeLayerOpacity(adapterPosition, opacityPercentage)
                     }
 
-                    layerPresenter.getLayerItem(position).opacityPercentage = opacityPercentage
+                    layerPresenter.getLayerItem(adapterPosition).opacityPercentage = opacityPercentage
                     layerPresenter.refreshDrawingSurface()
                 }
             })
@@ -159,7 +159,7 @@ class LayerAdapter(
                 }
 
                 override fun onStopTrackingTouch(seekBar: SeekBar) {
-                    layerPresenter.changeLayerOpacity(position, seekBar.progress)
+                    layerPresenter.changeLayerOpacity(adapterPosition, seekBar.progress)
                 }
 
                 override fun onStartTrackingTouch(seekBar: SeekBar) = Unit


### PR DESCRIPTION
[PAINTROID-572](https://jira.catrob.at/browse/PAINTROID-572)

In LayerAdapter.kt ifle below message is showing.
getter for position: Int' is deprecated. Deprecated in Java
Maybe this thing is happening since LayerAdapter.kt file refactoring.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
