### PR TITLE
PAINTROID-367 Use finger size to set width of watercolor paint brush

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/dialog/AdvancedSettingsDialog.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/dialog/AdvancedSettingsDialog.kt
@@ -9,20 +9,24 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SwitchCompat
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms.smoothing
+import org.catrobat.paintroid.tools.helper.AdvancedSettingsAlgorithms.useEventSize
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint.Companion.antialiasing
 
 class AdvancedSettingsDialog : MainActivityDialogFragment() {
     private var initValueAntialiasing: Boolean = antialiasing
     private var initValueSmoothing: Boolean = smoothing
+    private var initValueUseEventSize: Boolean = useEventSize
 
     @SuppressLint("UseSwitchCompatOrMaterialCode")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val antialiasingSwitch = view.findViewById<SwitchCompat>(R.id.pocketpaint_antialiasing)
         val smoothSwitch = view.findViewById<SwitchCompat>(R.id.pocketpaint_smoothing)
+        val useEventSizeSwitch = view.findViewById<SwitchCompat>(R.id.pocketpaint_eventsize)
 
         antialiasingSwitch.isChecked = antialiasing
         smoothSwitch.isChecked = smoothing
+        useEventSizeSwitch.isChecked = useEventSize
 
         antialiasingSwitch.setOnCheckedChangeListener { _, isChecked ->
             antialiasing = isChecked
@@ -30,6 +34,10 @@ class AdvancedSettingsDialog : MainActivityDialogFragment() {
 
         smoothSwitch?.setOnCheckedChangeListener { _, isChecked ->
             smoothing = isChecked
+        }
+
+        useEventSizeSwitch?.setOnCheckedChangeListener { _, isChecked ->
+            useEventSize = isChecked
         }
     }
 
@@ -49,6 +57,7 @@ class AdvancedSettingsDialog : MainActivityDialogFragment() {
             .setNegativeButton(R.string.cancel_button_text) { _, _ ->
                 antialiasing = initValueAntialiasing
                 smoothing = initValueSmoothing
+                useEventSize = initValueUseEventSize
                 dismiss()
             }
             .create()
@@ -57,6 +66,7 @@ class AdvancedSettingsDialog : MainActivityDialogFragment() {
     override fun onCancel(dialog: DialogInterface) {
         antialiasing = initValueAntialiasing
         smoothing = initValueSmoothing
+        useEventSize = initValueUseEventSize
         super.onCancel(dialog)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.kt
@@ -24,6 +24,7 @@ import android.graphics.Paint.Cap
 import android.graphics.Point
 import android.graphics.PointF
 import android.os.Bundle
+import android.view.MotionEvent
 
 interface Tool {
     val toolType: ToolType
@@ -37,6 +38,8 @@ interface Tool {
     fun handleDown(coordinate: PointF?): Boolean
 
     fun handleMove(coordinate: PointF?): Boolean
+
+    fun handleMove(coordinate: PointF?, event: MotionEvent) : Boolean
 
     fun handleUp(coordinate: PointF?): Boolean
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/AdvancedSettingsAlgorithms.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/AdvancedSettingsAlgorithms.kt
@@ -4,11 +4,13 @@ import android.graphics.PointF
 import org.catrobat.paintroid.command.serialization.SerializablePath
 
 object AdvancedSettingsAlgorithms {
-    @kotlin.jvm.JvmField
+    @JvmField
     var smoothing = true
 
     const val threshold = 0.2
     const val divider = 3
+
+    var useEventSize = false
 
     @JvmStatic
     fun smoothingAlgorithm(pointArray: List<PointF>): SerializablePath {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/PathContainer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/helper/PathContainer.kt
@@ -1,0 +1,107 @@
+package org.catrobat.paintroid.tools.helper
+
+import android.graphics.PointF
+import org.catrobat.paintroid.command.serialization.SerializablePath
+import kotlin.math.sqrt
+
+data class Move(val p: PointF)
+
+class PathContainer {
+    private var moveRight = mutableListOf<Move>()
+    private var moveLeft = mutableListOf<Move>()
+    private var points = mutableListOf<PointF>()
+
+    private var lastEndPoint = PointF(0f, 0f)
+
+    private var endPoint = PointF(0f, 0f)
+
+    private var lastPath: SerializablePath = SerializablePath()
+    fun getClosedPathFromPoints(): SerializablePath {
+        val path = SerializablePath()
+
+        if (moveLeft.isEmpty()) return path
+
+        path.moveTo(moveRight[0].p.x, moveRight[0].p.y)
+        @Suppress("SwallowedException")
+        try {
+            moveRight.forEach { move -> path.lineTo(move.p.x, move.p.y) }
+
+            if (!(endPoint.x == 0f && endPoint.y == 0f)) {
+                path.lineTo(endPoint.x, endPoint.y)
+            }
+            val reversed = moveLeft.reversed()
+
+            reversed.forEach { move -> path.lineTo(move.p.x, move.p.y) }
+        } catch (ex: ConcurrentModificationException) {
+            return lastPath
+        }
+
+        path.close()
+        lastPath = path
+        return path
+    }
+
+    private fun smooth() {
+        moveRight[0] = moveLeft.first()
+        moveRight[moveRight.size - 1] = moveLeft.last()
+
+        moveRight.forEachIndexed { index, move ->
+            if (moveRight.size < index + 2 || move == moveRight.last())
+                return
+
+            if (index == 0)
+                return@forEachIndexed
+
+            val beforeIndex = index - 1
+            val afterIndex = index + 1
+
+            val beforeRight = moveRight[beforeIndex]
+            val afterRight = moveRight[afterIndex]
+            move.p.x = (beforeRight.p.x + afterRight.p.x) / 2
+            move.p.y = (beforeRight.p.y + afterRight.p.y) / 2
+
+            val beforeLeft = moveLeft[beforeIndex]
+            val afterLeft = moveLeft[afterIndex]
+            moveLeft[index].p.x = (beforeLeft.p.x + afterLeft.p.x) / 2
+            moveLeft[index].p.y = (beforeLeft.p.y + afterLeft.p.y) / 2
+        }
+    }
+
+    fun addStartPoint(coordinate: PointF) {
+        points = mutableListOf()
+        points.add(PointF(coordinate.x, coordinate.y))
+        moveRight = mutableListOf()
+        moveLeft = mutableListOf()
+        addNewPoint(coordinate, 0f)
+        lastEndPoint = coordinate
+    }
+
+    fun addNewPoint(canvasPoint: PointF, shiftBy: Float) {
+        if (points.isNotEmpty() && points.last() == canvasPoint) return
+
+        val orthogonalRight = getNormalizedOrthogonalVector(getDirectionalVector(points.last(), canvasPoint))
+        val orthogonalLeft = getNormalizedOrthogonalVector(getDirectionalVector(points.last(), canvasPoint))
+
+        moveRight.add(Move(getPointShiftedByDistanceRight(canvasPoint, orthogonalRight, shiftBy)))
+        moveLeft.add(Move(getPointShiftedByDistanceLeft(canvasPoint, orthogonalLeft, shiftBy)))
+
+        points.add(PointF(canvasPoint.x, canvasPoint.y))
+    }
+
+    fun addEndPoint(coordinate: PointF) {
+        endPoint = PointF(coordinate.x, coordinate.y)
+        smooth()
+    }
+
+    private fun getDirectionalVector(vecA: PointF, vecB: PointF): PointF = PointF(vecA.x - vecB.x, vecA.y - vecB.y)
+
+    private fun getNormalizedOrthogonalVector(vector: PointF): PointF {
+        val orth = PointF(vector.y, -vector.x)
+        val length = sqrt(orth.x * orth.x + orth.y * orth.y)
+        return if(length == 0f) PointF(0.0f, 0.0f) else PointF(orth.x / length, orth.y / length)
+    }
+
+    private fun getPointShiftedByDistanceRight(point: PointF, orth: PointF, shiftBy: Float): PointF = PointF(point.x + shiftBy * orth.x, point.y + shiftBy * orth.y)
+
+    private fun getPointShiftedByDistanceLeft(point: PointF, orth: PointF, shiftBy: Float): PointF = PointF(point.x - shiftBy * orth.x, point.y - shiftBy * orth.y)
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
@@ -24,6 +24,7 @@ import android.graphics.Paint.Cap
 import android.graphics.Point
 import android.graphics.PointF
 import android.os.Bundle
+import android.view.MotionEvent
 import androidx.annotation.ColorInt
 import androidx.test.espresso.idling.CountingIdlingResource
 import org.catrobat.paintroid.command.CommandFactory
@@ -49,7 +50,8 @@ abstract class BaseTool(
     @JvmField
     protected var idlingResource: CountingIdlingResource,
     @JvmField
-    protected var commandManager: CommandManager
+    protected var commandManager: CommandManager,
+    var useEventDependentStrokeWidth: Boolean = false
 ) : Tool {
     @JvmField
     protected val movedDistance: PointF
@@ -96,10 +98,15 @@ abstract class BaseTool(
         return true
     }
 
+<<<<<<< HEAD
     override fun handleMove(coordinate: PointF?): Boolean {
         toolOptionsViewController.animateBottomAndTopNavigation(true)
         return true
     }
+=======
+    override fun handleMove(coordinate: PointF?, event: MotionEvent): Boolean = true
+
+>>>>>>> PAINTROID-367 watercolor tool uses event data for stroke width
     override val drawPaint
         get() = Paint(toolPaint.paint)
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -32,6 +32,7 @@ import android.os.Bundle
 import android.os.CountDownTimer
 import android.util.DisplayMetrics
 import android.view.View
+import android.view.MotionEvent
 import androidx.annotation.ColorRes
 import androidx.annotation.VisibleForTesting
 import androidx.test.espresso.idling.CountingIdlingResource
@@ -308,6 +309,8 @@ abstract class BaseToolWithRectangleShape(
         }
         return true
     }
+
+    override fun handleMove(coordinate: PointF?, event: MotionEvent): Boolean = true
 
     override fun handleUp(coordinate: PointF?): Boolean {
         if (previousEventCoordinate == null) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
@@ -147,6 +147,7 @@ class ClipboardTool(
     }
 
     override fun resetInternalState() = Unit
+
     override fun onSaveInstanceState(bundle: Bundle?) {
         super.onSaveInstanceState(bundle)
         bundle?.putParcelable(BUNDLE_TOOL_DRAWING_BITMAP, drawingBitmap)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
@@ -55,6 +55,8 @@ class WatercolorTool(
         get() = ToolType.WATERCOLOR
 
     init {
+        useEventDependentStrokeWidth = true
+
         bitmapPaint.maskFilter = BlurMaskFilter(calcRange(bitmapPaint.alpha), BlurMaskFilter.Blur.INNER)
         previewPaint.maskFilter = BlurMaskFilter(calcRange(previewPaint.alpha), BlurMaskFilter.Blur.INNER)
     }

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_advanced_settings.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_advanced_settings.xml
@@ -45,4 +45,17 @@
         android:textColor="@color/design_default_color_on_secondary"
         android:theme="@style/CustomSwitchTheme" />
 
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="16dp" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/pocketpaint_eventsize"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:checked="false"
+        android:text="@string/dialog_use_touch_size"
+        android:textColor="@color/design_default_color_on_secondary"
+        android:theme="@style/CustomSwitchTheme" />
+
 </LinearLayout>

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -167,6 +167,7 @@
 
     <string name="dialog_antialiasing">Antialiasing</string>
     <string name="dialog_smoothing">Smoothing</string>
+    <string name="dialog_use_touch_size">Use touch size for variable brush width instead of pressure</string>
 
     <string name="dialog_zoom_window_enabled">Enabled</string>
     <string name="dialog_zoom_window_from_size" translatable="false">100</string>


### PR DESCRIPTION
Added a way to use event data in tools. 
Watercolor tool now uses event.pressure or event.size (changeable in settings)

- [x] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
