### PR TITLE
PAINTROID-680 Zoom window shows wrong background when used with multi…

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ZoomWindowInteraction.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ZoomWindowInteraction.kt
@@ -1,8 +1,11 @@
 package org.catrobat.paintroid.test.espresso.util.wrappers
 
+import android.graphics.Bitmap
 import android.view.View
 import android.widget.RelativeLayout
+import androidx.annotation.ColorInt
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.CoordinatesProvider
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.catrobat.paintroid.R
@@ -11,6 +14,29 @@ import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
 
 class ZoomWindowInteraction private constructor() : CustomViewInteraction(Espresso.onView(withId(R.id.pocketpaint_zoom_window_image))) {
+    fun checkPixelColor(
+        @ColorInt expectedColor: Int,
+        coordinateProvider: CoordinatesProvider,
+        zoomWindowBitmap: Bitmap?
+    ): ZoomWindowInteraction {
+        check(ViewAssertions.matches(object : TypeSafeMatcher<View?>() {
+            override fun describeTo(description: Description) {
+                description.appendText(
+                    "Color in Zoom window at coordinates is " + Integer.toHexString(
+                        expectedColor
+                    )
+                )
+            }
+
+            override fun matchesSafely(view: View?): Boolean {
+                val coordinates = coordinateProvider.calculateCoordinates(view)
+                val actualColor = zoomWindowBitmap?.getPixel(coordinates[0].toInt(), coordinates[1].toInt())
+                return expectedColor == actualColor
+            }
+        }))
+        return this
+    }
+
     fun checkAlignment(verb: Int): ZoomWindowInteraction {
         check(ViewAssertions.matches(object : TypeSafeMatcher<View?>() {
             override fun matchesSafely(view: View?): Boolean {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/model/LayerModel.kt
@@ -22,6 +22,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import org.catrobat.paintroid.contract.LayerContracts
+import org.catrobat.paintroid.tools.Tool
 
 open class LayerModel : LayerContracts.Model {
     override var currentLayer: LayerContracts.Layer? = null
@@ -88,6 +89,56 @@ open class LayerModel : LayerContracts.Model {
                     alpha = layer.getValueForOpacityPercentage()
                 }
                 canvas?.drawBitmap(layer.bitmap, 0f, 0f, alphaPaint)
+            }
+        }
+    }
+
+    fun drawLayersOntoCanvasCorrectOrder(
+        surfaceViewCanvas: Canvas?,
+        currentLayerIndex: Int?,
+        drawingBoardCanvas: Canvas?,
+        tool: Tool?
+    ) {
+        layers.asReversed().forEach { layer ->
+            val layerIndex = getLayerIndexOf(layer)
+            if (layer.isVisible) {
+                val alphaPaint = Paint().apply {
+                    isFilterBitmap = false
+                    alpha = layer.getValueForOpacityPercentage()
+                }
+                surfaceViewCanvas?.drawBitmap(layer.bitmap, 0f, 0f, alphaPaint)
+                drawingBoardCanvas?.drawBitmap(layer.bitmap, 0f, 0f, alphaPaint)
+                if (surfaceViewCanvas != null && layerIndex == currentLayerIndex) {
+                    tool?.draw(surfaceViewCanvas)
+                }
+                if (drawingBoardCanvas != null && layerIndex == currentLayerIndex) {
+                    tool?.draw(drawingBoardCanvas)
+                }
+            }
+        }
+    }
+
+    fun drawLayersOntoCanvasCorrectOrderEraser(
+        surfaceViewCanvas: Canvas?,
+        currentLayerIndex: Int?,
+        tool: Tool?
+    ) {
+        var bitmapWithEraseApplied: Bitmap?
+        var eraseAppliedCanvas: Canvas?
+        layers.asReversed().forEach { layer ->
+            val layerIndex = getLayerIndexOf(layer)
+            if (layer.isVisible) {
+                val alphaPaint = Paint().apply {
+                    isFilterBitmap = false
+                    alpha = layer.getValueForOpacityPercentage()
+                }
+                surfaceViewCanvas?.drawBitmap(layer.bitmap, 0f, 0f, alphaPaint)
+                if (surfaceViewCanvas != null && layerIndex == currentLayerIndex) {
+                    bitmapWithEraseApplied = currentLayer?.bitmap
+                    eraseAppliedCanvas = bitmapWithEraseApplied?.let { Canvas(it) }
+                    eraseAppliedCanvas?.let { tool?.draw(it) }
+                    bitmapWithEraseApplied?.let { surfaceViewCanvas.drawBitmap(it, 0f, 0f, alphaPaint) }
+                }
             }
         }
     }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/zoomwindow/DefaultZoomWindowController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/zoomwindow/DefaultZoomWindowController.kt
@@ -90,10 +90,11 @@ class DefaultZoomWindowController
         activity.findViewById(R.id.pocketpaint_zoom_window)
     private val zoomWindowImage: ImageView =
         activity.findViewById(R.id.pocketpaint_zoom_window_image)
+    private var zoomWindowBitmap: Bitmap? = null
     private var coordinates: PointF? = null
 
     override fun show(drawingSurfaceCoordinates: PointF, displayCoordinates: PointF) {
-        if (checkIfToolCompatibleWithZoomWindow(toolReference.tool) != Constants.NOT_COMPATIBLE &&
+        if (checkIfToolCompatibleWithZoomWindow(toolReference.tool) == Constants.COMPATIBLE &&
             isPointOnCanvas(drawingSurfaceCoordinates.x, drawingSurfaceCoordinates.y)) {
             setZoomWindowPosition(displayCoordinates)
             zoomWindow.visibility = View.VISIBLE
@@ -110,7 +111,7 @@ class DefaultZoomWindowController
     }
 
     override fun onMove(drawingSurfaceCoordinates: PointF, displayCoordinates: PointF) {
-        if (checkIfToolCompatibleWithZoomWindow(toolReference.tool) != Constants.NOT_COMPATIBLE) {
+        if (checkIfToolCompatibleWithZoomWindow(toolReference.tool) == Constants.COMPATIBLE) {
             setZoomWindowPosition(displayCoordinates)
             if (isPointOnCanvas(drawingSurfaceCoordinates.x, drawingSurfaceCoordinates.y)) {
                 if (zoomWindow.visibility == View.GONE) {
@@ -131,9 +132,12 @@ class DefaultZoomWindowController
         }
     }
 
-    override fun getBitmap(bitmap: Bitmap?) {
+    override fun setBitmap(bitmap: Bitmap?) {
         zoomWindowImage.setImageBitmap(coordinates?.let { cropBitmap(bitmap, it) })
+        zoomWindowBitmap = bitmap
     }
+
+    override fun getBitmap(): Bitmap? = zoomWindowBitmap
 
     private fun isPointOnCanvas(pointX: Float, pointY: Float): Boolean =
         pointX > 0 && pointX < layerModel.width && pointY > 0 && pointY < layerModel.height
@@ -203,12 +207,6 @@ class DefaultZoomWindowController
 
         canvas.drawBitmap(backgroundBitmap, Matrix(), null)
 
-        if (checkIfToolCompatibleWithZoomWindow(toolReference.tool) == Constants.COMPATIBLE_NEW) {
-            layerModel.currentLayer?.bitmap?.let {
-                canvas.drawBitmap(it, zoomWindowDiameter / 2f, zoomWindowDiameter / 2f, null)
-            }
-        }
-
         bitmap?.let { canvas.drawBitmap(it, zoomWindowDiameter / 2f, zoomWindowDiameter / 2f, null) }
 
         return bitmapOverlay
@@ -221,22 +219,22 @@ class DefaultZoomWindowController
 
     override fun checkIfToolCompatibleWithZoomWindow(tool: Tool?): Constants {
         return when (tool?.toolType?.name) {
-            ToolType.HAND.name,
-            ToolType.FILL.name,
-            ToolType.CLIPBOARD.name,
-            ToolType.TRANSFORM.name,
-            ToolType.IMPORTPNG.name,
-            ToolType.SHAPE.name,
-            ToolType.TEXT.name -> Constants.NOT_COMPATIBLE
-            ToolType.ERASER.name -> Constants.COMPATIBLE_ALL
-            else -> Constants.COMPATIBLE_NEW
+            ToolType.LINE.name,
+            ToolType.CURSOR.name,
+            ToolType.WATERCOLOR.name,
+            ToolType.SPRAY.name,
+            ToolType.BRUSH.name,
+            ToolType.ERASER.name,
+            ToolType.PIPETTE.name,
+            ToolType.CLIP.name,
+            ToolType.SMUDGE.name -> Constants.COMPATIBLE
+            else -> Constants.NOT_COMPATIBLE
         }
     }
 
     enum class Constants {
         NOT_COMPATIBLE,
-        COMPATIBLE_NEW,
-        COMPATIBLE_ALL
+        COMPATIBLE
     }
 
     companion object {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/zoomwindow/ZoomWindowController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/zoomwindow/ZoomWindowController.kt
@@ -13,7 +13,9 @@ interface ZoomWindowController {
 
     fun onMove(drawingSurfaceCoordinates: PointF, displayCoordinates: PointF)
 
-    fun getBitmap(bitmap: Bitmap?)
+    fun setBitmap(bitmap: Bitmap?)
+
+    fun getBitmap(): Bitmap?
 
     fun checkIfToolCompatibleWithZoomWindow(tool: Tool?): DefaultZoomWindowController.Constants
 }


### PR DESCRIPTION
[PAINTROID-680](https://jira.catrob.at/browse/PAINTROID-680)

+ Fixed bug where the Zoom Window didn't show the correct background (it showed the checkered pattern)
+ Now it shows the current layer as expected when drawing or using a tool
+ It also shows all the other layers in the zoom window
+ This also fixes the problem in [PAINTROID-650](https://jira.catrob.at/browse/PAINTROID-650)
+ Added 2 Test cases for the zoom window background, one when using a single layer and the other for using multiple layers
+ Renamed the function getBitmap() to setBitmap() to avoid confusion, since it was not a getter and just set the bitmap of the zoom window image
+ Resolved merge conflicts with [PAINTROID-650](https://jira.catrob.at/browse/PAINTROID-650) since it was already merged into develop

+ This also fixes [PAINTROID-686](https://jira.catrob.at/browse/PAINTROID-686), I decided to fix it in this ticket since it turned out that they depend on each other a little bit. The problem was that when drawing with multiple layers, the drawn line or tool that is being used, would show on the very top of all layers and then once the finger is removed, it would automatically readjust to the correct layer. Now while drawing the lines are where they belong on the correct layer and there is no weird readjusting anymore.
+ Also simplified the code for the 680 fix.


- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
