### PR TITLE
PAINTROID-604 fix KryoException: buffer underflow

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/CommandSerializer.kt
@@ -245,7 +245,9 @@ open class CommandSerializer(private val activityContext: Context, private val c
                     registerClasses()
                 }
                 commandModel = kryo.readObject(input, CommandManagerModel::class.java)
-                colorHistory = kryo.readObject(input, ColorHistory::class.java)
+                if (input.canReadInt()) {
+                    colorHistory = kryo.readObject(input, ColorHistory::class.java)
+                }
             }
         } catch (ex: KryoException) {
             Log.d(TAG, "KryoException while reading autosave: " + ex.message)


### PR DESCRIPTION
[PAINTROID-604](https://jira.catrob.at/browse/PAINTROID-604)
fixes a "KryoException : buffer underflow" that kept occuring when the 
CommandSerializer.readFromInternalMemory
was called and
colorHistory = kryo.readObject(input, ColorHistory::class.java)
was executed and apparently it requires an Int to be read, which it doesn' get so a buffer underflow happened.
Added check that checks if the corresponding readObject can read an Int before it gets executed, so we don't get the exception all the time.

Stack Trace:
![KryoException_Buffer_underflow](https://user-images.githubusercontent.com/71790852/235361695-177fde5c-105b-4b30-ba3b-30b7af5d69e9.png)

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
