### PR TITLE
PAINTROID-241 Layout errors in right-to-left languages

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/LanguageHelper.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/LanguageHelper.kt
@@ -1,0 +1,12 @@
+package org.catrobat.paintroid
+
+import android.text.TextUtils
+import android.view.View
+import java.util.*
+
+object LanguageHelper {
+    fun isCurrentLanguageRTL(): Boolean {
+        val layoutDirection = TextUtils.getLayoutDirectionFromLocale(Locale.getDefault())
+        return layoutDirection == View.LAYOUT_DIRECTION_RTL
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -43,6 +43,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.content.ContextCompat
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -549,7 +550,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
     private fun setLayoutDirection() {
         var visibilityBtn = findViewById<ImageButton>(R.id.pocketpaint_layer_side_nav_button_visibility)
         var layerNavigationView = findViewById<NavigationView>(R.id.pocketpaint_nav_view_layer)
-        if (resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+        if (LanguageHelper.isCurrentLanguageRTL()) {
             visibilityBtn.setBackgroundResource(R.drawable.rounded_corner_top_rtl)
             layerNavigationView.setBackgroundResource(R.drawable.layer_nav_view_background_rtl)
         } else {
@@ -587,9 +588,32 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         TooltipCompat.setTooltipText(topBar.redoButton, context.getString(R.string.button_redo))
     }
 
+    private fun mirrorUndoAndRedoButtonsForRtlLanguage() {
+        val undoButton: ImageButton = findViewById(R.id.pocketpaint_btn_top_undo)
+        val undoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_undo)
+
+        val redoButton: ImageButton = findViewById(R.id.pocketpaint_btn_top_redo)
+        val redoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_redo)
+
+        undoDrawable?.let {
+            it.isAutoMirrored = true
+            undoButton.setImageDrawable(it)
+        }
+
+        redoDrawable?.let {
+            it.isAutoMirrored = true
+            redoButton.setImageDrawable(it)
+        }
+    }
+
     private fun setTopBarListeners(topBar: TopBarViewHolder) {
         topBar.undoButton.setOnClickListener { presenterMain.undoClicked() }
         topBar.redoButton.setOnClickListener { presenterMain.redoClicked() }
+
+        if (LanguageHelper.isCurrentLanguageRTL()) {
+            mirrorUndoAndRedoButtonsForRtlLanguage()
+        }
+
         topBar.checkmarkButton.setOnClickListener {
             if (toolReference.tool?.toolType?.name.equals(ToolType.TRANSFORM.name)) {
                 (toolReference.tool as TransformTool).checkMarkClicked = true

--- a/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/WelcomeActivity.kt
@@ -18,7 +18,6 @@
  */
 package org.catrobat.paintroid
 
-import android.content.Context
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
@@ -39,7 +38,6 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import org.catrobat.paintroid.common.RESULT_INTRO_MW_NOT_SUPPORTED
 import org.catrobat.paintroid.intro.IntroPageViewAdapter
 import org.catrobat.paintroid.tools.ToolType
-import java.util.Locale
 
 private const val DEFAULT_TEXT_SIZE = 30f
 
@@ -106,17 +104,35 @@ class WelcomeActivity : AppCompatActivity() {
             }
         }
 
+    private fun mirrorUndoAndRedoButtonsForRtlLanguage(undoButton: AppCompatImageButton, redoButton: AppCompatImageButton) {
+        val undoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_undo)
+        val redoDrawable = ContextCompat.getDrawable(this, R.drawable.ic_pocketpaint_redo)
+
+        undoDrawable?.let {
+            it.isAutoMirrored = true
+            undoButton.setImageDrawable(it)
+        }
+
+        redoDrawable?.let {
+            it.isAutoMirrored = true
+            redoButton.setImageDrawable(it)
+        }
+    }
+
     private fun setUpUndoAndRedoButtons(head: AppCompatTextView, description: AppCompatTextView) {
-        val topBar: AppBarLayout =
-            findViewById(R.id.pocketpaint_intro_possibilities_topbar)
-        val undo: AppCompatImageButton =
-            topBar.findViewById(R.id.pocketpaint_btn_top_undo)
-        val redo: AppCompatImageButton =
-            topBar.findViewById(R.id.pocketpaint_btn_top_redo)
+        val topBar: AppBarLayout = findViewById(R.id.pocketpaint_intro_possibilities_topbar)
+        val undo: AppCompatImageButton = topBar.findViewById(R.id.pocketpaint_btn_top_undo)
+        val redo: AppCompatImageButton = topBar.findViewById(R.id.pocketpaint_btn_top_redo)
+
+        if (LanguageHelper.isCurrentLanguageRTL()) {
+            mirrorUndoAndRedoButtonsForRtlLanguage(undo, redo)
+        }
+
         undo.setOnClickListener {
             head.setText(ToolType.UNDO.nameResource)
             description.setText(ToolType.UNDO.helpTextResource)
         }
+
         redo.setOnClickListener {
             head.setText(ToolType.REDO.nameResource)
             description.setText(ToolType.REDO.helpTextResource)
@@ -158,6 +174,7 @@ class WelcomeActivity : AppCompatActivity() {
             finish()
             return
         }
+
         setContentView(R.layout.activity_pocketpaint_welcome)
         viewPager = findViewById(R.id.pocketpaint_view_pager)
         dotsLayout = findViewById(R.id.pocketpaint_layout_dots)
@@ -179,7 +196,7 @@ class WelcomeActivity : AppCompatActivity() {
             var finished: Boolean
             var current = getItem(1)
             finished = current > layouts.size - 1
-            if (isRTL(this@WelcomeActivity)) {
+            if (LanguageHelper.isCurrentLanguageRTL()) {
                 current = getItem(-1)
                 finished = current < 0
             }
@@ -192,12 +209,12 @@ class WelcomeActivity : AppCompatActivity() {
     }
 
     private fun initViewPager() {
-        if (isRTL(this)) {
+        if (LanguageHelper.isCurrentLanguageRTL()) {
             layouts.reverse()
         }
         viewPager.adapter = IntroPageViewAdapter(layouts)
         viewPager.addOnPageChangeListener(viewPagerPageChangeListener)
-        if (isRTL(this)) {
+        if (LanguageHelper.isCurrentLanguageRTL()) {
             val pos = layouts.size
             viewPager.currentItem = pos
             addBottomDots(layouts.size - 1)
@@ -232,23 +249,8 @@ class WelcomeActivity : AppCompatActivity() {
         }
     }
 
-    private fun defaultLocaleIsRTL(): Boolean {
-        val locale = Locale.getDefault()
-        if (locale.toString().isEmpty()) {
-            return false
-        }
-        val directionality = Character.getDirectionality(locale.displayName[0]).toInt()
-        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT.toInt() || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC.toInt()
-    }
-
-    private fun isRTL(context: Context): Boolean {
-        val layoutDirection = context.resources.configuration.layoutDirection
-        val layoutDirectionIsRTL = layoutDirection == View.LAYOUT_DIRECTION_RTL
-        return layoutDirectionIsRTL || defaultLocaleIsRTL()
-    }
-
     private fun getDotsIndex(position: Int): Int =
-        if (isRTL(this)) layouts.size - position - 1 else position
+        if (LanguageHelper.isCurrentLanguageRTL()) layouts.size - position - 1 else position
 
     override fun onBackPressed() {
         finish()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/LayerAdapter.kt
@@ -39,6 +39,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.catrobat.paintroid.LanguageHelper
 import org.catrobat.paintroid.MainActivity
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.contract.LayerContracts
@@ -264,21 +265,20 @@ class LayerAdapter(
         }
 
         private fun getRadius(backgroundType: BackgroundType): FloatArray {
-            val isRTL = mainActivity?.resources?.configuration?.layoutDirection == View.LAYOUT_DIRECTION_RTL
             val cornerRadius = mainActivity?.let { CORNER_RADIUS * it.resources.displayMetrics.density } ?: 0f
 
             return when (backgroundType) {
-                BackgroundType.TOP -> if (isRTL) {
+                BackgroundType.TOP -> if (LanguageHelper.isCurrentLanguageRTL()) {
                     floatArrayOf(0f, 0f, cornerRadius, cornerRadius, 0f, 0f, 0f, 0f)
                 } else {
                     floatArrayOf(cornerRadius, cornerRadius, 0f, 0f, 0f, 0f, 0f, 0f)
                 }
-                BackgroundType.BOTTOM -> if (isRTL) {
+                BackgroundType.BOTTOM -> if (LanguageHelper.isCurrentLanguageRTL()) {
                     floatArrayOf(0f, 0f, 0f, 0f, cornerRadius, cornerRadius, 0f, 0f)
                 } else {
                     floatArrayOf(0f, 0f, 0f, 0f, 0f, 0f, cornerRadius, cornerRadius)
                 }
-                BackgroundType.SINGLE -> if (isRTL) {
+                BackgroundType.SINGLE -> if (LanguageHelper.isCurrentLanguageRTL()) {
                     floatArrayOf(0f, 0f, cornerRadius, cornerRadius, cornerRadius, cornerRadius, 0f, 0f)
                 } else {
                     floatArrayOf(cornerRadius, cornerRadius, 0f, 0f, 0f, 0f, cornerRadius, cornerRadius)

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_margin="10dp"
             android:layout_marginTop="@dimen/toolbar_height"
             tools:ignore="RelativeOverlap,RtlHardcoded">

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_top_bar.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_top_bar.xml
@@ -66,7 +66,7 @@
                 android:contentDescription="@string/button_checkmark"
                 android:src="@drawable/ic_pocketpaint_plus_enabled"
                 android:tint="@android:color/white"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <ImageButton
                 android:id="@+id/pocketpaint_btn_top_checkmark"
@@ -77,7 +77,7 @@
                 android:contentDescription="@string/button_checkmark"
                 android:src="@drawable/ic_pocketpaint_checkmark"
                 android:tint="@android:color/white"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
         </LinearLayout>
     </androidx.appcompat.widget.Toolbar>


### PR DESCRIPTION
[PAINTROID-241](https://jira.catrob.at/browse/PAINTROID-241)

- Undo/Redo in top toolbar fixed for RTL languages according to Material Design.
- Undo/Redo arrows pointing in the right direction now according to Material Design.
- Undo/Redo in welcome screen fixed for RTL languages according to Material Design.
- Text Tool: fixed the icons and texts of icons according to Material Design. Also fixed the font size textinput.
- Created a new class called "LanguageHelper" that we can use in case we need to do language specific things like checking if the current language is a RTL language, for code reusability.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
