### PR TITLE
PAINTROID_693_auto_load_file_not_found

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
@@ -596,18 +596,18 @@ object FileIO {
 
             val stream = FileOutputStream("$tempPath/$newFileName")
             commandSerializer.writeToInternalMemory(stream)
-            temporaryFilePath = TEMP_IMAGE_TEMP_PATH
+            stream.close()
         } catch (e: IOException) {
             Log.e("Cannot write", "Can't write to stream", e)
         }
         val oldFile = File(internalMemoryPath, TEMP_IMAGE_PATH)
-        if (oldFile.exists()) {
+        val newFile = File(internalMemoryPath, TEMP_IMAGE_TEMP_PATH)
+        if (oldFile.exists() && newFile.exists()) {
             oldFile.delete()
         }
-        val newFile = File(internalMemoryPath, TEMP_IMAGE_TEMP_PATH)
         if (newFile.exists()) {
-            newFile.renameTo(File(internalMemoryPath, TEMP_IMAGE_PATH))
-            temporaryFilePath = TEMP_IMAGE_PATH
+            val rename = File(internalMemoryPath, TEMP_IMAGE_PATH)
+            newFile.renameTo(rename)
         }
     }
 
@@ -616,26 +616,12 @@ object FileIO {
         if (!tempPath.exists()) {
             return false
         }
-        val fileList = tempPath.listFiles()
-        if (fileList != null && fileList.isNotEmpty()) {
-            if (fileList.size == 2) {
-                if (fileList[1].lastModified() > fileList[0].lastModified()) {
-                    reorganizeTempFiles(fileList[1], fileList[0], internalMemoryPath)
-                } else {
-                    reorganizeTempFiles(fileList[0], fileList[1], internalMemoryPath)
-                }
-            } else {
-                temporaryFilePath = fileList[0].path
-            }
+        val file = File(internalMemoryPath, TEMP_IMAGE_PATH)
+        if (file.exists()){
+            temporaryFilePath = file.path
             return true
         }
         return false
-    }
-
-    private fun reorganizeTempFiles(file1: File, file2: File, internalMemoryPath: File) {
-        file2.delete()
-        file1.renameTo(File(internalMemoryPath, TEMP_IMAGE_PATH))
-        temporaryFilePath = TEMP_IMAGE_PATH
     }
 
     fun openTemporaryPictureFile(commandSerializer: CommandSerializer): WorkspaceReturnValue? {
@@ -643,7 +629,9 @@ object FileIO {
         if (temporaryFilePath != null) {
             try {
                 val stream = FileInputStream(temporaryFilePath)
+                if (stream.available() == 0) throw IOException("FileInputStream not available!")
                 workspaceReturnValue = commandSerializer.readFromInternalMemory(stream)
+                stream.close()
             } catch (e: IOException) {
                 Log.e("Cannot read", "Can't read from stream", e)
             }


### PR DESCRIPTION
Removed bug where path to temp file was set incorrectly and therefore image could not be loaded.

- streamlined saving and loading of temp file
- closed streams

https://jira.catrob.at/browse/PAINTROID-693

in addition, avoided kryo buffer underflow when app is started and no temp file available
should solve:
https://jira.catrob.at/browse/PAINTROID-655

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
