### PR TITLE
Paintroid-606 Opening the keyboard changes drawing surface position

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/Perspective.kt
@@ -104,7 +104,7 @@ open class Perspective(private var bitmapWidth: Int, private var bitmapHeight: I
             surfaceWidth = right
             surfaceCenterX = exactCenterX()
             surfaceHeight = bottom
-            surfaceCenterY = exactCenterY()
+            surfaceCenterY = getExactCenterYIgnoreWindowResize(surfaceFrame.exactCenterY())
         }
     }
 
@@ -210,5 +210,14 @@ open class Perspective(private var bitmapWidth: Int, private var bitmapHeight: I
     fun applyToCanvas(canvas: Canvas) {
         canvas.scale(surfaceScale, surfaceScale, surfaceCenterX, surfaceCenterY)
         canvas.translate(surfaceTranslationX, surfaceTranslationY)
+    }
+
+    private fun getExactCenterYIgnoreWindowResize(actualExactCenterY: Float): Float {
+        var exactCenterYIgnoreWindowResize = if (surfaceCenterY != 0.0f && surfaceCenterY > actualExactCenterY) {
+            surfaceCenterY
+        } else {
+            actualExactCenterY
+        }
+        return exactCenterYIgnoreWindowResize
     }
 }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/ui/PerspectiveTests.kt
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/ui/PerspectiveTests.kt
@@ -142,6 +142,12 @@ class PerspectiveTests {
         perspective?.scale?.let { Assert.assertEquals(maxScale, it, Float.MIN_VALUE) }
     }
 
+    @Test
+    fun testSurfaceCenterYNotChangedWhenSurfaceFrameCenterYIsLower() {
+        perspective?.setSurfaceFrame(Rect(0, 0, SURFACE_WIDTH, SURFACE_HEIGHT - 20))
+        Assert.assertEquals(50.0f, perspective?.surfaceCenterY)
+    }
+
     companion object {
         private const val SURFACE_WIDTH = 10
         private const val SURFACE_HEIGHT = 100


### PR DESCRIPTION
[PAINTROID-606](https://jira.catrob.at/browse/PAINTROID-606)

Opening keyboard resizes the app window by default and changes the vertical center of DrawingSurface. This moved the canvas up or down depending on whether the keyboard is opened or closed. Fixed it by ignoring centerY changes of  DrawingSurface.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
