### PR TITLE
PAINTROID-605 When fully zoomed in drawings are pixelated

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
@@ -70,17 +70,22 @@ open class LayerModel : LayerContracts.Model {
         val bitmap = Bitmap.createBitmap(referenceBitmap.width, referenceBitmap.height, Bitmap.Config.ARGB_8888)
         val canvas = bitmap?.let { Canvas(it) }
 
-        layers.asReversed().forEach { layer ->
-            if (layer.isVisible) {
-                val alphaPaint = Paint().apply {
-                    alpha = layer.getValueForOpacityPercentage()
-                }
-                canvas?.drawBitmap(layer.bitmap, 0f, 0f, alphaPaint)
-            }
-        }
+        drawLayersOntoCanvas(canvas)
 
         return bitmap
     }
 
     override fun getBitmapListOfAllLayers(): List<Bitmap?> = layers.map { it.bitmap }
+
+    fun drawLayersOntoCanvas(canvas: Canvas?) {
+        layers.asReversed().forEach { layer ->
+            if (layer.isVisible) {
+                val alphaPaint = Paint().apply {
+                    isFilterBitmap = false
+                    alpha = layer.getValueForOpacityPercentage()
+                }
+                canvas?.drawBitmap(layer.bitmap, 0f, 0f, alphaPaint)
+            }
+        }
+    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/DrawingSurface.kt
@@ -44,6 +44,7 @@ import org.catrobat.paintroid.UserPreferences
 import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.listener.DrawingSurfaceListener
 import org.catrobat.paintroid.listener.DrawingSurfaceListener.DrawingSurfaceListenerCallback
+import org.catrobat.paintroid.model.LayerModel
 import org.catrobat.paintroid.tools.Tool
 import org.catrobat.paintroid.tools.ToolReference
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
@@ -158,14 +159,7 @@ open class DrawingSurface : SurfaceView, SurfaceHolder.Callback {
                 surfaceViewCanvas.drawRect(canvasRect, checkeredPattern)
                 surfaceViewCanvas.drawRect(canvasRect, framePaint)
 
-                layerModel.layers.asReversed().forEach { layer ->
-                    if (layer.isVisible) {
-                        val alphaPaint = Paint().apply {
-                            alpha = layer.getValueForOpacityPercentage()
-                        }
-                        surfaceViewCanvas.drawBitmap(layer.bitmap, 0f, 0f, alphaPaint)
-                    }
-                }
+                (layerModel as LayerModel).drawLayersOntoCanvas(surfaceViewCanvas)
 
                 val tool = toolReference.tool
                 when (zoomController.checkIfToolCompatibleWithZoomWindow(tool)) {


### PR DESCRIPTION
[PAINTROID-605](https://jira.catrob.at/browse/PAINTROID-605)

In the `DrawingSurface.doDraw` method, each layer is drawn to the bitmap with the opacity set before drawing. Originally, a `null` value was passed as the `Paint` parameter to `canvas?.drawBitmap()`. However, in a later implementation, a `Paint` object with an alpha value was introduced to allow for varying levels of transparency. However, the `Paint`object by default had a filter enabled, which made the stroke appear blurry.

To fix this issue, set `isFilterBitmap` of the `Paint`object to `false`.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
