### PR TITLE
PAINTROID-652 Accessibility of shape frames

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BaseToolWithShape.kt
@@ -64,7 +64,7 @@ abstract class BaseToolWithShape @SuppressLint("VisibleForTests") constructor(
         contextCallback.getColor(R.color.pocketpaint_main_rectangle_tool_primary_color)
 
     @JvmField
-    var secondaryShapeColor: Int = contextCallback.getColor(R.color.pocketpaint_colorAccent)
+    var secondaryShapeColor: Int = contextCallback.getColor(R.color.pocketpaint_colorAccentAlpha60)
 
     @JvmField
     val linePaint: Paint

--- a/Paintroid/src/main/res/values/colors.xml
+++ b/Paintroid/src/main/res/values/colors.xml
@@ -23,6 +23,7 @@
     <color name="pocketpaint_colorPrimary">#138293</color>
     <color name="pocketpaint_colorPrimaryDark">#0D6775</color>
     <color name="pocketpaint_colorAccent">#157DA2</color>
+    <color name="pocketpaint_colorAccentAlpha60">#99157DA2</color>
     <color name="pocketpaint_text_color_link">#BD5800</color>
 
     <!-- PocketPaint main activity -->
@@ -31,9 +32,9 @@
     <color name="pocketpaint_main_drawing_surface_active">#00000000</color>
     <color name="pocketpaint_main_drawing_surface_inactive">#80000000</color>
     <color name="pocketpaint_main_drawing_surface_background">#D3D3D3</color>
-    <color name="pocketpaint_main_rectangle_tool_primary_color">#555555</color>
-    <color name="pocketpaint_main_rectangle_tool_accent_color">#33B5E5</color>
-    <color name="pocketpaint_main_rectangle_tool_highlight_color">#e56b33</color>
+    <color name="pocketpaint_main_rectangle_tool_primary_color">#99555555</color>
+    <color name="pocketpaint_main_rectangle_tool_accent_color">#9933B5E5</color>
+    <color name="pocketpaint_main_rectangle_tool_highlight_color">#99E56B33</color>
     <color name="pocketpaint_main_cursor_tool_inactive_primary_color">#555555</color>
 
     <!-- PocketPaint welcome activity -->


### PR DESCRIPTION
Reduced alpha value of shape frame to 60% instead of 80% (80% does not make that much of a difference) for better visibility of drawing underneath

https://jira.catrob.at/browse/PAINTROID-652

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
