### PR TITLE
PAINTROID-466 Crash ArrayIndexOutOfBoundsException at LayerPresenter.getLayerItem

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/contract/LayerContracts.kt
@@ -48,7 +48,7 @@ interface LayerContracts {
 
         fun disableVisibilityAndOpacityButtons()
 
-        fun getLayerItem(position: Int): Layer
+        fun getLayerItem(position: Int): Layer?
 
         fun getLayerItemId(position: Int): Long
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/LayerPresenter.kt
@@ -160,7 +160,14 @@ class LayerPresenter(
 
     override fun isShown(): Boolean = layerMenuViewHolder.isShown()
 
-    override fun getLayerItem(position: Int): LayerContracts.Layer = layers[position]
+    override fun getLayerItem(position: Int): LayerContracts.Layer? {
+        if (isPositionValid(position)) {
+            return layers[position]
+        } else {
+            Log.w("LayerPresenter.kt", "LayerPresenter.getLayerItem(position) - tried to access position out of range of the layers array!")
+            return null
+        }
+    }
 
     override fun getLayerItemId(position: Int): Long = position.toLong()
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -615,11 +615,12 @@ open class MainActivityPresenter(
     override fun showLayerMenuClicked() {
         idlingResource.increment()
         layerAdapter?.apply {
-            for (i in 0 until itemCount) {
-                val currentHolder = getViewHolderAt(i)
+            for (position in 0 until itemCount) {
+                val currentHolder = getViewHolderAt(position)
                 currentHolder?.let {
-                    if (it.bitmap != null) {
-                        it.updateImageView(presenter.getLayerItem(i))
+                    val layer = presenter.getLayerItem(position)
+                    if (it.bitmap != null && layer != null) {
+                        it.updateImageView(layer)
                     }
                 }
             }
@@ -1019,7 +1020,8 @@ open class MainActivityPresenter(
         if (bottomBarViewHolder.isVisible) {
             bottomBarViewHolder.hide()
         } else {
-            if (layerAdapter?.presenter?.getLayerItem(workspace.currentLayerIndex)?.isVisible == false) {
+            val layer = layerAdapter?.presenter?.getLayerItem(workspace.currentLayerIndex)
+            if (layer != null && !layer.isVisible) {
                 navigator.showToast(R.string.no_tools_on_hidden_layer, Toast.LENGTH_SHORT)
                 return
             }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -97,6 +97,9 @@ class LayerAdapter(
 
         override fun bindView() {
             val layer = layerPresenter.getLayerItem(position)
+            if (layer == null) {
+                return
+            }
             val isSelected = layer === layerPresenter.getSelectedLayer()
             setSelected(isSelected)
             setLayerVisibilityCheckbox(layer.isVisible)
@@ -120,9 +123,9 @@ class LayerAdapter(
                 true
             }
 
-            opacitySeekBar.progress = layerPresenter.getLayerItem(position).opacityPercentage
+            opacitySeekBar.progress = layer.opacityPercentage
             opacityEditText.filters = arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
-            opacityEditText.setText(layerPresenter.getLayerItem(position).opacityPercentage.toString())
+            opacityEditText.setText(layer.opacityPercentage.toString())
             opacityEditText.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
@@ -143,7 +146,7 @@ class LayerAdapter(
                         layerPresenter.changeLayerOpacity(position, opacityPercentage)
                     }
 
-                    layerPresenter.getLayerItem(position).opacityPercentage = opacityPercentage
+                    layer.opacityPercentage = opacityPercentage
                     layerPresenter.refreshDrawingSurface()
                 }
             })


### PR DESCRIPTION
[PAINTROID-466](https://jira.catrob.at/browse/PAINTROID-466)

I tried to reproduce the bug, but didn't manage to reproduce it as there is also no description on how to reproduce it.  The getLayerItem() is now checked in case we try to access a position that is out of bounds, to avoid the app from crashing in case the bug would occur. I also adapted the code parts where the getLayerItem() is called, in case the method would return null.

This should then hopefully eliminate the problem.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
