### PR TITLE
DEVOPS-779 Revert Browserstack stage in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,25 +27,7 @@ pipeline {
     parameters {
         string name: 'DEBUG_LABEL', defaultValue: '', description: 'For debugging when entered will be used as label to decide on which slaves the jobs will run.'
         booleanParam name: 'BUILD_WITH_CATROID', defaultValue: false, description: 'When checked then the current Paintroid build will be built with the current develop branch of Catroid'
-        booleanParam name: 'DEVICE_TESTING', defaultValue: true, description: 'When selected UI-testing runs locally'
         string name: 'CATROID_BRANCH', defaultValue: 'develop', description: 'The branch which to build catroid with, when BUILD_WITH_CATROID is checked.'
-        separator(name: "BROWSERSTACK", sectionHeader: "BrowserStack configuration",
-                separatorStyle: "border-width: 0",
-                sectionHeaderStyle: """
-                background-color: #ffff00;
-                text-align: center;
-                padding: 4px;
-                color: #000000;
-                font-size: 20px;
-                font-weight: normal;
-                font-family: 'Orienta', sans-serif;
-                letter-spacing: 1px;
-                font-style: italic;
-                """)
-        choice choices: ['AndroidDevices', 'Samsung Galaxy S23-13.0', 'Samsung Galaxy S23 Ultra-13.0', 'Samsung Galaxy S22 Ultra-12.0', 'Samsung Galaxy S22 Plus-12.0', 'Samsung Galaxy S22-12.0', 'Samsung Galaxy S21-12.0', 'Samsung Galaxy S21 Ultra-11.0', 'Samsung Galaxy S21-11.0', 'Samsung Galaxy S21 Plus-11.0', 'Samsung Galaxy S20-10.0', 'Samsung Galaxy S20 Plus-10.0', 'Samsung Galaxy S20 Ultra-10.0', 'Samsung Galaxy M52-11.0', 'Samsung Galaxy M32-11.0', 'Samsung Galaxy A52-11.0', 'Samsung Galaxy Note 20 Ultra-10.0', 'Samsung Galaxy Note 20-10.0', 'Samsung Galaxy A51-10.0', 'Samsung Galaxy A11-10.0', 'Samsung Galaxy S10e-9.0', 'Samsung Galaxy S10 Plus-9.0', 'Samsung Galaxy S10-9.0', 'Samsung Galaxy Note 10 Plus-9.0', 'Samsung Galaxy Note 10-9.0', 'Samsung Galaxy A10-9.0', 'Samsung Galaxy Note 9-8.1', 'Samsung Galaxy J7 Prime-8.1', 'Samsung Galaxy S9 Plus-9.0', 'Samsung Galaxy S9 Plus-8.0', 'Samsung Galaxy S9-8.0', 'Samsung Galaxy Note 8-7.1', 'Samsung Galaxy A8-7.1', 'Samsung Galaxy S8 Plus-7.0', 'Samsung Galaxy S8-7.0', 'Samsung Galaxy S7-6.0', 'Samsung Galaxy S6-5.0', 'Samsung Galaxy Tab S8-12.0', 'Samsung Galaxy Tab S7-11.0', 'Samsung Galaxy Tab S7-10.0', 'Samsung Galaxy Tab S6-9.0', 'Samsung Galaxy Tab S5e-9.0', 'Samsung Galaxy Tab S4-8.1', 'Google Pixel 7 Pro-13.0', 'Google Pixel 7-13.0', 'Google Pixel 6 Pro-13.0', 'Google Pixel 6 Pro-12.0', 'Google Pixel 6-12.0', 'Google Pixel 5-12.0', 'Google Pixel 5-11.0', 'Google Pixel 4-11.0', 'Google Pixel 4 XL-10.0', 'Google Pixel 4-10.0', 'Google Pixel 3-10.0', 'Google Pixel 3a XL-9.0', 'Google Pixel 3a-9.0', 'Google Pixel 3 XL-9.0', 'Google Pixel 3-9.0', 'Google Pixel 2-9.0', 'Google Pixel 2-8.0', 'Google Pixel-7.1', 'Google Nexus 5-4.4', 'OnePlus 9-11.0', 'OnePlus 8-10.0', 'OnePlus 7T-10.0', 'OnePlus 7-9.0', 'OnePlus 6T-9.0', 'Xiaomi Redmi Note 11-11.0', 'Xiaomi Redmi Note 9-10.0', 'Xiaomi Redmi Note 8-9.0', 'Xiaomi Redmi Note 7-9.0', 'Motorola Moto G71 5G-11.0', 'Motorola Moto G9 Play-10.0', 'Motorola Moto G7 Play-9.0', 'Vivo Y21-11.0', 'Vivo Y50-10.0', 'Oppo Reno 6-11.0', 'Oppo A96-11.0', 'Oppo Reno 3 Pro-10.0', 'Huawei P30-9.0'], description: 'Available Android Devices on BrowserStack', name: 'BROWSERSTACK_ANDROID_DEVICES'
-        booleanParam name: 'BROWSERSTACK_TESTING', defaultValue: false, description: 'When selected testing runs over Browserstack'
-        choice choices: ['1', '2', '3', '4',' 5'], description: 'Number of Shards for running tests on BrowserStack. <a href="https://app-automate.browserstack.com/dashboard/v2/builds/">BrowserStack Dashboard</a>', name: 'BROWSERSTACK_SHARDS'
-
     }
 
     agent {
@@ -56,8 +38,6 @@ pipeline {
             alwaysPull true
         }
     }
-
-    tools {nodejs "NodeJS"}
 
     options {
         timeout(time: 2, unit: 'HOURS')
@@ -75,15 +55,6 @@ pipeline {
             steps {
                 sh "./gradlew -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME' assembleDebug"
                 archiveArtifacts 'app/build/outputs/apk/debug/paintroid-debug*.apk'
-                plot csvFileName: 'dexcount.csv', csvSeries: [[displayTableFlag: false, exclusionValues: '', file: 'Paintroid/build/outputs/dexcount/*.csv', inclusionFlag: 'OFF', url: '']], group: 'APK Stats', numBuilds: '180', style: 'line', title: 'dexcount'
-            }
-        }
-
-        stage('Build Test-APK') {
-            steps {
-                sh "./gradlew -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME' assembleAndroidTest"
-                archiveArtifacts 'Paintroid/build/outputs/apk/androidTest/debug/*.apk'
-                renameApks("${env.BRANCH_NAME}-${env.BUILD_NUMBER}")
                 plot csvFileName: 'dexcount.csv', csvSeries: [[displayTableFlag: false, exclusionValues: '', file: 'Paintroid/build/outputs/dexcount/*.csv', inclusionFlag: 'OFF', url: '']], group: 'APK Stats', numBuilds: '180', style: 'line', title: 'dexcount'
             }
         }
@@ -129,18 +100,6 @@ pipeline {
             }
         }
 
-        stage('Browserstack testing') {
-            when {
-                expression { params.BROWSERSTACK_TESTING == true }
-            }
-            steps {
-                withCredentials([usernamePassword(credentialsId: 'browserstack', passwordVariable: 'BROWSERSTACK_ACCESS_KEY', usernameVariable: 'BROWSERSTACK_USERNAME')]) {
-                    script {
-                         browserStack('app/build/outputs/apk/debug/', 'Paintroid/build/outputs/apk/androidTest/debug/', 'Paintroid')
-                    }
-                }
-            }
-        }
         stage('Tests') {
             stages {
                 stage('Unit Tests') {
@@ -155,9 +114,6 @@ pipeline {
                 }
 
                 stage('Device Tests') {
-                    when {
-                        expression { params.DEVICE_TESTING == true }
-                    }
                     steps {
                         sh "echo no | avdmanager create avd --force --name android28 --package 'system-images;android-28;default;x86_64'"
                         sh "/home/user/android/sdk/emulator/emulator -no-window -no-boot-anim -noaudio -avd android28 > /dev/null 2>&1 &"


### PR DESCRIPTION
*Fix the Pantroid pipeline via removing the Browserstack stage*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
