### PR TITLE
PAINTROID-241 Layout errors in right-to-left languages

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/LanguageHelper.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/LanguageHelper.kt
@@ -1,0 +1,16 @@
+package org.catrobat.paintroid
+
+import android.text.TextUtils
+import android.view.View
+import java.util.*
+
+class LanguageHelper {
+
+    companion object {
+        fun isCurrentLanguageRTL(): Boolean {
+            val layoutDirection = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault())
+            return layoutDirection == View.LAYOUT_DIRECTION_RTL
+        }
+    }
+
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -43,6 +43,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.content.ContextCompat
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -549,7 +550,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
     private fun setLayoutDirection() {
         var visibilityBtn = findViewById<ImageButton>(R.id.pocketpaint_layer_side_nav_button_visibility)
         var layerNavigationView = findViewById<NavigationView>(R.id.pocketpaint_nav_view_layer)
-        if (resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+        if (LanguageHelper.isCurrentLanguageRTL()) {
             visibilityBtn.setBackgroundResource(R.drawable.rounded_corner_top_rtl)
             layerNavigationView.setBackgroundResource(R.drawable.layer_nav_view_background_rtl)
         } else {
@@ -587,9 +588,32 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         TooltipCompat.setTooltipText(topBar.redoButton, context.getString(R.string.button_redo))
     }
 
+    private fun mirrorUndoAndRedoButtonsForRtlLanguage() {
+        val undoButton: ImageButton = findViewById(R.id.pocketpaint_btn_top_undo)
+        val undoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_undo)
+
+        val redoButton: ImageButton = findViewById(R.id.pocketpaint_btn_top_redo)
+        val redoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_redo)
+
+        undoDrawable?.let {
+            it.isAutoMirrored = true
+            undoButton.setImageDrawable(it)
+        }
+
+        redoDrawable?.let {
+            it.isAutoMirrored = true
+            redoButton.setImageDrawable(it)
+        }
+    }
+
     private fun setTopBarListeners(topBar: TopBarViewHolder) {
         topBar.undoButton.setOnClickListener { presenterMain.undoClicked() }
         topBar.redoButton.setOnClickListener { presenterMain.redoClicked() }
+
+        if (LanguageHelper.isCurrentLanguageRTL()) {
+            mirrorUndoAndRedoButtonsForRtlLanguage()
+        }
+
         topBar.checkmarkButton.setOnClickListener {
             if (toolReference.tool?.toolType?.name.equals(ToolType.TRANSFORM.name)) {
                 (toolReference.tool as TransformTool).checkMarkClicked = true

--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.kt
@@ -24,6 +24,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
+import android.widget.ImageButton
 import android.widget.RelativeLayout
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -84,6 +85,7 @@ class WelcomeActivity : AppCompatActivity() {
                         val description: AppCompatTextView =
                             findViewById(R.id.pocketpaint_intro_possibilities_text)
                         setUpUndoAndRedoButtons(head, description)
+
                         setUpNavigationView(head, description)
                     } else if (layouts[pos] == R.layout.pocketpaint_slide_intro_tools_selection) {
                         val view = findViewById<View>(R.id.pocketpaint_intro_bottom_bar)
@@ -106,17 +108,35 @@ class WelcomeActivity : AppCompatActivity() {
             }
         }
 
+    private fun mirrorUndoAndRedoButtonsForRtlLanguage(undoButton: AppCompatImageButton, redoButton: AppCompatImageButton) {
+        val undoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_undo)
+        val redoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_redo)
+
+        undoDrawable?.let {
+            it.isAutoMirrored = true
+            undoButton.setImageDrawable(it)
+        }
+
+        redoDrawable?.let {
+            it.isAutoMirrored = true
+            redoButton.setImageDrawable(it)
+        }
+    }
+
     private fun setUpUndoAndRedoButtons(head: AppCompatTextView, description: AppCompatTextView) {
-        val topBar: AppBarLayout =
-            findViewById(R.id.pocketpaint_intro_possibilities_topbar)
-        val undo: AppCompatImageButton =
-            topBar.findViewById(R.id.pocketpaint_btn_top_undo)
-        val redo: AppCompatImageButton =
-            topBar.findViewById(R.id.pocketpaint_btn_top_redo)
+        val topBar: AppBarLayout = findViewById(R.id.pocketpaint_intro_possibilities_topbar)
+        val undo: AppCompatImageButton = topBar.findViewById(R.id.pocketpaint_btn_top_undo)
+        val redo: AppCompatImageButton = topBar.findViewById(R.id.pocketpaint_btn_top_redo)
+
+        if (LanguageHelper.isCurrentLanguageRTL()) {
+            mirrorUndoAndRedoButtonsForRtlLanguage(undo, redo)
+        }
+
         undo.setOnClickListener {
             head.setText(ToolType.UNDO.nameResource)
             description.setText(ToolType.UNDO.helpTextResource)
         }
+
         redo.setOnClickListener {
             head.setText(ToolType.REDO.nameResource)
             description.setText(ToolType.REDO.helpTextResource)
@@ -158,6 +178,7 @@ class WelcomeActivity : AppCompatActivity() {
             finish()
             return
         }
+
         setContentView(R.layout.activity_pocketpaint_welcome)
         viewPager = findViewById(R.id.pocketpaint_view_pager)
         dotsLayout = findViewById(R.id.pocketpaint_layout_dots)
@@ -179,7 +200,7 @@ class WelcomeActivity : AppCompatActivity() {
             var finished: Boolean
             var current = getItem(1)
             finished = current > layouts.size - 1
-            if (isRTL(this@WelcomeActivity)) {
+            if (LanguageHelper.isCurrentLanguageRTL()) {
                 current = getItem(-1)
                 finished = current < 0
             }
@@ -192,12 +213,13 @@ class WelcomeActivity : AppCompatActivity() {
     }
 
     private fun initViewPager() {
-        if (isRTL(this)) {
+        if (LanguageHelper.isCurrentLanguageRTL()) {
             layouts.reverse()
+
         }
         viewPager.adapter = IntroPageViewAdapter(layouts)
         viewPager.addOnPageChangeListener(viewPagerPageChangeListener)
-        if (isRTL(this)) {
+        if (LanguageHelper.isCurrentLanguageRTL()) {
             val pos = layouts.size
             viewPager.currentItem = pos
             addBottomDots(layouts.size - 1)
@@ -232,23 +254,8 @@ class WelcomeActivity : AppCompatActivity() {
         }
     }
 
-    private fun defaultLocaleIsRTL(): Boolean {
-        val locale = Locale.getDefault()
-        if (locale.toString().isEmpty()) {
-            return false
-        }
-        val directionality = Character.getDirectionality(locale.displayName[0]).toInt()
-        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT.toInt() || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC.toInt()
-    }
-
-    private fun isRTL(context: Context): Boolean {
-        val layoutDirection = context.resources.configuration.layoutDirection
-        val layoutDirectionIsRTL = layoutDirection == View.LAYOUT_DIRECTION_RTL
-        return layoutDirectionIsRTL || defaultLocaleIsRTL()
-    }
-
     private fun getDotsIndex(position: Int): Int =
-        if (isRTL(this)) layouts.size - position - 1 else position
+        if (LanguageHelper.isCurrentLanguageRTL()) layouts.size - position - 1 else position
 
     override fun onBackPressed() {
         finish()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -39,16 +39,15 @@ import android.os.Environment
 import android.provider.DocumentsContract
 import android.provider.MediaStore
 import android.provider.OpenableColumns
+import android.text.TextUtils
 import android.util.Log
 import android.view.Gravity
 import android.view.Menu
+import android.view.View
 import android.widget.Toast
 import androidx.core.view.GravityCompat
 import androidx.test.espresso.idling.CountingIdlingResource
-import org.catrobat.paintroid.FileIO
-import org.catrobat.paintroid.MainActivity
-import org.catrobat.paintroid.R
-import org.catrobat.paintroid.UserPreferences
+import org.catrobat.paintroid.*
 import org.catrobat.paintroid.colorpicker.ColorHistory
 import org.catrobat.paintroid.command.CommandFactory
 import org.catrobat.paintroid.command.CommandManager
@@ -99,6 +98,7 @@ import org.catrobat.paintroid.tools.implementation.LineTool
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint
 import org.catrobat.paintroid.ui.LayerAdapter
 import java.io.File
+import java.util.*
 
 @SuppressWarnings("LongParameterList", "LargeClass", "ThrowingExceptionsWithoutMessageOrCause")
 open class MainActivityPresenter(

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -39,6 +39,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.catrobat.paintroid.LanguageHelper
 import org.catrobat.paintroid.MainActivity
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.contract.LayerContracts
@@ -269,21 +270,20 @@ class LayerAdapter(
         }
 
         private fun getRadius(backgroundType: BackgroundType): FloatArray {
-            val isRTL = mainActivity.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL
             val cornerRadius = CORNER_RADIUS * mainActivity.resources.displayMetrics.density
 
             return when (backgroundType) {
-                BackgroundType.TOP -> if (isRTL) {
+                BackgroundType.TOP -> if (LanguageHelper.isCurrentLanguageRTL()) {
                     floatArrayOf(0f, 0f, cornerRadius, cornerRadius, 0f, 0f, 0f, 0f)
                 } else {
                     floatArrayOf(cornerRadius, cornerRadius, 0f, 0f, 0f, 0f, 0f, 0f)
                 }
-                BackgroundType.BOTTOM -> if (isRTL) {
+                BackgroundType.BOTTOM -> if (LanguageHelper.isCurrentLanguageRTL()) {
                     floatArrayOf(0f, 0f, 0f, 0f, cornerRadius, cornerRadius, 0f, 0f)
                 } else {
                     floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f, cornerRadius, cornerRadius)
                 }
-                BackgroundType.SINGLE -> if (isRTL) {
+                BackgroundType.SINGLE -> if (LanguageHelper.isCurrentLanguageRTL()) {
                     floatArrayOf(0f, 0f, cornerRadius, cornerRadius, cornerRadius, cornerRadius, 0f, 0f)
                 } else {
                     floatArrayOf(cornerRadius, cornerRadius, 0f, 0f, 0f, 0f, cornerRadius, cornerRadius)

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
@@ -27,6 +27,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 
+
         <com.google.android.material.textfield.TextInputLayout
             style="@style/TextFieldTheme"
             android:layout_width="wrap_content"
@@ -59,7 +60,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_margin="10dp"
             android:layout_marginTop="@dimen/toolbar_height"
             tools:ignore="RelativeOverlap,RtlHardcoded">

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_top_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_top_bar.xml
@@ -66,7 +66,7 @@
                 android:contentDescription="@string/button_checkmark"
                 android:src="@drawable/ic_pocketpaint_plus_enabled"
                 android:tint="@android:color/white"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <ImageButton
                 android:id="@+id/pocketpaint_btn_top_checkmark"
@@ -77,7 +77,7 @@
                 android:contentDescription="@string/button_checkmark"
                 android:src="@drawable/ic_pocketpaint_checkmark"
                 android:tint="@android:color/white"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
         </LinearLayout>
     </androidx.appcompat.widget.Toolbar>

--- a/Paintroid/src/main/res/values-af/string.xml
+++ b/Paintroid/src/main/res/values-af/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ar/string.xml
+++ b/Paintroid/src/main/res/values-ar/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">لا يوجد شيء لتغيير حجمه</string>
     <string name="resize_cannot_resize_to_this_size">لا يمكن تغيير الحجم إلى هذا الحجم</string>
     <string name="resize_max_image_resolution_reached">الوصول الى الحد الأقصى لدقة الشاشة</string>
-    <string name="text_tool_dialog_underline_shortcut">يو</string>
-    <string name="text_tool_dialog_italic_shortcut">ص</string>
-    <string name="text_tool_dialog_bold_shortcut">ب</string>
     <string name="text_tool_dialog_input_hint">أنقر هنا للكتابة</string>
     <string name="text_tool_dialog_font_monospace">فضاء أحادي</string>
     <string name="text_tool_dialog_font_serif">سيرفر</string>

--- a/Paintroid/src/main/res/values-az/string.xml
+++ b/Paintroid/src/main/res/values-az/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ölçüsü dəyişdiriləcək heç nə yoxdur</string>
     <string name="resize_cannot_resize_to_this_size">bu ölçüdə təyin edilə bilməz</string>
     <string name="resize_max_image_resolution_reached">maksimal təsvir ölçülərinə çatıldı</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Yazmaq üçün bura toxunun</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-bg/string.xml
+++ b/Paintroid/src/main/res/values-bg/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-bn/string.xml
+++ b/Paintroid/src/main/res/values-bn/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">পুনঃস্থাপন করার মত কিছু নেই</string>
     <string name="resize_cannot_resize_to_this_size">এই আকার পরিবর্তন করতে পারে না</string>
     <string name="resize_max_image_resolution_reached">সর্বোচ্চ চিত্রের রেজোলিউশনে পৌঁছেছে</string>
-    <string name="text_tool_dialog_underline_shortcut">উ</string>
-    <string name="text_tool_dialog_italic_shortcut">আমি</string>
-    <string name="text_tool_dialog_bold_shortcut">খ</string>
     <string name="text_tool_dialog_input_hint">লিখতে এখানে আলতো চাপুন</string>
     <string name="text_tool_dialog_font_monospace">মনোস্পেস</string>
     <string name="text_tool_dialog_font_serif">সেরিফ</string>

--- a/Paintroid/src/main/res/values-bs/string.xml
+++ b/Paintroid/src/main/res/values-bs/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ništa za promjenu veličine</string>
     <string name="resize_cannot_resize_to_this_size">ne može promijeniti veličinu na ovu veličinu</string>
     <string name="resize_max_image_resolution_reached">maksimalna rezolucija postignuta</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Dodirnite ovdje kako bi zapoceli pisanje</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ca/string.xml
+++ b/Paintroid/src/main/res/values-ca/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-chr/string.xml
+++ b/Paintroid/src/main/res/values-chr/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-cs/string.xml
+++ b/Paintroid/src/main/res/values-cs/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nic pro změnu velikosti</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">maximální rozlišení dosaženo</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Klepnutím sem psát</string>
     <string name="text_tool_dialog_font_monospace">Neproporcionální</string>
     <string name="text_tool_dialog_font_serif">Patkové</string>

--- a/Paintroid/src/main/res/values-da/string.xml
+++ b/Paintroid/src/main/res/values-da/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-de/string.xml
+++ b/Paintroid/src/main/res/values-de/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nichts zu verändern</string>
     <string name="resize_cannot_resize_to_this_size">Kann nicht auf diese Größe angepasst werden</string>
     <string name="resize_max_image_resolution_reached">Maximale Bildauflösung erreicht</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">K</string>
-    <string name="text_tool_dialog_bold_shortcut">F</string>
     <string name="text_tool_dialog_input_hint">Tippe hier, um zu schreiben</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-el/string.xml
+++ b/Paintroid/src/main/res/values-el/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-en-rAU/string.xml
+++ b/Paintroid/src/main/res/values-en-rAU/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-en-rCA/string.xml
+++ b/Paintroid/src/main/res/values-en-rCA/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-en-rGB/string.xml
+++ b/Paintroid/src/main/res/values-en-rGB/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-es/string.xml
+++ b/Paintroid/src/main/res/values-es/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nada para cambiar el tamaño</string>
     <string name="resize_cannot_resize_to_this_size">no se puede cambiar el tamaño</string>
     <string name="resize_max_image_resolution_reached">resolución de imagen máxima alcanzada</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Pulsa aquí para escribir</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-eu-rES/string.xml
+++ b/Paintroid/src/main/res/values-eu-rES/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">Ez dago neurria aldatzeko ezer</string>
     <string name="resize_cannot_resize_to_this_size">Ezin da neurri honetara aldatu</string>
     <string name="resize_max_image_resolution_reached">Irudiaren gehieneko erresoluzioa da hau</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Idatzi hemen:</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-fa-rIR/string.xml
+++ b/Paintroid/src/main/res/values-fa-rIR/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">هیچ چیز برای تغییر اندازه نیست</string>
     <string name="resize_cannot_resize_to_this_size">نمی تواند به این اندازه تغییر اندازه دهد</string>
     <string name="resize_max_image_resolution_reached">وضوح تصویر به حداکثر رسیده</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">ب</string>
     <string name="text_tool_dialog_input_hint">برای نوشتن اینجا ضربه بزن</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-fa/string.xml
+++ b/Paintroid/src/main/res/values-fa/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">چیز برای تغییر اندازه نیست</string>
     <string name="resize_cannot_resize_to_this_size">نمی تواند به این اندازه تغییر اندازه دهد</string>
     <string name="resize_max_image_resolution_reached">حداکثر رزولوشن تصویر رسیده است</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">برای نوشتن اینجا را ضربه بزنید</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-fi/string.xml
+++ b/Paintroid/src/main/res/values-fi/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-fr/string.xml
+++ b/Paintroid/src/main/res/values-fr/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">rien à redimensionner</string>
     <string name="resize_cannot_resize_to_this_size">ne peut pas redimensionner à cette taille</string>
     <string name="resize_max_image_resolution_reached">résolution maximale de l\'image atteinte</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">l</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tape ici pour écrire</string>
     <string name="text_tool_dialog_font_monospace">Monoespace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-gl/string.xml
+++ b/Paintroid/src/main/res/values-gl/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-gu/string.xml
+++ b/Paintroid/src/main/res/values-gu/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ha/string.xml
+++ b/Paintroid/src/main/res/values-ha/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-hi/string.xml
+++ b/Paintroid/src/main/res/values-hi/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">आकार बदलने के लिए कुछ नहीं</string>
     <string name="resize_cannot_resize_to_this_size">इस आकार का आकार नहीं बदल सकता</string>
     <string name="resize_max_image_resolution_reached">अधिकतम छवि संकल्प पहुंचे</string>
-    <string name="text_tool_dialog_underline_shortcut">यू</string>
-    <string name="text_tool_dialog_italic_shortcut">मैं</string>
-    <string name="text_tool_dialog_bold_shortcut">बी</string>
     <string name="text_tool_dialog_input_hint">लिखने के लिए यहां टैप करें</string>
     <string name="text_tool_dialog_font_monospace">एकलस्पेस</string>
     <string name="text_tool_dialog_font_serif">सेरिफ़</string>

--- a/Paintroid/src/main/res/values-hr/string.xml
+++ b/Paintroid/src/main/res/values-hr/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ništa za promjenu veličine</string>
     <string name="resize_cannot_resize_to_this_size">ne može promijeniti veličinu na ovu veličinu</string>
     <string name="resize_max_image_resolution_reached">maksimalna rezolucija postignuta</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Dodirnite ovdje kako bi zapoceli pisanje</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-hu/string.xml
+++ b/Paintroid/src/main/res/values-hu/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nincs átméretezendő elem</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">elérte a maximális képfelbontást</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Koppintsd ide az íráshoz</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ig/string.xml
+++ b/Paintroid/src/main/res/values-ig/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-in/string.xml
+++ b/Paintroid/src/main/res/values-in/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">tidak ada yang diubah ukurannya</string>
     <string name="resize_cannot_resize_to_this_size">tidak dapat mengubah ukuran menjadi ukuran ini</string>
     <string name="resize_max_image_resolution_reached">resolusi citra maksimum tercapai</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tekan di sini untuk menambahkan teks</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-it/string.xml
+++ b/Paintroid/src/main/res/values-it/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nulla da ridimensionare</string>
     <string name="resize_cannot_resize_to_this_size">non si può ridimensionare a questa dimensione</string>
     <string name="resize_max_image_resolution_reached">si è raggiunta la risoluzione massima</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Toccare qui per scrivere</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-iw/string.xml
+++ b/Paintroid/src/main/res/values-iw/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">אין מה להגדיל</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">הושגה רזולוציית מסך מקסימאלית</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">מ</string>
     <string name="text_tool_dialog_input_hint">הקש כאן כדי לכתוב</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ja/string.xml
+++ b/Paintroid/src/main/res/values-ja/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">サイズを変更するものはありません</string>
     <string name="resize_cannot_resize_to_this_size">このサイズにサイズを変更できません</string>
     <string name="resize_max_image_resolution_reached">最大の画像解像度に達しました</string>
-    <string name="text_tool_dialog_underline_shortcut">う</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">テキストを追加するにはここをタップ</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ka/string.xml
+++ b/Paintroid/src/main/res/values-ka/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-kab/string.xml
+++ b/Paintroid/src/main/res/values-kab/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-kk/string.xml
+++ b/Paintroid/src/main/res/values-kk/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">өлшемін өзгерту үшін ештеңе жоқ</string>
     <string name="resize_cannot_resize_to_this_size">өлшемін бұл өлшемге өзгерту мүмкін емес</string>
     <string name="resize_max_image_resolution_reached">максималды кескін ажыратымдылығына жетті</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Жазу үшін осы жерді түртіңіз</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-kn/string.xml
+++ b/Paintroid/src/main/res/values-kn/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ko/string.xml
+++ b/Paintroid/src/main/res/values-ko/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">크기 변경 없음</string>
     <string name="resize_cannot_resize_to_this_size">크기 변경 불가능</string>
     <string name="resize_max_image_resolution_reached">최고 이미지 해상도</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">나</string>
-    <string name="text_tool_dialog_bold_shortcut">비</string>
     <string name="text_tool_dialog_input_hint">여기를 눌러 텍스트를 추가하세요</string>
     <string name="text_tool_dialog_font_monospace">고정 폭</string>
     <string name="text_tool_dialog_font_serif">명조체</string>

--- a/Paintroid/src/main/res/values-lt/string.xml
+++ b/Paintroid/src/main/res/values-lt/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-mk/string.xml
+++ b/Paintroid/src/main/res/values-mk/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ml-rIN/string.xml
+++ b/Paintroid/src/main/res/values-ml-rIN/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ms/string.xml
+++ b/Paintroid/src/main/res/values-ms/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-nl/string.xml
+++ b/Paintroid/src/main/res/values-nl/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">niets om te schalen</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max beeldresolutie bereikt</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Klik hier om te typen</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-no/string.xml
+++ b/Paintroid/src/main/res/values-no/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-pa-rIN/string.xml
+++ b/Paintroid/src/main/res/values-pa-rIN/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ਮੁੜ ਆਕਾਰ ਦੇਣ ਲਈ ਕੁਝ ਨਹੀਂ</string>
     <string name="resize_cannot_resize_to_this_size">ਇਸ ਅਕਾਰ ਦਾ ਆਕਾਰ ਨਹੀਂ ਬਦਲ ਸਕਦਾ</string>
     <string name="resize_max_image_resolution_reached">ਵੱਧ ਤੋਂ ਵੱਧ ਚਿੱਤਰ ਰੈਜ਼ੋਲੇਸ਼ਨ ਪਹੁੰਚ ਗਿਆ</string>
-    <string name="text_tool_dialog_underline_shortcut">ਯੂ</string>
-    <string name="text_tool_dialog_italic_shortcut">ਆਈ</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">ਲਿਖਣ ਲਈ ਇੱਥੇ ਟੈਪ ਕਰੋ</string>
     <string name="text_tool_dialog_font_monospace">ਮੋਨੋਸਪੇਸ</string>
     <string name="text_tool_dialog_font_serif">ਸੀਰੀਫ</string>

--- a/Paintroid/src/main/res/values-pl/string.xml
+++ b/Paintroid/src/main/res/values-pl/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nie ma niczego do zmiany rozmiaru</string>
     <string name="resize_cannot_resize_to_this_size">nie można zmienić na ten rozmiar</string>
     <string name="resize_max_image_resolution_reached">osiągnięto maksymalną rozdzielczość</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Naciśnij tutaj, aby pisać</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ps/string.xml
+++ b/Paintroid/src/main/res/values-ps/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">د اندازه کولو لپاره هیڅ شی نشته</string>
     <string name="resize_cannot_resize_to_this_size">د دې اندازې اندازه نشي کولی</string>
     <string name="resize_max_image_resolution_reached">د عکس اعظمي حد ته رسیدلی</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">د لیکلو لپاره دلته ټک وکړئ</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-pt-rBR/string.xml
+++ b/Paintroid/src/main/res/values-pt-rBR/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nada há nada para ser redimensionado</string>
     <string name="resize_cannot_resize_to_this_size">não é possível redimensionar para este tamanho</string>
     <string name="resize_max_image_resolution_reached">resolução máxima de imagem alcançada</string>
-    <string name="text_tool_dialog_underline_shortcut">S</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">N</string>
     <string name="text_tool_dialog_input_hint">Toque aqui para escrever</string>
     <string name="text_tool_dialog_font_monospace">Monoespaçada</string>
     <string name="text_tool_dialog_font_serif">Serifa</string>

--- a/Paintroid/src/main/res/values-pt/string.xml
+++ b/Paintroid/src/main/res/values-pt/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">não há nada para ser redimensionado</string>
     <string name="resize_cannot_resize_to_this_size">não é possível redimensionar para este tamanho</string>
     <string name="resize_max_image_resolution_reached">foi atingida a resolução máxima de imagem</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Toque aqui para escrever</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ro/string.xml
+++ b/Paintroid/src/main/res/values-ro/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ru/string.xml
+++ b/Paintroid/src/main/res/values-ru/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">нечего менять</string>
     <string name="resize_cannot_resize_to_this_size">невозможно изменить размер до этого размера</string>
     <string name="resize_max_image_resolution_reached">достигнуто максимальное разрешение изображения</string>
-    <string name="text_tool_dialog_underline_shortcut">Ч</string>
-    <string name="text_tool_dialog_italic_shortcut">К</string>
-    <string name="text_tool_dialog_bold_shortcut">Ж</string>
     <string name="text_tool_dialog_input_hint">Нажмите здесь, чтобы написать</string>
     <string name="text_tool_dialog_font_monospace">Моноспейс</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sd/string.xml
+++ b/Paintroid/src/main/res/values-sd/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">سائيز مَٽائڻ لاءِ ڪجھ ڪونهي</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">تصوير جو رزالوشن ان کان مٿي نه ٿيندو</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">لکڻ لاءِ هتي ڪلڪ ڪريو</string>
     <string name="text_tool_dialog_font_monospace">مونوسپيس فانٽ</string>
     <string name="text_tool_dialog_font_serif">سيرف</string>

--- a/Paintroid/src/main/res/values-si/string.xml
+++ b/Paintroid/src/main/res/values-si/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sk/string.xml
+++ b/Paintroid/src/main/res/values-sk/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sl/string.xml
+++ b/Paintroid/src/main/res/values-sl/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ni česa spreminjati</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max ločljivost že dosežena</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sq/string.xml
+++ b/Paintroid/src/main/res/values-sq/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">asgjë për të ndryshuar madhësinë</string>
     <string name="resize_cannot_resize_to_this_size">nuk mund të ndryshojë madhësinë në këto përmasa</string>
     <string name="resize_max_image_resolution_reached">resolucioni maksimal i imazhit u arrit</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Prek këtu për të shkruar</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sr-rCS/string.xml
+++ b/Paintroid/src/main/res/values-sr-rCS/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ništa za promenu veličine</string>
     <string name="resize_cannot_resize_to_this_size">ne može da podesi veličinu za ovu veličinu</string>
     <string name="resize_max_image_resolution_reached">postignuta je maksimalna rezolucija slike</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Dodirnite ovde da pišete</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sr-rSP/string.xml
+++ b/Paintroid/src/main/res/values-sr-rSP/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ништа за промену величине</string>
     <string name="resize_cannot_resize_to_this_size">не може да подеси величину за ову величину</string>
     <string name="resize_max_image_resolution_reached">постигнута је максимална резолуција слике</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">Б</string>
     <string name="text_tool_dialog_input_hint">Додирните овде да пишете</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sv/string.xml
+++ b/Paintroid/src/main/res/values-sv/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">inget att ändra storlek på</string>
     <string name="resize_cannot_resize_to_this_size">kan inte ändra storlek till denna storlek</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tryck här för att skriva</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-sw/string.xml
+++ b/Paintroid/src/main/res/values-sw/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">hakuna kubadilisha ukubwa</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">kikomo cha muonekano wa picha kimefikiwa</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Bonyeza hapa ili kuandika</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ta/string.xml
+++ b/Paintroid/src/main/res/values-ta/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">மறுஅளவிடுவதற்கு எதுவும் இல்லை</string>
     <string name="resize_cannot_resize_to_this_size">இந்த அளவுக்கு அளவை மாற்ற முடியாது</string>
     <string name="resize_max_image_resolution_reached">அதிகபட்ச படத் தீர்மானம் அடைந்தது</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">எழுத இங்கே தட்டவும்</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-te/string.xml
+++ b/Paintroid/src/main/res/values-te/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-th/string.xml
+++ b/Paintroid/src/main/res/values-th/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">ไม่มีภาพให้ปรับขนาด</string>
     <string name="resize_cannot_resize_to_this_size">ไม่สามารถปรับขนาดเป็นขนาดนี้</string>
     <string name="resize_max_image_resolution_reached">ปรับความละเอียดภาพสูงสุดแล้ว</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">แตะที่นี่เพื่อเขียน</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-tl/string.xml
+++ b/Paintroid/src/main/res/values-tl/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">walang mababago sa sukat</string>
     <string name="resize_cannot_resize_to_this_size">hindi maaaring baguhin sa ganitong sukat</string>
     <string name="resize_max_image_resolution_reached">narating na ng imahe ang pinakamataas na resolusyon</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Pindutin dito upang magsulat</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-tr/string.xml
+++ b/Paintroid/src/main/res/values-tr/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">yeniden boyutlandırılacak bir şey yok</string>
     <string name="resize_cannot_resize_to_this_size">bu boyuta yeniden boyutlandırılamaz</string>
     <string name="resize_max_image_resolution_reached">maksimum görüntü çözünürlüğüne ulaşıldı</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Yazmak için buraya dokunun</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-tw/string.xml
+++ b/Paintroid/src/main/res/values-tw/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-uk/string.xml
+++ b/Paintroid/src/main/res/values-uk/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">нічого розтягувати</string>
     <string name="resize_cannot_resize_to_this_size">не вдається розтягнути до такого розміру</string>
     <string name="resize_max_image_resolution_reached">зображення надто велике</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">В</string>
     <string name="text_tool_dialog_input_hint">Натисніть, щоб писати</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-ur/string.xml
+++ b/Paintroid/src/main/res/values-ur/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">سائز تبدیل نہیں ہوا ہے۔</string>
     <string name="resize_cannot_resize_to_this_size">اس سائز کا سائز تبدیل نہیں کر سکتے ہیں</string>
     <string name="resize_max_image_resolution_reached">زیادہ سے زیادہ تصویر کے  ریسیلیوشن  تک پہنچ گئی</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">لکھنے کے لئے یہاں کلک کریں۔</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-uz/string.xml
+++ b/Paintroid/src/main/res/values-uz/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-vi/string.xml
+++ b/Paintroid/src/main/res/values-vi/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">không có gì để thay đổi kích cỡ</string>
     <string name="resize_cannot_resize_to_this_size">không thể thay đổi kích thước thành kích thước này</string>
     <string name="resize_max_image_resolution_reached">hình ảnh đã đạt độ phân giải tối đa</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Nhấn vào đây để viết</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-yo-rNG/string.xml
+++ b/Paintroid/src/main/res/values-yo-rNG/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">nothing to resize</string>
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>

--- a/Paintroid/src/main/res/values-zh-rCN/string.xml
+++ b/Paintroid/src/main/res/values-zh-rCN/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">没有什么可调整大小</string>
     <string name="resize_cannot_resize_to_this_size">无法调整为此尺寸</string>
     <string name="resize_max_image_resolution_reached">达到最大图像分辨率</string>
-    <string name="text_tool_dialog_underline_shortcut">你</string>
-    <string name="text_tool_dialog_italic_shortcut">我</string>
-    <string name="text_tool_dialog_bold_shortcut">乙</string>
     <string name="text_tool_dialog_input_hint">点击此处添加文本</string>
     <string name="text_tool_dialog_font_monospace">等宽</string>
     <string name="text_tool_dialog_font_serif">衬线</string>

--- a/Paintroid/src/main/res/values-zh-rTW/string.xml
+++ b/Paintroid/src/main/res/values-zh-rTW/string.xml
@@ -105,9 +105,6 @@
     <string name="resize_nothing_to_resize">沒有改變大小</string>
     <string name="resize_cannot_resize_to_this_size">無法調整為此大小</string>
     <string name="resize_max_image_resolution_reached">到達圖案最大解析度</string>
-    <string name="text_tool_dialog_underline_shortcut">剪切</string>
-    <string name="text_tool_dialog_italic_shortcut">一世</string>
-    <string name="text_tool_dialog_bold_shortcut">乙</string>
     <string name="text_tool_dialog_input_hint">點按此處撰寫</string>
     <string name="text_tool_dialog_font_monospace">等寬</string>
     <string name="text_tool_dialog_font_serif">襯線</string>

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -114,9 +114,9 @@
     <string name="resize_cannot_resize_to_this_size">cannot resize to this size</string>
     <string name="resize_max_image_resolution_reached">max image resolution reached</string>
 
-    <string name="text_tool_dialog_underline_shortcut">U</string>
-    <string name="text_tool_dialog_italic_shortcut">I</string>
-    <string name="text_tool_dialog_bold_shortcut">B</string>
+    <string name="text_tool_dialog_underline_shortcut" translatable="false">U</string>
+    <string name="text_tool_dialog_italic_shortcut" translatable="false">I</string>
+    <string name="text_tool_dialog_bold_shortcut" translatable="false">B</string>
     <string name="text_tool_dialog_input_hint">Tap here to write</string>
     <string name="text_tool_dialog_font_monospace">Monospace</string>
     <string name="text_tool_dialog_font_serif">Serif</string>


### PR DESCRIPTION
[PAINTROID-241](https://jira.catrob.at/browse/PAINTROID-241)

- Removed translation of Bold/Italic/Underline shortcuts for all languages, as they should not be translated according to Material Design (also wouldnt make sense).
- Undo/Redo in top toolbar fixed for RTL languages according to Material Design.
- Undo/Redo arrows pointing in the right direction now according to Material Design.
- Undo/Redo in welcome screen fixed for RTL languages according to Material Design.
- Text Tool: fixed the icons and texts of icons according to Material Design. Also fixed the font size textinput.
- Created a new class called "LanguageHelper" that we can use in case we need to do language specific things like checking if the current language is a RTL language, for code reusability.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
