### PR TITLE
PAINTROID-621 Crash org.catrobat.paintroid.command.serialization.ClipboardCommandSerializer.readCurrentVersion

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/ClipboardCommandSerializer.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/serialization/ClipboardCommandSerializer.kt
@@ -27,6 +27,7 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import org.catrobat.paintroid.FileIO
 import org.catrobat.paintroid.command.implementation.ClipboardCommand
+import java.io.IOException
 
 class ClipboardCommandSerializer(version: Int) : VersionSerializer<ClipboardCommand>(version) {
 
@@ -61,6 +62,7 @@ class ClipboardCommandSerializer(version: Int) : VersionSerializer<ClipboardComm
                 val width = readFloat()
                 val height = readFloat()
                 val rotation = readFloat()
+                if (bitmap == null) throw IOException("Bitmap is null! Can not create ClipboardCommand.")
                 ClipboardCommand(bitmap, coordinates, width, height, rotation)
             }
         }


### PR DESCRIPTION
When the bitmap in the ClipboardCommandSerializer is null, an IOException instead of NullPointerException is thrown.  This exception is handled in FileIO.kt without crashing

https://jira.catrob.at/browse/PAINTROID-621

Should hopefully fix https://jira.catrob.at/browse/PAINTROID-600 too

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
