### PR TITLE
PAINTROID-699 Shape Tool: star tips missing in stroke mode

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ShapeTool.kt
@@ -42,6 +42,7 @@ private const val DEFAULT_OUTLINE_WIDTH = 25
 private const val BUNDLE_BASE_SHAPE = "BASE_SHAPE"
 private const val BUNDLE_SHAPE_DRAW_TYPE = "SHAPE_DRAW_TYPE"
 private const val BUNDLE_OUTLINE_WIDTH = "OUTLINE_WIDTH"
+private const val STROKE_MITER_MULTIPLICATOR: Int = 4
 
 class ShapeTool(
     shapeToolOptionsView: ShapeToolOptionsView,
@@ -168,6 +169,7 @@ class ShapeTool(
                 paint.strokeWidth = shapeOutlineWidth.toFloat()
                 paint.strokeCap = Paint.Cap.BUTT
                 paint.strokeJoin = Paint.Join.MITER
+                paint.strokeMiter *= STROKE_MITER_MULTIPLICATOR
                 val antiAlias = shapeOutlineWidth > 1
                 paint.isAntiAlias = antiAlias
             }


### PR DESCRIPTION
set higher strokeMiter threshold to avoid switching to bevel join prematurely

https://jira.catrob.at/browse/PAINTROID-699

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
