### PR TITLE
DEVOPS-737 Remove caching and disable animations on the emulator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
     agent {
          docker {
             image 'catrobat/catrobat-paintroid:stable'
-            args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=6.5G'
+            args '--device /dev/kvm:/dev/kvm -m=6.5G'
             label 'LimitedEmulator'
             alwaysPull true
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,6 +115,10 @@ pipeline {
 
                 stage('Device Tests') {
                     steps {
+                        sh '/home/user/android/sdk/platform-tools/adb start-server'
+                        sh '/home/user/android/sdk/platform-tools/adb shell settings put global window_animation_scale 0 &'
+                        sh '/home/user/android/sdk/platform-tools/adb shell settings put global transition_animation_scale 0 &'
+                        sh '/home/user/android/sdk/platform-tools/adb shell settings put global animator_duration_scale 0 &'
                         sh "echo no | avdmanager create avd --force --name android28 --package 'system-images;android-28;default;x86_64'"
                         sh "/home/user/android/sdk/emulator/emulator -no-window -no-boot-anim -noaudio -avd android28 > /dev/null 2>&1 &"
                         sh './gradlew -PenableCoverage -Pjenkins -Pemulator=android28 -Pci createDebugCoverageReport -i'
@@ -122,7 +126,7 @@ pipeline {
                     post {
                         always {
                             sh '/home/user/android/sdk/platform-tools/adb logcat -d > logcat.txt'
-                            sh './gradlew stopEmulator'
+                            sh '/home/user/android/sdk/platform-tools/adb kill-server'
                             junitAndCoverage "$reports/coverage/debug/report.xml", 'device', javaSrc
                             archiveArtifacts 'logcat.txt'
                         }


### PR DESCRIPTION
*Caching had to be removed as well, as it did not function properly. Additionally some of the espresso tests timed out and by disabling animations on the emulator, this problem is seem to be fixed now.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
