### PR TITLE
PAINTROID-530 Line tool color

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.kt
@@ -69,6 +69,10 @@ interface CommandManager {
 
     fun getUndoCommandCount(): Int
 
+    fun getColorCommandCount(): Int
+
+    fun isLastColorCommandOnTop(): Boolean
+
     interface CommandListener {
         fun commandPostExecute()
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
@@ -214,4 +214,12 @@ open class AsyncCommandManager(
     override fun getUndoCommandCount(): Int {
         synchronized(layerModel) { return commandManager.getUndoCommandCount() }
     }
+
+    override fun getColorCommandCount(): Int {
+        synchronized(layerModel) { return commandManager.getColorCommandCount() }
+    }
+
+    override fun isLastColorCommandOnTop(): Boolean {
+        synchronized(layerModel) { return commandManager.isLastColorCommandOnTop() }
+    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ColorChangedCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ColorChangedCommand.kt
@@ -56,6 +56,25 @@ class ColorChangedCommand(toolReference: ToolReference, context: Context, color:
         }
     }
 
+     fun runInUndoMode() {
+        if (toolReference.tool !is LineTool) {
+            (context as MainActivity).runOnUiThread {
+                toolReference.tool?.changePaintColor(color, false)
+            }
+        } else {
+            if (toolReference.tool is LineTool && !firstTime) {
+                (context as MainActivity).runOnUiThread {
+                    (toolReference.tool as LineTool).undoColorChangedCommand(color, false)
+                }
+            } else {
+                (context as MainActivity).runOnUiThread {
+                    toolReference.tool?.changePaintColor(color, false)
+                }
+                firstTime = false
+            }
+        }
+    }
+
     override fun freeResources() {
         // No resources to free
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
@@ -156,7 +156,11 @@ class DefaultCommandManager(
 
         initialStateCommand?.run(canvas, layerModel)
 
+        val colorCommandCount = getColorCommandCount()
+
+        var currentColorCommandCount = 0
         val iterator = undoCommandList.descendingIterator()
+
         while (iterator.hasNext()) {
             val nextCommand = iterator.next()
             if (nextCommand is ColorChangedCommand && ignoreColorCommand) {
@@ -164,12 +168,44 @@ class DefaultCommandManager(
             }
             val currentLayer = layerModel.currentLayer
             canvas.setBitmap(currentLayer?.bitmap)
-            nextCommand.run(canvas, layerModel)
+            if (nextCommand is ColorChangedCommand && ++currentColorCommandCount < colorCommandCount) {
+                nextCommand.runInUndoMode()
+            } else {
+                nextCommand.run(canvas, layerModel)
+            }
         }
 
         if (!currentCommandName.matches(mergeLayerCommandRegex)) {
             fetchBackCheckBoxes(layerCount, checkBoxes)
         }
+    }
+
+    override fun getColorCommandCount(): Int {
+        val commandIterator = undoCommandList.iterator()
+        var counter = 0
+        while (commandIterator.hasNext()) {
+            val nextCommand = commandIterator.next()
+            if (nextCommand is ColorChangedCommand) {
+                counter++
+            }
+        }
+        return counter
+    }
+
+    override fun isLastColorCommandOnTop(): Boolean {
+        var retVal = false
+        if (undoCommandList.first is ColorChangedCommand) {
+            val commandIterator = undoCommandList.iterator()
+            var counter = 0
+            while (commandIterator.hasNext()) {
+                val nextCommand = commandIterator.next()
+                if (nextCommand is ColorChangedCommand) {
+                    counter++
+                }
+            }
+            retVal = counter == 1
+        }
+        return retVal
     }
 
     override fun executeAllCommands() {
@@ -250,11 +286,10 @@ class DefaultCommandManager(
     override fun undoInConnectedLinesMode() {
         val colorCommandList = removeColorCommands()
         if (undoCommandList.isNotEmpty()) {
-            val commandForUndo: Command
-            if (colorCommandList.isNotEmpty()) {
-                commandForUndo = colorCommandList.pop()
+            val commandForUndo: Command = if (colorCommandList.isNotEmpty()) {
+                colorCommandList.pop()
             } else {
-                commandForUndo = undoCommandList.pop()
+                undoCommandList.pop()
             }
             redoCommandList.addFirst(commandForUndo)
             handleUndo(commandForUndo)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -573,17 +573,19 @@ open class MainActivityPresenter(
         if (view.isKeyboardShown) {
             view.hideKeyboard()
         } else {
-            setBottomNavigationColor(Color.BLACK)
-            if (toolController.currentTool is LineTool) {
-                (toolController.currentTool as LineTool).undoChangePaintColor(Color.BLACK)
+            if (commandManager.isLastColorCommandOnTop() || commandManager.getColorCommandCount() == 0) {
+                toolController.currentTool?.changePaintColor(Color.BLACK)
+                setBottomNavigationColor(Color.BLACK)
+            }
+            if (toolController.currentTool is ClippingTool) {
+                val clippingTool = toolController.currentTool as ClippingTool
+                clippingToolPaint = clippingTool.drawPaint
+                commandManager.undo()
+                clippingToolInUseAndUndoRedoClicked = true
             } else {
-                if (toolController.currentTool is ClippingTool) {
-                    val clippingTool = toolController.currentTool as ClippingTool
-                    clippingToolPaint = clippingTool.drawPaint
-                    commandManager.undo()
-                    clippingToolInUseAndUndoRedoClicked = true
+                if (toolController.currentTool is LineTool) {
+                    (toolController.currentTool as LineTool).undoChangePaintColor(Color.BLACK, false)
                 } else {
-                    toolController.currentTool?.changePaintColor(Color.BLACK)
                     commandManager.undo()
                 }
             }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.kt
@@ -40,7 +40,7 @@ interface Tool {
 
     fun handleUp(coordinate: PointF?): Boolean
 
-    fun changePaintColor(color: Int)
+    fun changePaintColor(color: Int, invalidate: Boolean = true)
 
     fun changePaintStrokeWidth(strokeWidth: Int)
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
@@ -77,7 +77,7 @@ abstract class BaseTool(
 
     override fun onRestoreInstanceState(bundle: Bundle?) = Unit
 
-    override fun changePaintColor(@ColorInt color: Int) {
+    override fun changePaintColor(@ColorInt color: Int, invalidate: Boolean) {
         toolPaint.color = color
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
@@ -213,9 +213,9 @@ open class BrushTool(
         previousEventCoordinate = null
     }
 
-    override fun changePaintColor(color: Int) {
-        super.changePaintColor(color)
-        brushToolOptionsView.invalidate()
+    override fun changePaintColor(color: Int, invalidate: Boolean) {
+        super.changePaintColor(color, invalidate)
+        if (invalidate) brushToolOptionsView.invalidate()
     }
 
     private fun eventCoordinatesAreNull(): Boolean =

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
@@ -113,12 +113,12 @@ open class CursorTool(
         brushToolOptionsView.setStrokeCapButtonChecked(toolPaint.strokeCap)
     }
 
-    override fun changePaintColor(color: Int) {
-        super.changePaintColor(color)
+    override fun changePaintColor(color: Int, invalidate: Boolean) {
+        super.changePaintColor(color, invalidate)
         if (toolInDrawMode) {
             cursorToolSecondaryShapeColor = toolPaint.color
         }
-        brushToolOptionsView.invalidate()
+        if (invalidate) brushToolOptionsView.invalidate()
     }
 
     private fun hideToolOptions() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
@@ -393,8 +393,8 @@ class LineTool(
         }
     }
 
-    override fun changePaintColor(color: Int) {
-        super.changePaintColor(color)
+    override fun changePaintColor(color: Int, invalidate: Boolean) {
+        super.changePaintColor(color, invalidate)
         if (startpointSet && endpointSet) {
             val startX = startPointToDraw?.x
             val startY = startPointToDraw?.y
@@ -418,13 +418,13 @@ class LineTool(
                 }
             }
         }
-        brushToolOptionsView.invalidate()
+        if (invalidate) brushToolOptionsView.invalidate()
     }
 
-    fun undoChangePaintColor(color: Int) {
+    fun undoChangePaintColor(color: Int, invalidate: Boolean) {
         handleStateBeforeUndo()
-        super.changePaintColor(color)
-        brushToolOptionsView.invalidate()
+        super.changePaintColor(color, invalidate)
+        if (invalidate) brushToolOptionsView.invalidate()
         if (connectedLines) {
             commandManager.undoInConnectedLinesMode()
         } else {
@@ -441,9 +441,9 @@ class LineTool(
         }
     }
 
-    fun undoColorChangedCommand(color: Int) {
-        super.changePaintColor(color)
-        brushToolOptionsView.invalidate()
+    fun undoColorChangedCommand(color: Int, invalidate: Boolean = true) {
+        super.changePaintColor(color, invalidate)
+        if (invalidate) brushToolOptionsView.invalidate()
     }
 
     override fun changePaintStrokeWidth(strokeWidth: Int) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
@@ -108,9 +108,9 @@ class ShapeTool(
         shapeDrawable = drawableFactory.createDrawable(shape)
     }
 
-    override fun changePaintColor(color: Int) {
-        super.changePaintColor(color)
-        workspace.invalidate()
+    override fun changePaintColor(color: Int, invalidate: Boolean) {
+        super.changePaintColor(color, invalidate)
+        if (invalidate) workspace.invalidate()
     }
 
     override fun onSaveInstanceState(bundle: Bundle?) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
@@ -443,8 +443,8 @@ class TextTool(
         }
     }
 
-    override fun changePaintColor(color: Int) {
-        super.changePaintColor(color)
+    override fun changePaintColor(color: Int, invalidate: Boolean) {
+        super.changePaintColor(color, invalidate)
         changeTextColor()
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/WatercolorTool.kt
@@ -59,10 +59,10 @@ class WatercolorTool(
         previewPaint.maskFilter = BlurMaskFilter(calcRange(previewPaint.alpha), BlurMaskFilter.Blur.INNER)
     }
 
-    override fun changePaintColor(color: Int) {
-        super.changePaintColor(color)
+    override fun changePaintColor(color: Int, invalidate: Boolean) {
+        super.changePaintColor(color, invalidate)
 
-        brushToolOptionsView.invalidate()
+        if (invalidate) brushToolOptionsView.invalidate()
         bitmapPaint.maskFilter = BlurMaskFilter(calcRange(bitmapPaint.alpha), BlurMaskFilter.Blur.INNER)
         previewPaint.maskFilter = BlurMaskFilter(calcRange(previewPaint.alpha), BlurMaskFilter.Blur.INNER)
     }

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/DefaultCommandManagerTest.kt
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/command/implementation/DefaultCommandManagerTest.kt
@@ -29,6 +29,7 @@ import org.junit.Before
 import org.mockito.Mockito
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import org.catrobat.paintroid.command.Command
 import org.catrobat.paintroid.contract.LayerContracts
 import org.hamcrest.CoreMatchers
@@ -37,6 +38,9 @@ import org.junit.Test
 import org.mockito.junit.MockitoJUnitRunner
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
+import org.catrobat.paintroid.MainActivity
+import org.catrobat.paintroid.command.implementation.ColorChangedCommand
+import org.catrobat.paintroid.tools.ToolReference
 
 @RunWith(MockitoJUnitRunner::class)
 class DefaultCommandManagerTest {
@@ -293,5 +297,25 @@ class DefaultCommandManagerTest {
         commandManager.reset()
         Assert.assertFalse(commandManager.isRedoAvailable)
         Assert.assertFalse(commandManager.isUndoAvailable)
+    }
+
+    @Test
+    fun testIsLastColorCommandUndone() {
+        val firstCommand = Mockito.mock(Command::class.java)
+        val secondCommand = ColorChangedCommand(Mockito.mock(ToolReference::class.java), MainActivity(), Color.BLUE)
+        val thirdCommand = Mockito.mock(Command::class.java)
+        val currentLayer = Mockito.mock(LayerContracts.Layer::class.java)
+
+        layerModel.currentLayer = currentLayer
+        layerModel.addLayerAt(0, currentLayer)
+        Mockito.`when`(currentLayer.bitmap).thenReturn(Mockito.mock(Bitmap::class.java))
+        Mockito.`when`(commonFactory.createCanvas()).thenReturn(Mockito.mock(Canvas::class.java))
+        commandManager.addCommand(firstCommand)
+        commandManager.addCommand(secondCommand)
+        commandManager.addCommand(thirdCommand)
+
+        Assert.assertFalse(commandManager.isLastColorCommandOnTop())
+        commandManager.undo()
+        Assert.assertTrue(commandManager.isLastColorCommandOnTop())
     }
 }


### PR DESCRIPTION
flashing of color preview removed (issue was for all tools)

-color is set to black before undo only if needed
-view is not always invalidated

[PAINTROID-530](https://jira.catrob.at/browse/PAINTROID-530)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
