### PR TITLE
PAINTROID-681 Smoothing algorithm displays two lines (eraser tool)

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/BrushTool.kt
@@ -230,20 +230,25 @@ open class BrushTool(
             return false
         }
 
-        var distance: Double? = null
-        initialEventCoordinate?.apply {
-            distance =
-                sqrt(((coordinate.x - x) * (coordinate.x - x) + (coordinate.y - y) * (coordinate.y - y)).toDouble())
-        }
-        val speed = distance?.div(drawTime)
-
-        if (!smoothing || speed != null && speed < threshold) {
+        if (toolType == ToolType.ERASER) {
             val command = commandFactory.createPathCommand(bitmapPaint, pathToDraw)
             commandManager.addCommand(command)
         } else {
-            val pathNew = AdvancedSettingsAlgorithms.smoothingAlgorithm(pointArray)
-            val command = commandFactory.createPathCommand(bitmapPaint, pathNew)
-            commandManager.addCommand(command)
+            var distance: Double? = null
+            initialEventCoordinate?.apply {
+                distance =
+                    sqrt(((coordinate.x - x) * (coordinate.x - x) + (coordinate.y - y) * (coordinate.y - y)).toDouble())
+            }
+            val speed = distance?.div(drawTime)
+
+            if (!smoothing || speed != null && speed < threshold) {
+                val command = commandFactory.createPathCommand(bitmapPaint, pathToDraw)
+                commandManager.addCommand(command)
+            } else {
+                val pathNew = AdvancedSettingsAlgorithms.smoothingAlgorithm(pointArray)
+                val command = commandFactory.createPathCommand(bitmapPaint, pathNew)
+                commandManager.addCommand(command)
+            }
         }
 
         pointArray.clear()


### PR DESCRIPTION
[PAINTROID-681](https://jira.catrob.at/browse/PAINTROID-681)

Fixed bug where eraser was weirdly readjusting the erased line causing a 2nd erased line to appear when removing the finger from the canvas. (after erasing was done)

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
