### PR TITLE
PAINTROID-648 Dynamic animation of top and bottom bar

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/LineToolTest.kt
@@ -191,7 +191,7 @@ class LineToolTest {
         val tap1 = PointF(7f, 7f)
         Mockito.`when`(toolOptionsViewController.isVisible).thenReturn(true)
         Mockito.`when`(viewMock.visibility).thenReturn(View.VISIBLE)
-        tool.handleMove(tap1)
+        tool.handleMove(tap1, true)
 
         Mockito.verify(toolOptionsViewController).slideUp(viewMock,
                                                           willHide = true,

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/SprayToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/SprayToolTest.kt
@@ -168,7 +168,7 @@ class SprayToolTest {
         val tap1 = PointF(7f, 7f)
         Mockito.`when`(toolOptionsViewController.isVisible).thenReturn(true)
         Mockito.`when`(viewMock.visibility).thenReturn(View.VISIBLE)
-        tool.handleMove(tap1)
+        tool.handleMove(tap1, true)
 
         Mockito.verify(toolOptionsViewController).slideUp(viewMock,
                                                             willHide = true,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/listener/DrawingSurfaceListener.kt
@@ -38,6 +38,7 @@ private const val DRAWER_EDGE_SIZE = 20f
 private const val CONSTANT_1 = 0.5f
 private const val JITTER_DELAY_THRESHOLD: Long = 30
 private const val JITTER_DISTANCE_THRESHOLD = 50f
+private const val ANIMATION_THRESHOLD = 4
 
 open class DrawingSurfaceListener(
     private val callback: DrawingSurfaceListenerCallback,
@@ -95,7 +96,7 @@ open class DrawingSurfaceListener(
         this.sharedPreferences = sharedPreferences
     }
 
-    private fun handleActionMove(currentTool: Tool?, event: MotionEvent) {
+    private fun handleActionMove(currentTool: Tool?, event: MotionEvent, shouldAnimate: Boolean) {
         val xOld: Float
         val yOld: Float
         if (event.pointerCount == 1) {
@@ -117,7 +118,7 @@ open class DrawingSurfaceListener(
                 }
             } else if (touchMode != TouchMode.PINCH) {
                 touchMode = TouchMode.DRAW
-                currentTool.handleMove(canvasTouchPoint)
+                currentTool.handleMove(canvasTouchPoint, shouldAnimate)
             }
             handleZoomWindowOnMove(currentTool, event)
         } else {
@@ -179,7 +180,11 @@ open class DrawingSurfaceListener(
                 currentTool?.handleDown(canvasTouchPoint)
                 handleZoomWindowOnTouch(currentTool, event)
             }
-            MotionEvent.ACTION_MOVE -> handleActionMove(currentTool, event)
+            MotionEvent.ACTION_MOVE -> {
+                var threshold = view.height / ANIMATION_THRESHOLD
+                var shouldAnimate = event.y < threshold || event.y > view.height - threshold
+                handleActionMove(currentTool, event, shouldAnimate)
+            }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 if (touchMode == TouchMode.DRAW) {
                     val drawingTime = System.currentTimeMillis() - timerStartDraw

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/Tool.kt
@@ -36,7 +36,7 @@ interface Tool {
 
     fun handleDown(coordinate: PointF?): Boolean
 
-    fun handleMove(coordinate: PointF?): Boolean
+    fun handleMove(coordinate: PointF?, shouldAnimate: Boolean = false): Boolean
 
     fun handleUp(coordinate: PointF?): Boolean
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseTool.kt
@@ -96,8 +96,10 @@ abstract class BaseTool(
         return true
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
-        toolOptionsViewController.animateBottomAndTopNavigation(true)
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
+        if (shouldAnimate) {
+            toolOptionsViewController.animateBottomAndTopNavigation(true)
+        }
         return true
     }
     override val drawPaint

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithRectangleShape.kt
@@ -287,7 +287,7 @@ abstract class BaseToolWithRectangleShape(
         return true
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
         if (previousEventCoordinate == null || currentAction == null) {
             return false
         }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
@@ -145,7 +145,6 @@ open class BrushTool(
     }
 
     override fun handleDownAnimations(coordinate: PointF?) {
-
         hideBrushSpecificLayoutOnHandleDown()
     }
 
@@ -154,12 +153,14 @@ open class BrushTool(
         super.handleUp(coordinate)
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
         if (eventCoordinatesAreNull() || coordinate == null) {
             return false
         }
-        super.handleMove(coordinate)
-        hideBrushSpecificLayoutOnHandleDown()
+        super.handleMove(coordinate, shouldAnimate)
+        if (shouldAnimate) {
+            hideBrushSpecificLayoutOnHandleDown()
+        }
         previousEventCoordinate?.let {
             pathToDraw.quadTo(it.x, it.y, coordinate.x, coordinate.y)
             pathToDraw.incReserve(1)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/CursorTool.kt
@@ -174,10 +174,12 @@ open class CursorTool(
         return true
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
         if (coordinate != null) {
-            hideToolOptions()
-            super.handleMove(coordinate)
+            if (shouldAnimate) {
+                hideToolOptions()
+            }
+            super.handleMove(coordinate, shouldAnimate)
             previousEventCoordinate?.let {
                 val deltaX = coordinate.x - it.x
                 val deltaY = coordinate.y - it.y

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/FillTool.kt
@@ -72,7 +72,7 @@ class FillTool(
 
     override fun handleDown(coordinate: PointF?): Boolean = false
 
-    override fun handleMove(coordinate: PointF?): Boolean = false
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean = false
 
     override fun handleUp(coordinate: PointF?): Boolean {
         coordinate ?: return false

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/HandTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/HandTool.kt
@@ -61,7 +61,7 @@ class HandTool(
 
     override fun handleDown(coordinate: PointF?): Boolean = true
 
-    override fun handleMove(coordinate: PointF?): Boolean = true
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean = true
 
     override fun handleUp(coordinate: PointF?): Boolean = true
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/LineTool.kt
@@ -237,10 +237,12 @@ class LineTool(
         return true
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
         coordinate ?: return false
-        hideToolOptions()
-        super.handleMove(coordinate)
+        super.handleMove(coordinate, shouldAnimate)
+        if (shouldAnimate) {
+            hideToolOptions()
+        }
         changeInitialCoordinateForHandleNormalLine = true
         if (startpointSet) {
             initialEventCoordinate = startPointToDraw?.let { PointF(it.x, it.y) }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/PipetteTool.kt
@@ -61,7 +61,7 @@ class PipetteTool(
 
     override fun handleDown(coordinate: PointF?): Boolean = setColor(coordinate)
 
-    override fun handleMove(coordinate: PointF?): Boolean = setColor(coordinate)
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean = setColor(coordinate)
 
     override fun handleUp(coordinate: PointF?): Boolean = setColor(coordinate)
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SmudgeTool.kt
@@ -168,7 +168,7 @@ class SmudgeTool(
         return true
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
         coordinate ?: return false
 
         if (currentBitmap != null) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SprayTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/SprayTool.kt
@@ -139,9 +139,11 @@ class SprayTool(
 
     override fun toolPositionCoordinates(coordinate: PointF): PointF = coordinate
 
-    override fun handleMove(coordinate: PointF?): Boolean {
-        hideToolOptions()
-        super.handleMove(coordinate)
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
+        if (shouldAnimate) {
+            hideToolOptions()
+        }
+        super.handleMove(coordinate, shouldAnimate)
         currentCoordinate = coordinate
         return true
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
@@ -257,10 +257,10 @@ class TextTool(
          }
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
         textToolOptionsView.hideKeyboard()
         hideTextToolLayout()
-        return super.handleMove(coordinate)
+        return super.handleMove(coordinate, false)
     }
 
     override fun handleUp(coordinate: PointF?): Boolean {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TransformTool.kt
@@ -227,11 +227,11 @@ class TransformTool(
         return true
     }
 
-    override fun handleMove(coordinate: PointF?): Boolean {
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
         if (isSetCenter) {
             return false
         }
-        return super.handleMove(coordinate)
+        return super.handleMove(coordinate, true)
     }
 
     override fun drawToolSpecifics(canvas: Canvas, boxWidth: Float, boxHeight: Float) {

--- a/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.kt
+++ b/Paintroid/src/test/java/org/catrobat/paintroid/test/listener/DrawingSurfaceListenerTest.kt
@@ -200,6 +200,9 @@ class DrawingSurfaceListenerTest {
         Mockito.verify(currentTool, Mockito.never())?.handleMove(
             ArgumentMatchers.any(
                 PointF::class.java
+            ),
+            ArgumentMatchers.any(
+                Boolean::class.java
             )
         )
     }
@@ -220,6 +223,9 @@ class DrawingSurfaceListenerTest {
         Mockito.verify(currentTool, Mockito.never())?.handleMove(
             ArgumentMatchers.any(
                 PointF::class.java
+            ),
+            ArgumentMatchers.any(
+                Boolean::class.java
             )
         )
         Mockito.verify(callback, Mockito.never())
@@ -255,6 +261,9 @@ class DrawingSurfaceListenerTest {
         Mockito.verify(currentTool, Mockito.never()).handleMove(
             ArgumentMatchers.any(
                 PointF::class.java
+            ),
+            ArgumentMatchers.any(
+                Boolean::class.java
             )
         )
         Mockito.verify(callback, Mockito.never())
@@ -310,6 +319,9 @@ class DrawingSurfaceListenerTest {
         Mockito.verify(currentTool, Mockito.never())?.handleMove(
             ArgumentMatchers.any(
                 PointF::class.java
+            ),
+            ArgumentMatchers.any(
+                Boolean::class.java
             )
         )
         Mockito.verify(callback)?.translatePerspective(10f, -10f)
@@ -346,6 +358,9 @@ class DrawingSurfaceListenerTest {
         Mockito.verify(currentTool, Mockito.never()).handleMove(
             ArgumentMatchers.any(
                 PointF::class.java
+            ),
+            ArgumentMatchers.any(
+                Boolean::class.java
             )
         )
         Mockito.verify(callback)?.translatePerspective(10f, -10f)
@@ -379,6 +394,9 @@ class DrawingSurfaceListenerTest {
         Mockito.verify(currentTool, Mockito.never())?.handleMove(
             ArgumentMatchers.any(
                 PointF::class.java
+            ),
+            ArgumentMatchers.any(
+                Boolean::class.java
             )
         )
         Mockito.verify(callback, Mockito.never())
@@ -420,6 +438,9 @@ class DrawingSurfaceListenerTest {
         Mockito.verify(currentTool, Mockito.never())?.handleMove(
             ArgumentMatchers.any(
                 PointF::class.java
+            ),
+            ArgumentMatchers.any(
+                Boolean::class.java
             )
         )
         Mockito.verify(currentTool, Mockito.never())?.handleUp(


### PR DESCRIPTION
Ticket: [PAINTROID-648](https://jira.catrob.at/browse/PAINTROID-648)

Added the threshold calculation to the handleMove method of Tool. Now it will only animate if the touchevent is within the first or last quarter of the devices display.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
