### PR TITLE
PAINTROID-614 Using LineTool too fast crashes app sometimes

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
@@ -62,17 +62,20 @@ open class LayerModel : LayerContracts.Model {
         false
     }
 
+    @Synchronized
     override fun getBitmapOfAllLayers(): Bitmap? {
-        if (layers.isEmpty()) {
-            return null
+        synchronized(this) {
+            if (layers.isEmpty()) {
+                return null
+            }
+            val referenceBitmap = layers[0].bitmap
+            val bitmap = Bitmap.createBitmap(referenceBitmap.width, referenceBitmap.height, Bitmap.Config.ARGB_8888)
+            val canvas = bitmap?.let { Canvas(it) }
+
+            drawLayersOntoCanvas(canvas)
+
+            return bitmap
         }
-        val referenceBitmap = layers[0].bitmap
-        val bitmap = Bitmap.createBitmap(referenceBitmap.width, referenceBitmap.height, Bitmap.Config.ARGB_8888)
-        val canvas = bitmap?.let { Canvas(it) }
-
-        drawLayersOntoCanvas(canvas)
-
-        return bitmap
     }
 
     override fun getBitmapListOfAllLayers(): List<Bitmap?> = layers.map { it.bitmap }


### PR DESCRIPTION
[PAINTROID-614](https://jira.catrob.at/browse/PAINTROID-614)

Using the LineTool too fast sometimes crashed the App. 

The reason for the crash seemed to be related to the forEach-Loop that is called in drawLayersOntoCanvas(). Sometimes the forEach tried to iterate out of bound, when using the tool too fast, causing a NoSuchElementException.

It seemed to be a problem with the locking, causing a race condition. I made the method getBitmapOfAllLayers() where the drawLayersOntoCanvas() is called Synchronized and synchronized the LayerModel too, and I didn't manage to reproduce the crash anymore with locking these ressources.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
