### PR TITLE
PAINTROID-429 Kryo does not correctly read files from autosave sometimes

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/dialog/ColorDialogIntegrationTest.java
@@ -28,6 +28,7 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.net.Uri;
+import android.os.Environment;
 import android.view.View;
 
 import org.catrobat.paintroid.MainActivity;
@@ -42,14 +43,13 @@ import org.catrobat.paintroid.test.utils.ScreenshotOnFailRule;
 import org.catrobat.paintroid.tools.ToolReference;
 import org.catrobat.paintroid.ui.Perspective;
 import org.hamcrest.core.AllOf;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import androidx.test.espresso.IdlingRegistry;
@@ -81,7 +81,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
@@ -129,11 +128,19 @@ public class ColorDialogIntegrationTest {
 
 	private ToolReference toolReference;
 
-	private List<File> deletionFileList = new ArrayList<>();
-
 	@Before
 	public void setUp() {
 		toolReference = launchActivityRule.getActivity().toolReference;
+	}
+
+	@After
+	public void tearDown() {
+		String imagesDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).toString();
+		String pathToFile = imagesDirectory + File.separator + IMAGE_NAME + "." + CATROBAT_IMAGE_ENDING;
+		File imageFile = new File(pathToFile);
+		if (imageFile.exists()) {
+			imageFile.delete();
+		}
 	}
 
 	private int getColorById(int colorId) {
@@ -397,7 +404,7 @@ public class ColorDialogIntegrationTest {
 		onView(withId(R.id.color_picker_color_rgb_textview_green)).check(matches(allOf(isDisplayed(), withText(R.string.color_green), withTextColor(getColorById(R.color.pocketpaint_color_picker_rgb_green)))));
 		onView(withId(R.id.color_picker_color_rgb_textview_blue)).check(matches(allOf(isDisplayed(), withText(R.string.color_blue), withTextColor(getColorById(R.color.pocketpaint_color_picker_rgb_blue)))));
 		onView(withId(R.id.color_picker_color_rgb_textview_alpha)).perform(scrollTo());
-		onView(withId(R.id.color_picker_color_rgb_textview_alpha)).check(matches(allOf(isDisplayed(), withText(R.string.color_alpha), withTextColor(getColorById(R.color.pocketpaint_color_picker_rgb_alpha)))));
+		onView(withId(R.id.color_picker_color_rgb_textview_alpha)).check(matches(allOf(isDisplayed(), withText(R.string.color_alpha), withTextColor(getColorById(R.color.pocketpaint_color_picker_hex_black)))));
 
 		onView(withId(R.id.color_picker_color_rgb_textview_red)).perform(scrollTo());
 		onView(withId(R.id.color_picker_color_rgb_seekbar_red)).check(matches(isDisplayed()));
@@ -1004,9 +1011,6 @@ public class ColorDialogIntegrationTest {
 				.performOpenColorPicker();
 		onColorPickerView().checkHistoryColor(3, presetColors.getColor(0, Color.BLACK));
 		presetColors.recycle();
-		if (!deletionFileList.isEmpty() && deletionFileList.get(0) != null && deletionFileList.get(0).exists()) {
-			assertTrue(deletionFileList.get(0).delete());
-		}
 	}
 
 	private void saveCatrobatImage() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -453,14 +453,13 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         )
         perspective = Perspective(layerModel.width, layerModel.height)
         val listener = DefaultWorkspace.Listener { drawingSurface.refreshDrawingSurface() }
-        model = MainActivityModel()
         workspace = DefaultWorkspace(
             layerModel,
             perspective,
             listener,
         )
-        commandSerializer = CommandSerializer(this, commandManager, model)
         model = MainActivityModel()
+        commandSerializer = CommandSerializer(this, commandManager, model)
         zoomWindowController = DefaultZoomWindowController(
             this,
             layerModel,
@@ -468,7 +467,6 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
             toolReference,
             UserPreferences(getPreferences(MODE_PRIVATE))
         )
-        model = MainActivityModel()
         defaultToolController = DefaultToolController(
             toolReference,
             toolOptionsViewController,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
@@ -32,9 +32,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import android.util.Log
 import com.esotericsoftware.kryo.Kryo
-import com.esotericsoftware.kryo.KryoException
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import org.catrobat.paintroid.colorpicker.ColorHistory
@@ -76,7 +74,6 @@ import org.catrobat.paintroid.tools.drawable.OvalDrawable
 import org.catrobat.paintroid.tools.drawable.RectangleDrawable
 import org.catrobat.paintroid.tools.drawable.ShapeDrawable
 import org.catrobat.paintroid.tools.drawable.StarDrawable
-import org.catrobat.paintroid.ui.DrawingSurfaceThread
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -87,7 +84,6 @@ open class CommandSerializer(private val activityContext: Context, private val c
     companion object {
         const val CURRENT_IMAGE_VERSION = 2
         const val MAGIC_VALUE = "CATROBAT"
-        private val TAG = DrawingSurfaceThread::class.java.simpleName
     }
 
     val kryo = Kryo()
@@ -234,21 +230,19 @@ open class CommandSerializer(private val activityContext: Context, private val c
         var commandModel: CommandManagerModel? = null
         var colorHistory: ColorHistory? = null
 
-        try {
-            Input(stream).use { input ->
-                if (!input.readString().equals(MAGIC_VALUE)) {
-                    throw NotCatrobatImageException("Magic Value doesn't exist.")
-                }
-                val imageVersion = input.readInt()
-                if (CURRENT_IMAGE_VERSION != imageVersion) {
-                    setRegisterMapVersion(imageVersion)
-                    registerClasses()
-                }
-                commandModel = kryo.readObject(input, CommandManagerModel::class.java)
+        Input(stream).use { input ->
+            if (!input.readString().equals(MAGIC_VALUE)) {
+                throw NotCatrobatImageException("Magic Value doesn't exist.")
+            }
+            val imageVersion = input.readInt()
+            if (CURRENT_IMAGE_VERSION != imageVersion) {
+                setRegisterMapVersion(imageVersion)
+                registerClasses()
+            }
+            commandModel = kryo.readObject(input, CommandManagerModel::class.java)
+            if (input.available() != 0) {
                 colorHistory = kryo.readObject(input, ColorHistory::class.java)
             }
-        } catch (ex: KryoException) {
-            Log.d(TAG, "KryoException while reading autosave: " + ex.message)
         }
 
         commandModel?.commands?.reverse()


### PR DESCRIPTION
[PAINTROID-429](https://jira.catrob.at/browse/PAINTROID-429)

The model was overwritten twice in the `onCreateMainView` method of the `MainActivity.kt`class. Therefore the actual ColorHistory was always written to the wrong model instance and never to the one in the CommandSerializer. Since the ColorHistory is only written to memory if the model in the CommandSerializer is not empty, it was never written at all.

Fix: Instanciate only one model and read ComandHistory only if there was one written before (if some bytes are left after reading CommandManagerModel from memory) 

Note:

- Fixed testIfRGBSeekBarsDoChangeColor which was failing because of [PAINTROID-397](https://jira.catrob.at/browse/PAINTROID-397).
- Added file cleanup for ColorDialogIntegrationTest

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
