### PR TITLE
PAINTROID-617 eraser improvements

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/UndoRedoIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/UndoRedoIntegrationTest.kt
@@ -453,4 +453,41 @@ class UndoRedoIntegrationTest {
             BitmapLocationProvider.HALFWAY_TOP_MIDDLE
         )
     }
+
+    @Test
+    fun testNoColorUndoInEraserMode() {
+        onToolBarView()
+                .performSelectTool(ToolType.FILL)
+        onDrawingSurfaceView()
+                .perform(UiInteractions.touchAt(DrawingSurfaceLocationProvider.MIDDLE))
+        selectColorInDialog(0)
+        selectColorInDialog(1)
+        selectColorInDialog(2)
+        onToolBarView()
+                .performSelectTool(ToolType.ERASER)
+        onDrawingSurfaceView().perform(
+                UiInteractions.swipeAccurate(
+                        DrawingSurfaceLocationProvider.HALFWAY_TOP_MIDDLE,
+                        DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_MIDDLE
+                )
+        )
+        onTopBarView().performUndo()
+        onTopBarView().performUndo()
+        onToolBarView()
+                .performSelectTool(ToolType.BRUSH)
+        onDrawingSurfaceView().perform(
+                UiInteractions.swipeAccurate(
+                        DrawingSurfaceLocationProvider.HALFWAY_TOP_MIDDLE,
+                        DrawingSurfaceLocationProvider.HALFWAY_BOTTOM_MIDDLE
+                )
+        )
+        onDrawingSurfaceView().perform(
+                UiInteractions.swipeAccurate(
+                        DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT,
+                        DrawingSurfaceLocationProvider.HALFWAY_TOP_RIGHT
+                )
+        )
+        onDrawingSurfaceView()
+                .checkPixelColor(Color.parseColor("#FF078707"), BitmapLocationProvider.HALFWAY_TOP_MIDDLE)
+    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ColorChangedCommand.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/ColorChangedCommand.kt
@@ -25,6 +25,7 @@ import org.catrobat.paintroid.MainActivity
 import org.catrobat.paintroid.command.Command
 import org.catrobat.paintroid.contract.LayerContracts
 import org.catrobat.paintroid.tools.ToolReference
+import org.catrobat.paintroid.tools.implementation.EraserTool
 import org.catrobat.paintroid.tools.implementation.LineTool
 
 class ColorChangedCommand(toolReference: ToolReference, context: Context, color: Int) : Command {
@@ -51,8 +52,10 @@ class ColorChangedCommand(toolReference: ToolReference, context: Context, color:
                 firstTime = false
             }
         }
-        (context as MainActivity).runOnUiThread {
-            (context as MainActivity).bottomNavigationViewHolder.setColorButtonColor(color)
+        if (toolReference.tool !is EraserTool) {
+            (context as MainActivity).runOnUiThread {
+                (context as MainActivity).bottomNavigationViewHolder.setColorButtonColor(color)
+            }
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -98,6 +98,7 @@ import org.catrobat.paintroid.tools.implementation.CONSTANT_3
 import org.catrobat.paintroid.tools.implementation.ClippingTool
 import org.catrobat.paintroid.tools.implementation.LineTool
 import org.catrobat.paintroid.tools.implementation.DefaultToolPaint
+import org.catrobat.paintroid.tools.implementation.EraserTool
 import org.catrobat.paintroid.ui.LayerAdapter
 import java.io.File
 
@@ -591,7 +592,7 @@ open class MainActivityPresenter(
         if (view.isKeyboardShown) {
             view.hideKeyboard()
         } else {
-            if (commandManager.isLastColorCommandOnTop() || commandManager.getColorCommandCount() == 0) {
+            if (toolController.currentTool !is EraserTool && (commandManager.isLastColorCommandOnTop() || commandManager.getColorCommandCount() == 0)) {
                 toolController.currentTool?.changePaintColor(Color.BLACK)
                 setBottomNavigationColor(Color.BLACK)
             }
@@ -604,7 +605,11 @@ open class MainActivityPresenter(
                 if (toolController.currentTool is LineTool) {
                     (toolController.currentTool as LineTool).undoChangePaintColor(Color.BLACK, false)
                 } else {
-                    commandManager.undo()
+                    if (toolController.currentTool is EraserTool) {
+                        commandManager.undoIgnoringColorChanges()
+                    } else {
+                        commandManager.undo()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Eraser did not work properly when used with multiple layers, but this issue was already fixed
Ticket was used for fixing eraser issues when using ColorChanged Commands (as discussed with Thorsten). As the selected color should always be transparent, but changed when applying an undo action.
(https://jira.catrob.at/browse/PAINTROID-617)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
