### PR TITLE
PAINTROID-444 Show size of shapes in different tools

### DIFF
--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClipboardToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ClipboardToolIntegrationTest.kt
@@ -25,9 +25,13 @@ import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.PointF
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import org.catrobat.paintroid.MainActivity
+import org.catrobat.paintroid.R
 import org.catrobat.paintroid.test.espresso.util.DrawingSurfaceLocationProvider
 import org.catrobat.paintroid.test.espresso.util.UiInteractions
 import org.catrobat.paintroid.test.espresso.util.wrappers.ClipboardToolViewInteraction.Companion.onClipboardToolViewInteraction
@@ -45,6 +49,7 @@ import org.catrobat.paintroid.tools.drawable.DrawableStyle
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape
 import org.catrobat.paintroid.tools.implementation.ClipboardTool
 import org.catrobat.paintroid.ui.Perspective
+import org.hamcrest.Matchers
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -235,6 +240,33 @@ class ClipboardToolIntegrationTest {
         onToolBarView().performSelectTool(ToolType.CLIPBOARD)
         perspective?.scale?.let { Assert.assertEquals(scale, it, 0.0001f) }
     }
+
+    @Test
+    fun testClipboardToolSizeDisplay() {
+        onToolBarView().performSelectTool(ToolType.CLIPBOARD)
+        val clipboardTool = toolReference?.tool as ClipboardTool
+
+        Espresso.onView(
+            Matchers.allOf(ViewMatchers.withParent(ViewMatchers.withId(R.id.pocketpaint_layout_clipboard_tool_options_view_shape_size)),
+                ViewMatchers.withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(ViewAssertions.matches(ViewMatchers.withText(getShapeSizeText(clipboardTool))))
+
+        onDrawingSurfaceView()
+            .perform(
+                UiInteractions.swipe(
+                    DrawingSurfaceLocationProvider.TOOL_POSITION,
+                    DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT
+                )
+            )
+
+        Espresso.onView(
+            Matchers.allOf(ViewMatchers.withParent(ViewMatchers.withId(R.id.pocketpaint_layout_clipboard_tool_options_view_shape_size)),
+            ViewMatchers.withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(ViewAssertions.matches(ViewMatchers.withText(getShapeSizeText(clipboardTool))))
+    }
+
+    private fun getShapeSizeText(clipboardTool: ClipboardTool): String =
+        "${clipboardTool.boxWidth.toInt()} x ${clipboardTool.boxHeight.toInt()} px"
 
     companion object {
         private const val SCALE_25 = 0.25f

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/ShapeToolIntegrationTest.kt
@@ -23,6 +23,9 @@ package org.catrobat.paintroid.test.espresso.tools
 
 import android.graphics.Color
 import android.graphics.Paint
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import org.catrobat.paintroid.MainActivity
@@ -43,6 +46,7 @@ import org.catrobat.paintroid.tools.drawable.DrawableShape
 import org.catrobat.paintroid.tools.drawable.DrawableStyle
 import org.catrobat.paintroid.tools.implementation.BaseToolWithRectangleShape
 import org.catrobat.paintroid.tools.implementation.ShapeTool
+import org.hamcrest.Matchers
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -207,6 +211,32 @@ class ShapeToolIntegrationTest {
                 mainActivity.perspective.surfaceCenterY - mainActivity.perspective.surfaceTranslationY
             )
     }
+
+    @Test
+    fun testShapeToolSizeDisplay() {
+        val shapeTool = toolReference?.tool as ShapeTool
+
+        Espresso.onView(
+            Matchers.allOf(ViewMatchers.withParent(ViewMatchers.withId(R.id.pocketpaint_layout_shape_tool_options_view_shape_size)),
+            ViewMatchers.withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(ViewAssertions.matches(ViewMatchers.withText(getShapeSizeText(shapeTool))))
+
+        onDrawingSurfaceView()
+            .perform(
+                UiInteractions.swipe(
+                    DrawingSurfaceLocationProvider.TOOL_POSITION,
+                    DrawingSurfaceLocationProvider.HALFWAY_TOP_LEFT
+                )
+            )
+
+        Espresso.onView(
+            Matchers.allOf(ViewMatchers.withParent(ViewMatchers.withId(R.id.pocketpaint_layout_shape_tool_options_view_shape_size)),
+            ViewMatchers.withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(ViewAssertions.matches(ViewMatchers.withText(getShapeSizeText(shapeTool))))
+    }
+
+    private fun getShapeSizeText(shapeTool: ShapeTool): String =
+        "${shapeTool.boxWidth.toInt()} x ${shapeTool.boxHeight.toInt()} px"
 
     private fun drawShape() {
         onToolBarView().performCloseToolOptionsView()

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/tools/TextToolIntegrationTest.kt
@@ -66,6 +66,7 @@ import org.catrobat.paintroid.tools.implementation.TEXT_SIZE_MAGNIFICATION_FACTO
 import org.catrobat.paintroid.tools.implementation.TextTool
 import org.catrobat.paintroid.ui.tools.FontListAdapter
 import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matchers
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
@@ -762,6 +763,41 @@ class TextToolIntegrationTest {
             Assert.assertTrue(boxWidth < toolMemberBoxWidth && boxHeight < toolMemberBoxHeight)
         }
     }
+
+    @Test
+    fun testTextToolSizeDisplay() {
+        onToolBarView().performSelectTool(ToolType.TEXT)
+
+        onView(
+            Matchers.allOf(ViewMatchers.withParent(withId(R.id.pocketpaint_layout_text_tool_options_view_shape_size)),
+            withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(matches(ViewMatchers.withText(getShapeSizeText())))
+
+        enterMultilineTestText()
+
+        onView(
+            Matchers.allOf(ViewMatchers.withParent(withId(R.id.pocketpaint_layout_text_tool_options_view_shape_size)),
+            withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(matches(ViewMatchers.withText(getShapeSizeText())))
+
+        onView(withId(R.id.pocketpaint_font_size_text))
+            .perform(ViewActions.replaceText("100"))
+
+        onView(
+            Matchers.allOf(ViewMatchers.withParent(withId(R.id.pocketpaint_layout_text_tool_options_view_shape_size)),
+            withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(matches(ViewMatchers.withText(getShapeSizeText())))
+
+        selectFontType(FontType.STC)
+
+        onView(
+            Matchers.allOf(ViewMatchers.withParent(withId(R.id.pocketpaint_layout_text_tool_options_view_shape_size)),
+            withId(R.id.pocketpaint_fill_shape_size_text)))
+            .check(matches(ViewMatchers.withText(getShapeSizeText())))
+    }
+
+    private fun getShapeSizeText(): String =
+        "${toolMemberBoxWidth.toInt()} x ${toolMemberBoxHeight.toInt()} px"
 
     private fun centerBox(): PointF? {
         val screenPoint =

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/espresso/util/wrappers/ToolBarViewInteraction.kt
@@ -64,16 +64,20 @@ class ToolBarViewInteraction :
         get() = EspressoUtils.mainActivity.toolReference.tool!!.toolType
 
     fun performOpenToolOptionsView(): ToolBarViewInteraction {
-        onToolOptionsView()
-            .check(ViewAssertions.matches(Matchers.not(ViewMatchers.isDisplayed())))
+        if (currentToolType != ToolType.TEXT) {
+            onToolOptionsView()
+                .check(ViewAssertions.matches(Matchers.not(ViewMatchers.isDisplayed())))
+        }
         onBottomNavigationView()
             .onCurrentClicked()
         return this
     }
 
     fun performCloseToolOptionsView(): ToolBarViewInteraction {
-        onToolOptionsView()
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        if (currentToolType != ToolType.TEXT) {
+            onToolOptionsView()
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        }
         onBottomNavigationView()
             .onCurrentClicked()
         return this

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ClipboardToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ClipboardToolTest.kt
@@ -104,6 +104,7 @@ class ClipboardToolTest {
         )
         Mockito.`when`(toolOptionsViewController.toolSpecificOptionsLayout).thenReturn(viewMock)
         Mockito.`when`(toolOptionsViewController.toolSpecificOptionsLayout).thenReturn(viewMock)
+        Mockito.`when`(clipboardToolOptionsView.getClipboardToolOptionsLayout()).thenReturn(viewMock)
     }
 
     @After

--- a/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.kt
+++ b/Paintroid/src/androidTest/java/org/catrobat/paintroid/test/junit/tools/ImportToolTest.kt
@@ -41,6 +41,7 @@ import org.catrobat.paintroid.ui.Perspective
 import android.graphics.Bitmap
 import org.catrobat.paintroid.tools.implementation.DEFAULT_BOX_RESIZE_MARGIN
 import org.catrobat.paintroid.tools.implementation.MAXIMUM_BORDER_RATIO
+import org.catrobat.paintroid.tools.options.ImportToolOptionsView
 import org.junit.After
 import org.junit.Assert
 import org.junit.Rule
@@ -63,6 +64,9 @@ class ImportToolTest {
 
     @Mock
     private lateinit var contextCallback: ContextCallback
+
+    @Mock
+    private val importToolOptionsView: ImportToolOptionsView? = null
 
     @Mock
     private val displayMetrics: DisplayMetrics? = null
@@ -90,7 +94,7 @@ class ImportToolTest {
         Mockito.`when`(workspace.height).thenReturn(30)
         Mockito.`when`(workspace.scale).thenReturn(1f)
         Mockito.`when`(workspace.perspective).thenReturn(Perspective(20, 30))
-        tool = ImportTool(contextCallback, toolOptionsViewController, toolPaint, workspace,
+        tool = ImportTool(importToolOptionsView!!, contextCallback, toolOptionsViewController, toolPaint, workspace,
                           idlingResource, commandManager, 0)
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -293,6 +293,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         onCreateMainView()
         onCreateLayerMenu()
         onCreateDrawingSurface()
+        presenterMain.onCreateTool()
         OpenRasterFileFormatConversion.mainActivity = this
 
         val receivedIntent = intent
@@ -339,7 +340,6 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                 )
             }
         }
-        presenterMain.onCreateTool()
 
         commandManager.addCommandListener(this)
         lastInteractionTime = System.currentTimeMillis()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -293,7 +293,6 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
         onCreateMainView()
         onCreateLayerMenu()
         onCreateDrawingSurface()
-        presenterMain.onCreateTool()
         OpenRasterFileFormatConversion.mainActivity = this
 
         val receivedIntent = intent
@@ -340,6 +339,7 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                 )
             }
         }
+        presenterMain.onCreateTool()
 
         commandManager.addCommandListener(this)
         lastInteractionTime = System.currentTimeMillis()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -67,7 +67,7 @@ class DefaultToolController(
     override val toolType: ToolType?
         get() = toolReference.tool?.toolType
 
-    private fun createAndSetupTool(toolType: ToolType): Tool {
+    private fun createAndSetupTool(toolType: ToolType, isFullScreen: Boolean = false): Tool {
         if (toolType != ToolType.HAND) {
             toolOptionsViewController.removeToolViews()
         } else if (toolType != ToolType.CLIP) {
@@ -93,7 +93,7 @@ class DefaultToolController(
         )
         if (toolType != ToolType.HAND) {
             toolOptionsViewController.resetToOrigin()
-            toolOptionsViewController.show()
+            toolOptionsViewController.show(isFullScreen)
         }
         return tool
     }
@@ -199,14 +199,14 @@ class DefaultToolController(
         toolOptionsViewController.disableHide()
     }
 
-    override fun createTool() {
+    override fun createTool(isFullScreen: Boolean) {
         val currentTool = toolReference.tool
         if (currentTool == null) {
             toolReference.tool = createAndSetupTool(ToolType.BRUSH)
         } else {
             val bundle = Bundle()
             toolReference.tool?.onSaveInstanceState(bundle)
-            toolReference.tool = createAndSetupTool(currentTool.toolType)
+            toolReference.tool = createAndSetupTool(currentTool.toolType, isFullScreen)
             toolReference.tool?.onRestoreInstanceState(bundle)
         }
         workspace.invalidate()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -67,7 +67,7 @@ class DefaultToolController(
     override val toolType: ToolType?
         get() = toolReference.tool?.toolType
 
-    private fun createAndSetupTool(toolType: ToolType, isFullScreen: Boolean = false): Tool {
+    private fun createAndSetupTool(toolType: ToolType): Tool {
         if (toolType != ToolType.HAND) {
             toolOptionsViewController.removeToolViews()
         } else if (toolType != ToolType.CLIP) {
@@ -93,7 +93,7 @@ class DefaultToolController(
         )
         if (toolType != ToolType.HAND) {
             toolOptionsViewController.resetToOrigin()
-            toolOptionsViewController.show(isFullScreen)
+            toolOptionsViewController.show()
         }
         return tool
     }
@@ -191,6 +191,11 @@ class DefaultToolController(
         toolOptionsViewController.enable()
     }
 
+    override fun adaptLayoutForFullScreen() {
+        if(toolReference.tool?.toolType != ToolType.HAND)
+        toolOptionsViewController.show(true)
+    }
+
     override fun enableHideOption() {
         toolOptionsViewController.enableHide()
     }
@@ -199,14 +204,14 @@ class DefaultToolController(
         toolOptionsViewController.disableHide()
     }
 
-    override fun createTool(isFullScreen: Boolean) {
+    override fun createTool() {
         val currentTool = toolReference.tool
         if (currentTool == null) {
             toolReference.tool = createAndSetupTool(ToolType.BRUSH)
         } else {
             val bundle = Bundle()
             toolReference.tool?.onSaveInstanceState(bundle)
-            toolReference.tool = createAndSetupTool(currentTool.toolType, isFullScreen)
+            toolReference.tool = createAndSetupTool(currentTool.toolType)
             toolReference.tool?.onRestoreInstanceState(bundle)
         }
         workspace.invalidate()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -192,8 +192,9 @@ class DefaultToolController(
     }
 
     override fun adaptLayoutForFullScreen() {
-        if(toolReference.tool?.toolType != ToolType.HAND)
-        toolOptionsViewController.show(true)
+        if (toolReference.tool?.toolType != ToolType.HAND) {
+            toolOptionsViewController.show(true)
+        }
     }
 
     override fun enableHideOption() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -116,11 +116,12 @@ class DefaultToolController(
     }
 
     override fun showToolOptionsView() {
+        toolOptionsViewController.show()
         when (toolReference.tool?.toolType) {
             ToolType.TEXT -> (toolReference.tool as TextTool).showTextToolLayout()
             ToolType.SHAPE -> (toolReference.tool as ShapeTool).changeShapeToolLayoutVisibility(false, true)
             ToolType.CLIPBOARD -> (toolReference.tool as ClipboardTool).changeClipboardToolLayoutVisibility(false, true)
-            else -> toolOptionsViewController.show()
+            else -> {}
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -184,7 +184,9 @@ class DefaultToolController(
     }
 
     override fun disableToolOptionsView() {
-        toolOptionsViewController.disable()
+        if (toolType != ToolType.IMPORTPNG) {
+            toolOptionsViewController.disable()
+        }
     }
 
     override fun enableToolOptionsView() {
@@ -202,7 +204,9 @@ class DefaultToolController(
     }
 
     override fun disableHideOption() {
-        toolOptionsViewController.disableHide()
+        if (toolType != ToolType.IMPORTPNG) {
+            toolOptionsViewController.disableHide()
+        }
     }
 
     override fun createTool() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -115,6 +115,15 @@ class DefaultToolController(
         }
     }
 
+    override fun hideToolOptionsViewForShapeTools() {
+        when (toolReference.tool?.toolType) {
+            ToolType.TEXT -> (toolReference.tool as TextTool).hideTextToolLayout()
+            ToolType.SHAPE -> (toolReference.tool as ShapeTool).changeShapeToolLayoutVisibility(true, true)
+            ToolType.CLIPBOARD -> (toolReference.tool as ClipboardTool).changeClipboardToolLayoutVisibility(true, true)
+            else -> {}
+        }
+    }
+
     override fun showToolOptionsView() {
         toolOptionsViewController.show()
         when (toolReference.tool?.toolType) {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/DefaultToolController.kt
@@ -33,10 +33,12 @@ import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolReference
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
+import org.catrobat.paintroid.tools.implementation.ClipboardTool
 import org.catrobat.paintroid.tools.implementation.ClippingTool
 import org.catrobat.paintroid.tools.implementation.EraserTool
 import org.catrobat.paintroid.tools.implementation.ImportTool
 import org.catrobat.paintroid.tools.implementation.LineTool
+import org.catrobat.paintroid.tools.implementation.ShapeTool
 import org.catrobat.paintroid.tools.implementation.SprayTool
 import org.catrobat.paintroid.tools.implementation.TextTool
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
@@ -105,16 +107,20 @@ class DefaultToolController(
     }
 
     override fun hideToolOptionsView() {
-        toolOptionsViewController.hide()
-        if (toolReference.tool?.toolType == ToolType.TEXT) {
-            (toolReference.tool as TextTool).hideTextToolLayout()
+        when (toolReference.tool?.toolType) {
+            ToolType.TEXT -> (toolReference.tool as TextTool).hideTextToolLayout()
+            ToolType.SHAPE -> (toolReference.tool as ShapeTool).changeShapeToolLayoutVisibility(true, true)
+            ToolType.CLIPBOARD -> (toolReference.tool as ClipboardTool).changeClipboardToolLayoutVisibility(true, true)
+            else -> toolOptionsViewController.hide()
         }
     }
 
     override fun showToolOptionsView() {
-        toolOptionsViewController.show()
-        if (toolReference.tool?.toolType == ToolType.TEXT) {
-            (toolReference.tool as TextTool).showTextToolLayout()
+        when (toolReference.tool?.toolType) {
+            ToolType.TEXT -> (toolReference.tool as TextTool).showTextToolLayout()
+            ToolType.SHAPE -> (toolReference.tool as ShapeTool).changeShapeToolLayoutVisibility(false, true)
+            ToolType.CLIPBOARD -> (toolReference.tool as ClipboardTool).changeClipboardToolLayoutVisibility(false, true)
+            else -> toolOptionsViewController.show()
         }
     }
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
@@ -62,7 +62,9 @@ interface ToolController {
 
     fun enableToolOptionsView()
 
-    fun createTool(isFullScreen: Boolean = false)
+    fun createTool()
+
+    fun adaptLayoutForFullScreen()
 
     fun toggleToolOptionsView()
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
@@ -62,7 +62,7 @@ interface ToolController {
 
     fun enableToolOptionsView()
 
-    fun createTool()
+    fun createTool(isFullScreen: Boolean)
 
     fun toggleToolOptionsView()
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
@@ -62,7 +62,7 @@ interface ToolController {
 
     fun enableToolOptionsView()
 
-    fun createTool(isFullScreen: Boolean)
+    fun createTool(isFullScreen: Boolean = false)
 
     fun toggleToolOptionsView()
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/controller/ToolController.kt
@@ -44,6 +44,8 @@ interface ToolController {
 
     fun hideToolOptionsView()
 
+    fun hideToolOptionsViewForShapeTools()
+
     fun showToolOptionsView()
 
     fun toolOptionsViewVisible(): Boolean

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -785,10 +785,13 @@ open class MainActivityPresenter(
         model.cameraImageUri = cameraImageUri
         navigator.restoreFragmentListeners()
         toolController.resetToolInternalStateOnImageLoaded()
+        if (model.isFullscreen) {
+            toolController.adaptLayoutForFullScreen()
+        }
     }
 
     override fun onCreateTool() {
-        toolController.createTool(model.isFullscreen)
+        toolController.createTool()
     }
 
     private fun refreshTopBarButtons() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -758,6 +758,7 @@ open class MainActivityPresenter(
     private fun enterHideButtons() {
         if (toolController.toolOptionsViewVisible()) {
             toolOptionsViewWasShown = true
+            toolController.hideToolOptionsView()
         }
         view.hideKeyboard()
         view.enterHideButtons()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -788,7 +788,7 @@ open class MainActivityPresenter(
     }
 
     override fun onCreateTool() {
-        toolController.createTool()
+        toolController.createTool(model.isFullscreen)
     }
 
     private fun refreshTopBarButtons() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/presenter/MainActivityPresenter.kt
@@ -758,7 +758,7 @@ open class MainActivityPresenter(
     private fun enterHideButtons() {
         if (toolController.toolOptionsViewVisible()) {
             toolOptionsViewWasShown = true
-            toolController.hideToolOptionsView()
+            toolController.hideToolOptionsViewForShapeTools()
         }
         view.hideKeyboard()
         view.enterHideButtons()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
@@ -47,7 +47,7 @@ class ClipboardTool(
     override var drawTime: Long
 ) : BaseToolWithRectangleShape(
     contextCallback, toolOptionsViewController, toolPaint, workspace, idlingResource, commandManager
-) {
+), BaseToolWithRectangleShape.ShapeSizeChangedListener {
     private val clipboardToolOptionsView: ClipboardToolOptionsView
     private var readyForPaste = false
     private val isDrawingBitmapReusable: Boolean
@@ -96,6 +96,8 @@ class ClipboardTool(
         }
         clipboardToolOptionsView.setCallback(callback)
         toolOptionsViewController.showDelayed()
+        setShapeSizeChangedListener(this)
+        createAndSetShapeSizeText(boxWidth, boxHeight)
     }
 
     fun copyBoxContent() {
@@ -160,5 +162,16 @@ class ClipboardTool(
             drawingBitmap = getParcelable(BUNDLE_TOOL_DRAWING_BITMAP)
         }
         clipboardToolOptionsView.enablePaste(readyForPaste)
+    }
+    override fun onShapeSizeChanged(shapeText: String) {
+        clipboardToolOptionsView.setShapeSizeText(shapeText)
+    }
+
+    override fun onToggleVisibility(isVisible: Boolean) {
+        clipboardToolOptionsView.toggleShapeSizeVisibility(isVisible)
+    }
+
+    fun changeClipboardToolLayoutVisibility(willHide: Boolean, disabled: Boolean = false) {
+        changeToolLayoutVisibility(clipboardToolOptionsView.getClipboardToolOptionsLayout(), willHide, disabled)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/DefaultToolFactory.kt
@@ -34,6 +34,7 @@ import org.catrobat.paintroid.ui.tools.DefaultFillToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultShapeToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultSprayToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultClipboardToolOptionsView
+import org.catrobat.paintroid.ui.tools.DefaultImportToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultTextToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultTransformToolOptionsView
 import org.catrobat.paintroid.ui.tools.DefaultSmudgeToolOptionsView
@@ -76,6 +77,7 @@ class DefaultToolFactory(mainActivity: MainActivity) : ToolFactory {
                 DRAW_TIME_INIT
             )
             ToolType.IMPORTPNG -> ImportTool(
+                DefaultImportToolOptionsView(toolLayout),
                 contextCallback,
                 toolOptionsViewController,
                 toolPaint,

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ImportTool.kt
@@ -28,6 +28,7 @@ import org.catrobat.paintroid.tools.ContextCallback
 import org.catrobat.paintroid.tools.ToolPaint
 import org.catrobat.paintroid.tools.ToolType
 import org.catrobat.paintroid.tools.Workspace
+import org.catrobat.paintroid.tools.options.ImportToolOptionsView
 import org.catrobat.paintroid.tools.options.ToolOptionsViewController
 import kotlin.math.max
 import kotlin.math.min
@@ -35,6 +36,7 @@ import kotlin.math.min
 private const val BUNDLE_TOOL_DRAWING_BITMAP = "BUNDLE_TOOL_DRAWING_BITMAP"
 
 class ImportTool(
+    importToolOptionsView: ImportToolOptionsView,
     contextCallback: ContextCallback,
     toolOptionsViewController: ToolOptionsViewController,
     toolPaint: ToolPaint,
@@ -44,8 +46,9 @@ class ImportTool(
     override var drawTime: Long
 ) : BaseToolWithRectangleShape(
     contextCallback, toolOptionsViewController, toolPaint, workspace, idlingResource, commandManager
-) {
+), BaseToolWithRectangleShape.ShapeSizeChangedListener {
 
+    private val importToolOptionsView: ImportToolOptionsView
     override val toolType: ToolType
         get() = ToolType.IMPORTPNG
 
@@ -60,7 +63,10 @@ class ImportTool(
     override fun toolPositionCoordinates(coordinate: PointF): PointF = coordinate
 
     init {
+        this.importToolOptionsView = importToolOptionsView
         rotationEnabled = true
+        setShapeSizeChangedListener(this)
+        importToolOptionsView.setShapeSizeInvisble()
     }
 
     override fun drawShape(canvas: Canvas) {
@@ -101,5 +107,14 @@ class ImportTool(
         val minimumSize = DEFAULT_BOX_RESIZE_MARGIN.toFloat()
         boxWidth = max(minimumSize, min(maximumBorderRatioWidth, bitmap.width.toFloat()))
         boxHeight = max(minimumSize, min(maximumBorderRatioHeight, bitmap.height.toFloat()))
+        createAndSetShapeSizeText(boxWidth, boxHeight)
+    }
+
+    override fun onShapeSizeChanged(shapeText: String) {
+        importToolOptionsView.setShapeSizeText(shapeText)
+    }
+
+    override fun onToggleVisibility(isVisible: Boolean) {
+        if (isVisible) hideToolSpecificLayout(isVisible) else showToolSpecificLayout()
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
@@ -54,7 +54,7 @@ class ShapeTool(
     override var drawTime: Long
 ) : BaseToolWithRectangleShape(
     contextCallback, toolOptionsViewController, toolPaint, workspace, idlingResource, commandManager
-) {
+), BaseToolWithRectangleShape.ShapeSizeChangedListener {
     private val shapeToolOptionsView: ShapeToolOptionsView
     private val shapePreviewPaint = Paint()
     private val shapePreviewRect = RectF()
@@ -99,6 +99,8 @@ class ShapeTool(
                 }
             })
         toolOptionsViewController.showDelayed()
+        setShapeSizeChangedListener(this)
+        createAndSetShapeSizeText(boxWidth, boxHeight)
     }
 
     fun getBaseShape(): DrawableShape = baseShape
@@ -190,5 +192,17 @@ class ShapeTool(
             commandManager.addCommand(command)
             highlightBox()
         }
+    }
+
+    fun changeShapeToolLayoutVisibility(willHide: Boolean, disabled: Boolean = false) {
+        changeToolLayoutVisibility(shapeToolOptionsView.getShapeToolOptionsLayout(), willHide, disabled)
+    }
+
+    override fun onShapeSizeChanged(shapeText: String) {
+        shapeToolOptionsView.setShapeSizeText(shapeText)
+    }
+
+    override fun onToggleVisibility(isVisible: Boolean) {
+        shapeToolOptionsView.toggleShapeSizeVisibility(isVisible)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/TextTool.kt
@@ -79,7 +79,7 @@ class TextTool(
     workspace,
     idlingResource,
     commandManager
-) {
+), BaseToolWithRectangleShape.ShapeSizeChangedListener {
     @VisibleForTesting
     @JvmField
     val textPaint: Paint
@@ -134,6 +134,7 @@ class TextTool(
         resizePointsVisible = RESIZE_POINTS_VISIBLE
         stc = contextCallback.getFont(R.font.stc_regular)
         dubai = contextCallback.getFont(R.font.dubai)
+        setShapeSizeChangedListener(this)
         textPaint = Paint()
         initializePaint()
         resetPreview()
@@ -324,6 +325,7 @@ class TextTool(
         }
         boxHeight = textHeight * multilineText.size + 2 * BOX_OFFSET
         boxWidth = maxTextWidth + 2 * BOX_OFFSET
+        createAndSetShapeSizeText(boxWidth, boxHeight)
     }
 
     private fun storeAttributes(italic: Boolean = false) {
@@ -342,6 +344,7 @@ class TextTool(
         } else {
             resetBoxPosition()
         }
+        createAndSetShapeSizeText(boxWidth, boxHeight)
     }
 
     override fun onSaveInstanceState(bundle: Bundle?) {
@@ -446,5 +449,13 @@ class TextTool(
     override fun changePaintColor(color: Int, invalidate: Boolean) {
         super.changePaintColor(color, invalidate)
         changeTextColor()
+    }
+
+    override fun onShapeSizeChanged(shapeText: String) {
+        textToolOptionsView.setShapeSizeText(shapeText)
+    }
+
+    override fun onToggleVisibility(isVisible: Boolean) {
+        textToolOptionsView.toggleShapeSizeVisibility(isVisible)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ImportToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ImportToolOptionsView.kt
@@ -1,6 +1,6 @@
 /*
  * Paintroid: An image manipulation application for Android.
- *  Copyright (C) 2010-2022 The Catrobat Team
+ *  Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -18,24 +18,10 @@
  */
 package org.catrobat.paintroid.tools.options
 
-import android.view.View
-
-interface ClipboardToolOptionsView {
-    fun setCallback(callback: Callback)
-
-    fun enablePaste(enable: Boolean)
-
+interface ImportToolOptionsView {
     fun setShapeSizeText(shapeSize: String)
 
+    fun setShapeSizeInvisble()
+
     fun toggleShapeSizeVisibility(isVisible: Boolean)
-
-    fun getClipboardToolOptionsLayout(): View
-
-    interface Callback {
-        fun copyClicked()
-
-        fun cutClicked()
-
-        fun pasteClicked()
-    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ShapeToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ShapeToolOptionsView.kt
@@ -18,6 +18,7 @@
  */
 package org.catrobat.paintroid.tools.options
 
+import android.view.View
 import org.catrobat.paintroid.tools.drawable.DrawableShape
 import org.catrobat.paintroid.tools.drawable.DrawableStyle
 
@@ -29,6 +30,12 @@ interface ShapeToolOptionsView {
     fun setShapeOutlineWidth(outlineWidth: Int)
 
     fun setCallback(callback: Callback)
+
+    fun setShapeSizeText(shapeSize: String)
+
+    fun toggleShapeSizeVisibility(isVisible: Boolean)
+
+    fun getShapeToolOptionsLayout(): View
 
     interface Callback {
         fun setToolType(shape: DrawableShape)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/TextToolOptionsView.kt
@@ -41,6 +41,10 @@ interface TextToolOptionsView {
 
     fun getBottomLayout(): View
 
+    fun setShapeSizeText(shapeSize: String)
+
+    fun toggleShapeSizeVisibility(isVisible: Boolean)
+
     interface Callback {
         fun setText(text: String)
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ToolOptionsViewController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ToolOptionsViewController.kt
@@ -40,9 +40,9 @@ interface ToolOptionsViewController : ToolOptionsVisibilityController {
 
     fun hideCheckmark()
 
-    fun slideUp(view: View, willHide: Boolean, showOptionsView: Boolean)
+    fun slideUp(view: View, willHide: Boolean, showOptionsView: Boolean, setViewGone: Boolean = false)
 
-    fun slideDown(view: View, willHide: Boolean, showOptionsView: Boolean)
+    fun slideDown(view: View, willHide: Boolean, showOptionsView: Boolean, setViewGone: Boolean = false)
 
     fun animateBottomAndTopNavigation(hide: Boolean)
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ToolOptionsVisibilityController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ToolOptionsVisibilityController.kt
@@ -25,7 +25,7 @@ interface ToolOptionsVisibilityController {
 
     fun setCallback(callback: Callback)
 
-    fun show()
+    fun show(isFullScreen: Boolean = false)
 
     fun showDelayed()
 

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
@@ -18,15 +18,12 @@
  */
 package org.catrobat.paintroid.ui.tools
 
-import android.os.Handler
-import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import com.google.android.material.chip.Chip
 import org.catrobat.paintroid.R
-import org.catrobat.paintroid.common.ANIMATION_DURATION
 import org.catrobat.paintroid.tools.options.ClipboardToolOptionsView
 
 class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOptionsView {
@@ -64,10 +61,7 @@ class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOption
 
     override fun toggleShapeSizeVisibility(isVisible: Boolean) {
         if (isVisible && !changeSizeShapeSizeChipVisible && clipboardToolOptionsView.visibility == View.INVISIBLE) {
-            val handler = Handler(Looper.getMainLooper())
-            handler.postDelayed({
-                changeSizeShapeSizeChip.visibility = View.VISIBLE
-            }, ANIMATION_DURATION)
+            changeSizeShapeSizeChip.visibility = View.VISIBLE
         } else {
             if (isVisible && clipboardToolOptionsView.visibility == View.GONE) changeSizeShapeSizeChip.visibility = View.VISIBLE
             if (!isVisible) changeSizeShapeSizeChip.visibility = View.GONE

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
@@ -18,17 +18,26 @@
  */
 package org.catrobat.paintroid.ui.tools
 
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import com.google.android.material.chip.Chip
 import org.catrobat.paintroid.R
+import org.catrobat.paintroid.common.ANIMATION_DURATION
 import org.catrobat.paintroid.tools.options.ClipboardToolOptionsView
 
 class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOptionsView {
     private val pasteChip: Chip
     private val copyChip: Chip
     private val cutChip: Chip
+    private val shapeSizeChip: Chip
+    private val changeSizeShapeSizeChip: Chip
+    private val clipboardToolOptionsView: View
+    private var changeSizeShapeSizeChipVisible = false
+
     private var callback: ClipboardToolOptionsView.Callback? = null
 
     private fun initializeListeners() {
@@ -53,6 +62,26 @@ class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOption
         pasteChip.isEnabled = enable
     }
 
+    override fun toggleShapeSizeVisibility(isVisible: Boolean) {
+        if (isVisible && !changeSizeShapeSizeChipVisible && clipboardToolOptionsView.visibility == View.INVISIBLE) {
+            val handler = Handler(Looper.getMainLooper())
+            handler.postDelayed({
+                changeSizeShapeSizeChip.visibility = View.VISIBLE
+            }, ANIMATION_DURATION)
+        } else {
+            if (isVisible && clipboardToolOptionsView.visibility == View.GONE) changeSizeShapeSizeChip.visibility = View.VISIBLE
+            if (!isVisible) changeSizeShapeSizeChip.visibility = View.GONE
+        }
+        changeSizeShapeSizeChipVisible = isVisible
+    }
+
+    override fun getClipboardToolOptionsLayout(): View = clipboardToolOptionsView
+
+    override fun setShapeSizeText(shapeSize: String) {
+        shapeSizeChip.setText(shapeSize)
+        changeSizeShapeSizeChip.setText(shapeSize)
+    }
+
     init {
         val inflater = LayoutInflater.from(rootView.context)
         val stampToolOptionsView: View =
@@ -62,5 +91,15 @@ class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOption
         cutChip = stampToolOptionsView.findViewById(R.id.action_cut)
         enablePaste(false)
         initializeListeners()
+        stampToolOptionsView.run {
+            val viewShapeSizeLayout =
+                findViewById<LinearLayout>(R.id.pocketpaint_layout_clipboard_tool_options_view_shape_size)
+            shapeSizeChip = viewShapeSizeLayout.findViewById(R.id.pocketpaint_fill_shape_size_text)
+            val changeShapeSizeLayout =
+                findViewById<LinearLayout>(R.id.pocketpaint_layout_clipboard_tool_change_size_shape_size)
+            changeSizeShapeSizeChip = changeShapeSizeLayout.findViewById(R.id.pocketpaint_fill_shape_size_text)
+            clipboardToolOptionsView = findViewById(R.id.pocketpaint_layout_clipboard_tool_options)
+        }
+        toggleShapeSizeVisibility(false)
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultImportToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultImportToolOptionsView.kt
@@ -1,0 +1,52 @@
+/*
+ * Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2024 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.paintroid.ui.tools
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import com.google.android.material.chip.Chip
+import org.catrobat.paintroid.R
+import org.catrobat.paintroid.tools.options.ImportToolOptionsView
+
+class DefaultImportToolOptionsView(rootView: ViewGroup) : ImportToolOptionsView {
+    private val shapeSizeChip: Chip
+    private val shapeSizeLayout: LinearLayout
+    override fun setShapeSizeText(shapeSize: String) {
+        shapeSizeLayout.visibility = View.VISIBLE
+        shapeSizeChip.setText(shapeSize)
+    }
+
+    override fun setShapeSizeInvisble() {
+        shapeSizeLayout.visibility = View.INVISIBLE
+    }
+
+    override fun toggleShapeSizeVisibility(isVisible: Boolean) {
+        shapeSizeChip.visibility = if (isVisible) View.VISIBLE else View.INVISIBLE
+    }
+
+    init {
+        val inflater = LayoutInflater.from(rootView.context)
+        val importToolOptionsView: View =
+            inflater.inflate(R.layout.dialog_pocketpaint_import_tool, rootView)
+        shapeSizeChip = importToolOptionsView.findViewById(R.id.pocketpaint_fill_shape_size_text)
+        shapeSizeLayout = importToolOptionsView.findViewById(R.id.pocketpaint_layout_import_tool_shape_size)
+    }
+}

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptionsView.kt
@@ -18,8 +18,6 @@
  */
 package org.catrobat.paintroid.ui.tools
 
-import android.os.Handler
-import android.os.Looper
 import android.text.Editable
 import android.text.InputFilter
 import android.text.TextWatcher
@@ -35,7 +33,6 @@ import androidx.appcompat.widget.AppCompatSeekBar
 import androidx.appcompat.widget.AppCompatTextView
 import com.google.android.material.chip.Chip
 import org.catrobat.paintroid.R
-import org.catrobat.paintroid.common.ANIMATION_DURATION
 import org.catrobat.paintroid.tools.drawable.DrawableShape
 import org.catrobat.paintroid.tools.drawable.DrawableStyle
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter
@@ -254,10 +251,7 @@ class DefaultShapeToolOptionsView(rootView: ViewGroup) : ShapeToolOptionsView {
 
     override fun toggleShapeSizeVisibility(isVisible: Boolean) {
         if (isVisible && !changeSizeShapeSizeChipVisible && shapeToolOptionsView.visibility == View.INVISIBLE) {
-            val handler = Handler(Looper.getMainLooper())
-            handler.postDelayed({
-                changeSizeShapeSizeChip.visibility = View.VISIBLE
-            }, ANIMATION_DURATION)
+            changeSizeShapeSizeChip.visibility = View.VISIBLE
         } else {
             if (isVisible && shapeToolOptionsView.visibility == View.GONE) changeSizeShapeSizeChip.visibility = View.VISIBLE
             if (!isVisible) changeSizeShapeSizeChip.visibility = View.GONE

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultShapeToolOptionsView.kt
@@ -18,19 +18,24 @@
  */
 package org.catrobat.paintroid.ui.tools
 
+import android.os.Handler
+import android.os.Looper
 import android.text.Editable
 import android.text.InputFilter
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.appcompat.widget.AppCompatSeekBar
 import androidx.appcompat.widget.AppCompatTextView
+import com.google.android.material.chip.Chip
 import org.catrobat.paintroid.R
+import org.catrobat.paintroid.common.ANIMATION_DURATION
 import org.catrobat.paintroid.tools.drawable.DrawableShape
 import org.catrobat.paintroid.tools.drawable.DrawableStyle
 import org.catrobat.paintroid.tools.helper.DefaultNumberRangeFilter
@@ -57,6 +62,10 @@ class DefaultShapeToolOptionsView(rootView: ViewGroup) : ShapeToolOptionsView {
     private val outlineWidthEditText: AppCompatEditText
     private val shapeToolDialogTitle: AppCompatTextView
     private val shapeToolFillOutline: AppCompatTextView
+    private val shapeSizeChip: Chip
+    private val changeSizeShapeSizeChip: Chip
+    private val shapeToolOptionsView: View
+    private var changeSizeShapeSizeChipVisible = false
 
     init {
         val inflater = LayoutInflater.from(rootView.context)
@@ -74,7 +83,11 @@ class DefaultShapeToolOptionsView(rootView: ViewGroup) : ShapeToolOptionsView {
             outlineTextView = findViewById(R.id.pocketpaint_outline_view_text_view)
             outlineWidthSeekBar = findViewById(R.id.pocketpaint_shape_stroke_width_seek_bar)
             outlineWidthEditText = findViewById(R.id.pocketpaint_shape_outline_edit)
+            shapeSizeChip = findViewById<LinearLayout>(R.id.pocketpaint_layout_shape_tool_options_view_shape_size).findViewById(R.id.pocketpaint_fill_shape_size_text)
+            changeSizeShapeSizeChip = findViewById<LinearLayout>(R.id.pocketpaint_layout_shape_tool_change_size_shape_size).findViewById(R.id.pocketpaint_fill_shape_size_text)
+            shapeToolOptionsView = findViewById(R.id.pocketpaint_layout_shape_tool_options)
         }
+        toggleShapeSizeVisibility(false)
         outlineWidthEditText.filters =
             arrayOf<InputFilter>(DefaultNumberRangeFilter(MIN_VAL, MAX_VAL))
         outlineWidthEditText.setText(STARTING_OUTLINE_WIDTH.toString())
@@ -233,4 +246,24 @@ class DefaultShapeToolOptionsView(rootView: ViewGroup) : ShapeToolOptionsView {
     override fun setCallback(callback: ShapeToolOptionsView.Callback) {
         this.callback = callback
     }
+
+    override fun setShapeSizeText(shapeSize: String) {
+        shapeSizeChip.setText(shapeSize)
+        changeSizeShapeSizeChip.setText(shapeSize)
+    }
+
+    override fun toggleShapeSizeVisibility(isVisible: Boolean) {
+        if (isVisible && !changeSizeShapeSizeChipVisible && shapeToolOptionsView.visibility == View.INVISIBLE) {
+            val handler = Handler(Looper.getMainLooper())
+            handler.postDelayed({
+                changeSizeShapeSizeChip.visibility = View.VISIBLE
+            }, ANIMATION_DURATION)
+        } else {
+            if (isVisible && shapeToolOptionsView.visibility == View.GONE) changeSizeShapeSizeChip.visibility = View.VISIBLE
+            if (!isVisible) changeSizeShapeSizeChip.visibility = View.GONE
+        }
+        changeSizeShapeSizeChipVisible = isVisible
+    }
+
+    override fun getShapeToolOptionsLayout(): View = shapeToolOptionsView
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultTextToolOptionsView.kt
@@ -29,9 +29,11 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Checkable
 import android.widget.EditText
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.chip.Chip
 import org.catrobat.paintroid.R
 import org.catrobat.paintroid.tools.FontType
 import org.catrobat.paintroid.tools.options.TextToolOptionsView
@@ -53,6 +55,8 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
     private val fontTypes: List<FontType>
     private val topLayout: View
     private val bottomLayout: View
+    private val textToolOptionsViewShapeSizeChip: Chip
+    private val changeSizeShapeSizeChip: Chip
 
     init {
         val inflater = LayoutInflater.from(context)
@@ -74,6 +78,13 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
         fontTypes = FontType.values().toList()
         initializeListeners()
         textEditText.requestFocus()
+        val viewShapeSizeLayout =
+            textToolView.findViewById<LinearLayout>(R.id.pocketpaint_layout_text_tool_options_view_shape_size)
+        textToolOptionsViewShapeSizeChip = viewShapeSizeLayout.findViewById(R.id.pocketpaint_fill_shape_size_text)
+        val changeShapeSizeLayout =
+            textToolView.findViewById<LinearLayout>(R.id.pocketpaint_layout_text_tool_change_size_shape_size)
+        changeSizeShapeSizeChip = changeShapeSizeLayout.findViewById(R.id.pocketpaint_fill_shape_size_text)
+        toggleShapeSizeVisibility(false)
     }
 
     private fun initializeListeners() {
@@ -190,4 +201,12 @@ class DefaultTextToolOptionsView(rootView: ViewGroup) : TextToolOptionsView {
     override fun getTopLayout(): View = topLayout
 
     override fun getBottomLayout(): View = bottomLayout
+    override fun setShapeSizeText(shapeSize: String) {
+        textToolOptionsViewShapeSizeChip.setText(shapeSize)
+        changeSizeShapeSizeChip.setText(shapeSize)
+    }
+
+    override fun toggleShapeSizeVisibility(isVisible: Boolean) {
+        changeSizeShapeSizeChip.visibility = if (isVisible) View.VISIBLE else View.GONE
+    }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.kt
@@ -140,7 +140,7 @@ class DefaultToolOptionsViewController(
         hideButtonsEnabled = false
     }
 
-    override fun slideUp(view: View, willHide: Boolean, showOptionsView: Boolean) {
+    override fun slideUp(view: View, willHide: Boolean, showOptionsView: Boolean, setViewGone: Boolean) {
         if (!enabled || !hideButtonsEnabled) {
             return
         }
@@ -169,7 +169,7 @@ class DefaultToolOptionsViewController(
         animation.duration = ANIMATION_DURATION
         view.startAnimation(animation)
         if (willHide) {
-            view.visibility = View.INVISIBLE
+            view.visibility = if (setViewGone) View.GONE else View.INVISIBLE
             toolOptionsShown = showOptionsView
             notifyHide()
         } else {
@@ -177,7 +177,7 @@ class DefaultToolOptionsViewController(
         }
     }
 
-    override fun slideDown(view: View, willHide: Boolean, showOptionsView: Boolean) {
+    override fun slideDown(view: View, willHide: Boolean, showOptionsView: Boolean, setViewGone: Boolean) {
         if (!enabled || !hideButtonsEnabled) {
             return
         }
@@ -201,7 +201,7 @@ class DefaultToolOptionsViewController(
         animation.duration = ANIMATION_DURATION
         view.startAnimation(animation)
         if (willHide) {
-            view.visibility = View.INVISIBLE
+            view.visibility = if (setViewGone) View.GONE else View.INVISIBLE
             toolOptionsShown = showOptionsView
             notifyHide()
         } else {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultToolOptionsViewController.kt
@@ -95,7 +95,7 @@ class DefaultToolOptionsViewController(
         enabled = true
     }
 
-    override fun show() {
+    override fun show(isFullScreen: Boolean) {
         if (!enabled || !hideButtonsEnabled) {
             return
         }
@@ -103,7 +103,8 @@ class DefaultToolOptionsViewController(
         toolOptionsShown = true
         mainToolOptions.visibility = View.INVISIBLE
         mainToolOptions.post {
-            val yPos = bottomNavigation.y - mainToolOptions.height
+            val yDifference = if (isFullScreen) bottomNavigation.height else mainToolOptions.height
+            val yPos = bottomNavigation.y - yDifference
             mainToolOptions.animate().y(yPos)
             mainToolOptions.visibility = View.VISIBLE
         }

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_clipboard_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_clipboard_tool.xml
@@ -6,49 +6,77 @@
     android:layout_height="match_parent"
     android:padding="8dp">
 
-    <com.google.android.material.chip.Chip
-        android:id="@+id/action_copy"
+    <RelativeLayout
+        android:id="@+id/pocketpaint_layout_clipboard_tool_options"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <include
+            android:id="@+id/pocketpaint_layout_clipboard_tool_options_view_shape_size"
+            layout="@layout/pocketpaint_layout_shape_size_template"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_above="@id/action_copy" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/action_copy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentStart="true"
+            android:text="@string/clipboard_tool_copy"
+            android:theme="@style/Theme.MaterialComponents.Light"
+            app:chipIcon="@drawable/ic_pocketpaint_copy"
+            app:chipStartPadding="8dp" />
+
+        <Space
+            android:id="@+id/space_one"
+            style="@style/PocketPaintToolHorizontalSpace"
+            android:layout_alignParentBottom="true"
+            android:layout_toEndOf="@+id/action_copy" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/action_cut"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_toEndOf="@+id/space_one"
+            android:text="@string/clipboard_tool_cut"
+            android:theme="@style/Theme.MaterialComponents.Light"
+            app:chipIcon="@drawable/ic_pocketpaint_cut"
+            app:chipStartPadding="8dp" />
+
+        <Space
+            android:id="@+id/space_two"
+            style="@style/PocketPaintToolHorizontalSpace"
+            android:layout_alignParentBottom="true"
+            android:layout_toEndOf="@+id/action_cut" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/action_paste"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_toEndOf="@+id/space_two"
+            android:text="@string/clipboard_tool_paste"
+            android:theme="@style/Theme.MaterialComponents.Light"
+            app:chipIcon="@drawable/ic_pocketpaint_paste_chip_icon_selector"
+            app:chipStartPadding="8dp" />
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/pocketpaint_reshape_size_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentStart="true"
-        android:text="@string/clipboard_tool_copy"
-        android:theme="@style/Theme.MaterialComponents.Light"
-        app:chipIcon="@drawable/ic_pocketpaint_copy"
-        app:chipStartPadding="8dp" />
+        android:layout_alignParentBottom="true" >
 
-    <Space
-        android:id="@+id/space_one"
-        style="@style/PocketPaintToolHorizontalSpace"
-        android:layout_alignParentBottom="true"
-        android:layout_toEndOf="@+id/action_copy" />
-
-    <com.google.android.material.chip.Chip
-        android:id="@+id/action_cut"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_toEndOf="@+id/space_one"
-        android:text="@string/clipboard_tool_cut"
-        android:theme="@style/Theme.MaterialComponents.Light"
-        app:chipIcon="@drawable/ic_pocketpaint_cut"
-        app:chipStartPadding="8dp" />
-
-    <Space
-        android:id="@+id/space_two"
-        style="@style/PocketPaintToolHorizontalSpace"
-        android:layout_alignParentBottom="true"
-        android:layout_toEndOf="@+id/action_cut" />
-
-    <com.google.android.material.chip.Chip
-        android:id="@+id/action_paste"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_toEndOf="@+id/space_two"
-        android:text="@string/clipboard_tool_paste"
-        android:theme="@style/Theme.MaterialComponents.Light"
-        app:chipIcon="@drawable/ic_pocketpaint_paste_chip_icon_selector"
-        app:chipStartPadding="8dp" />
+        <include
+            android:id="@+id/pocketpaint_layout_clipboard_tool_change_size_shape_size"
+            layout="@layout/pocketpaint_layout_shape_size_template"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_import_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_import_tool.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp">
+
+    <include
+        android:id="@+id/pocketpaint_layout_import_tool_shape_size"
+        layout="@layout/pocketpaint_layout_shape_size_template"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</RelativeLayout>

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_shapes.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_shapes.xml
@@ -25,120 +25,161 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@android:color/white"
-        android:orientation="vertical">
-
-        <TextView
-            android:id="@+id/pocketpaint_outline_view_text_view"
-            style="@style/PocketPaintToolSubtitle"
-            android:text="@string/dialog_brush_width_text" />
-
-        <View
-            android:id="@+id/pocketpaint_outline_view_border"
-            style="@style/PocketPaintToolSectionDivider" />
+        android:orientation="vertical" >
 
         <LinearLayout
-            style="@style/PocketPaintToolSection"
-            android:orientation="horizontal">
+            android:id="@+id/pocketpaint_layout_shape_tool_options"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:background="@android:color/transparent">
 
-            <SeekBar
-                android:id="@+id/pocketpaint_shape_stroke_width_seek_bar"
-                android:layout_width="0dp"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:max="100" />
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:background="@android:color/transparent">
 
-            <Space style="@style/PocketPaintToolHorizontalSpace" />
+                <include
+                    android:id="@+id/pocketpaint_layout_shape_tool_options_view_shape_size"
+                    layout="@layout/pocketpaint_layout_shape_size_template"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
 
-            <EditText
-                android:id="@+id/pocketpaint_shape_outline_edit"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:imeOptions="actionDone"
-                android:importantForAutofill="no"
-                android:inputType="number"
-                android:minEms="3"
-                android:textColor="?attr/colorAccent"
-                android:textSize="14sp"
-                android:textStyle="bold"
-                tools:ignore="LabelFor" />
+                android:background="@android:color/white"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/pocketpaint_outline_view_text_view"
+                    style="@style/PocketPaintToolSubtitle"
+                    android:text="@string/dialog_brush_width_text" />
+
+                <View
+                    android:id="@+id/pocketpaint_outline_view_border"
+                    style="@style/PocketPaintToolSectionDivider" />
+
+                <LinearLayout
+                    style="@style/PocketPaintToolSection"
+                    android:orientation="horizontal">
+
+                    <SeekBar
+                        android:id="@+id/pocketpaint_shape_stroke_width_seek_bar"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:max="100" />
+
+                    <Space style="@style/PocketPaintToolHorizontalSpace" />
+
+                    <EditText
+                        android:id="@+id/pocketpaint_shape_outline_edit"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:imeOptions="actionDone"
+                        android:importantForAutofill="no"
+                        android:inputType="number"
+                        android:minEms="3"
+                        android:textColor="?attr/colorAccent"
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        tools:ignore="LabelFor" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/pocketpaint_shape_tool_fill_outline"
+                    style="@style/PocketPaintToolSubtitle"
+                    android:text="@string/shape_tool_dialog_fill_title" />
+
+                <View style="@style/PocketPaintToolSectionDivider" />
+
+                <LinearLayout
+                    style="@style/PocketPaintToolSection"
+                    android:layout_width="wrap_content"
+                    android:layout_gravity="center">
+
+                    <ImageButton
+                        android:id="@+id/pocketpaint_shape_ibtn_fill"
+                        style="@style/PocketPaintSelectableButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/shape_tool_dialog_rect_title"
+                        android:src="@drawable/ic_pocketpaint_rectangle" />
+
+                    <ImageButton
+                        android:id="@+id/pocketpaint_shape_ibtn_outline"
+                        style="@style/PocketPaintSelectableButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/shape_tool_dialog_outline_title"
+                        android:src="@drawable/ic_pocketpaint_rectangle_out" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/pocketpaint_shape_tool_dialog_title"
+                    style="@style/PocketPaintToolSubtitle"
+                    android:text="@string/shape_tool_dialog_rect_title" />
+
+                <View style="@style/PocketPaintToolSectionDivider" />
+
+                <LinearLayout
+                    android:id="@+id/pocketpaint_shapes_container"
+                    style="@style/PocketPaintToolSection">
+
+                    <ImageButton
+                        android:id="@+id/pocketpaint_shapes_square_btn"
+                        style="@style/PocketPaintSelectableButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:contentDescription="@string/shape_tool_dialog_rect_title"
+                        android:src="@drawable/ic_pocketpaint_rectangle" />
+
+                    <ImageButton
+                        android:id="@+id/pocketpaint_shapes_circle_btn"
+                        style="@style/PocketPaintSelectableButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:contentDescription="@string/shape_tool_dialog_ellipse_title"
+                        android:src="@drawable/ic_pocketpaint_circle" />
+
+                    <ImageButton
+                        android:id="@+id/pocketpaint_shapes_heart_btn"
+                        style="@style/PocketPaintSelectableButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:contentDescription="@string/shape_tool_dialog_heart_title"
+                        android:src="@drawable/ic_pocketpaint_heart" />
+
+                    <ImageButton
+                        android:id="@+id/pocketpaint_shapes_star_btn"
+                        style="@style/PocketPaintSelectableButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:contentDescription="@string/shape_tool_dialog_star_title"
+                        android:src="@drawable/ic_pocketpaint_star" />
+                </LinearLayout>
+            </LinearLayout>
         </LinearLayout>
-
-        <TextView
-            android:id="@+id/pocketpaint_shape_tool_fill_outline"
-            style="@style/PocketPaintToolSubtitle"
-            android:text="@string/shape_tool_dialog_fill_title" />
-
-        <View style="@style/PocketPaintToolSectionDivider" />
-
-        <LinearLayout
-            style="@style/PocketPaintToolSection"
+        <RelativeLayout
+            android:id="@+id/pocketpaint_reshape_size_layout"
             android:layout_width="wrap_content"
-            android:layout_gravity="center">
+            android:layout_height="wrap_content"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp">
 
-            <ImageButton
-                android:id="@+id/pocketpaint_shape_ibtn_fill"
-                style="@style/PocketPaintSelectableButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/shape_tool_dialog_rect_title"
-                android:src="@drawable/ic_pocketpaint_rectangle" />
-
-            <ImageButton
-                android:id="@+id/pocketpaint_shape_ibtn_outline"
-                style="@style/PocketPaintSelectableButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/shape_tool_dialog_outline_title"
-                android:src="@drawable/ic_pocketpaint_rectangle_out" />
-        </LinearLayout>
-
-        <TextView
-            android:id="@+id/pocketpaint_shape_tool_dialog_title"
-            style="@style/PocketPaintToolSubtitle"
-            android:text="@string/shape_tool_dialog_rect_title" />
-
-        <View style="@style/PocketPaintToolSectionDivider" />
-
-        <LinearLayout
-            android:id="@+id/pocketpaint_shapes_container"
-            style="@style/PocketPaintToolSection">
-
-            <ImageButton
-                android:id="@+id/pocketpaint_shapes_square_btn"
-                style="@style/PocketPaintSelectableButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:contentDescription="@string/shape_tool_dialog_rect_title"
-                android:src="@drawable/ic_pocketpaint_rectangle" />
-
-            <ImageButton
-                android:id="@+id/pocketpaint_shapes_circle_btn"
-                style="@style/PocketPaintSelectableButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:contentDescription="@string/shape_tool_dialog_ellipse_title"
-                android:src="@drawable/ic_pocketpaint_circle" />
-
-            <ImageButton
-                android:id="@+id/pocketpaint_shapes_heart_btn"
-                style="@style/PocketPaintSelectableButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:contentDescription="@string/shape_tool_dialog_heart_title"
-                android:src="@drawable/ic_pocketpaint_heart" />
-
-            <ImageButton
-                android:id="@+id/pocketpaint_shapes_star_btn"
-                style="@style/PocketPaintSelectableButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:contentDescription="@string/shape_tool_dialog_star_title"
-                android:src="@drawable/ic_pocketpaint_star" />
-        </LinearLayout>
+            <include
+                android:id="@+id/pocketpaint_layout_shape_tool_change_size_shape_size"
+                layout="@layout/pocketpaint_layout_shape_size_template"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </RelativeLayout>
     </LinearLayout>
 </ScrollView>

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_text_tool.xml
@@ -117,7 +117,21 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 
-    <androidx.recyclerview.widget.RecyclerView
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            android:layout_above="@id/pocketpaint_text_tool_dialog_list_font">
+
+            <include
+                android:id="@+id/pocketpaint_layout_text_tool_options_view_shape_size"
+                layout="@layout/pocketpaint_layout_shape_size_template"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </RelativeLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/pocketpaint_text_tool_dialog_list_font"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -149,4 +163,18 @@
         </RelativeLayout>
     </RelativeLayout>
 
+    <RelativeLayout
+        android:id="@+id/pocketpaint_text_reshape_size_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentStart="true"
+        android:padding="10dp" >
+
+        <include
+            android:id="@+id/pocketpaint_layout_text_tool_change_size_shape_size"
+            layout="@layout/pocketpaint_layout_shape_size_template"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
     </RelativeLayout>
+</RelativeLayout>

--- a/Paintroid/src/main/res/layout/pocketpaint_layout_shape_size_template.xml
+++ b/Paintroid/src/main/res/layout/pocketpaint_layout_shape_size_template.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+ *  Paintroid: An image manipulation application for Android.
+ *  Copyright (C) 2010-2024 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/pocketpaint_layout_shape_size_template"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    tools:ignore="MissingDefaultResource">
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/pocketpaint_fill_shape_size_text"
+        style="@style/ChipTheme"
+        android:theme="@style/Theme.MaterialComponents.Light"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checkable="false"
+        android:checked="false"
+        android:textColor="@android:color/black" />
+</LinearLayout>


### PR DESCRIPTION
Done for Clipboard-, Shape-, Import- and Text-Tool
Chip for current shape size is shown above other tool specific options
When shape is being resized, the current shape size is always shown now, 
independently of the toolOptionsLayout.

https://jira.catrob.at/browse/PAINTROID-444

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
