### PR TITLE
PAINTROID-760 Crash: Buffer underflow

### DIFF
--- a/Paintroid/build.gradle
+++ b/Paintroid/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.8'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8'
     implementation 'androidx.exifinterface:exifinterface:1.3.2'
-    implementation 'com.esotericsoftware:kryo:5.5.0'
+    implementation 'com.esotericsoftware:kryo:5.6.2'
     implementation 'id.zelory:compressor:2.1.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 


### PR DESCRIPTION
I managed to reproduce the [buffer underflow bug](https://catrobat.atlassian.net/jira/software/c/projects/PAINTROID/boards/130?selectedIssue=PAINTROID-760)

For some reason when starting the App with the device "Pixel Fold" (specifically with API 34) the app crashes.

Here is a better Stacktrace with more information for the bug, than the one in the kanban board.
![image](https://github.com/user-attachments/assets/3a71d591-a0d0-48c0-9aaa-66e757c72447)

When the exception gets thrown which crashes the app, it doesn't handle the exception correctly. There is a problem with the Temporary image file that the app tries to open during launch. I handled the exception now so hopefully this bug won't occur anymore.

After handling the exception, I couldn't manage to reproduce the bug anymore so hopefully this will be enough to fix it.

I also updated the Kryo version from 5.5.0 to 5.6.2

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
