### PR TITLE
PAINTROID-602 Fix "Crash in DefaultCommandManager"

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
@@ -141,8 +141,11 @@ class DefaultCommandManager(
                     layerModel.addLayerAt(0, this)
                 }
             }
-            val commandToRestore = redoCommandList.pop()
-            undoCommandList.addFirst(commandToRestore)
+
+            if (isRedoAvailable) {
+                val commandToRestore = redoCommandList.pop()
+                undoCommandList.addFirst(commandToRestore)
+            }
 
             return
         }
@@ -303,26 +306,29 @@ class DefaultCommandManager(
     }
 
     override fun redoInConnectedLinesMode() {
-        val command = redoCommandList.pop()
-        if (command is ColorChangedCommand) {
-            val colorCommandList = removeColorCommands()
-            if (undoCommandList.isNotEmpty()) {
-                val firstNonColorCommand = undoCommandList.first
-                val color = command.color
+        if (isRedoAvailable) {
+            val command = redoCommandList.pop()
 
-                if (firstNonColorCommand is PathCommand) {
-                    firstNonColorCommand.paint.color = color
-                } else if (firstNonColorCommand is PointCommand) {
-                    firstNonColorCommand.paint.color = color
+            if (command is ColorChangedCommand) {
+                val colorCommandList = removeColorCommands()
+                if (undoCommandList.isNotEmpty()) {
+                    val firstNonColorCommand = undoCommandList.first
+                    val color = command.color
+
+                    if (firstNonColorCommand is PathCommand) {
+                        firstNonColorCommand.paint.color = color
+                    } else if (firstNonColorCommand is PointCommand) {
+                        firstNonColorCommand.paint.color = color
+                    }
+                    executeAllCommands()
                 }
-                executeAllCommands()
+                addAndExecuteCommands(colorCommandList)
             }
-            addAndExecuteCommands(colorCommandList)
-        }
-        undoCommandList.addFirst(command)
+            undoCommandList.addFirst(command)
 
-        executeCommand(command)
-        notifyCommandExecuted()
+            executeCommand(command)
+            notifyCommandExecuted()
+        }
     }
 
     override fun getCommandManagerModelForCatrobatImage(): CommandManagerModel? {
@@ -339,29 +345,37 @@ class DefaultCommandManager(
     }
 
     override fun adjustUndoListForClippingTool() {
-        if (undoCommandList.first.toString().split(".", "@").size < FIVE) {
-            return
-        }
-        val commandName = undoCommandList.first.toString().split(".", "@")[FIVE]
-        if (commandName == ClippingCommand::class.java.simpleName) {
-            val clippingCommand = undoCommandList.pop()
-            undoCommandList.pop()
-            undoCommandList.addFirst(clippingCommand)
+        if (isUndoAvailable) {
+            if (undoCommandList.first.toString().split(".", "@").size < FIVE) {
+                return
+            }
+            val commandName = undoCommandList.first.toString().split(".", "@")[FIVE]
+            if (commandName == ClippingCommand::class.java.simpleName) {
+                val clippingCommand = undoCommandList.pop()
+                undoCommandList.pop()
+                undoCommandList.addFirst(clippingCommand)
+            }
         }
     }
 
     override fun undoInClippingTool() {
-        val command = undoCommandList.pop()
-        handleUndo(command)
-        notifyCommandExecuted()
+        if (isUndoAvailable) {
+            val command = undoCommandList.pop()
+            handleUndo(command)
+            notifyCommandExecuted()
+        }
     }
 
     override fun popFirstCommandInUndo() {
-        undoCommandList.pop()
+        if (isUndoAvailable) {
+            undoCommandList.pop()
+        }
     }
 
     override fun popFirstCommandInRedo() {
-        redoCommandList.pop()
+        if (isRedoAvailable) {
+            redoCommandList.pop()
+        }
     }
 
     override fun setInitialStateCommand(command: Command) {


### PR DESCRIPTION
[PAINTROID-602](https://jira.catrob.at/browse/PAINTROID-602)
This check should fix the bug now in case an access to an element of the undoCommandList happens and the element does not exist..

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
