### PR TITLE
fix PAINTROID-802 Add clear button to clipboard tool

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClipboardTool.kt
@@ -93,6 +93,10 @@ class ClipboardTool(
                 highlightBox()
                 pasteBoxContent()
             }
+
+            override fun clearClicked() {
+                clearClipboardContent()
+            }
         }
         clipboardToolOptionsView.setCallback(callback)
         toolOptionsViewController.showDelayed()
@@ -137,6 +141,13 @@ class ClipboardTool(
         val command =
             commandFactory.createCutCommand(toolPosition, boxWidth, boxHeight, boxRotation)
         commandManager.addCommand(command)
+    }
+
+    private fun clearClipboardContent() {
+        drawingBitmap?.recycle()
+        drawingBitmap = null
+        readyForPaste = false
+        clipboardToolOptionsView.enablePaste(false)
     }
 
     override fun onClickOnButton() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ClipboardToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/options/ClipboardToolOptionsView.kt
@@ -37,5 +37,7 @@ interface ClipboardToolOptionsView {
         fun cutClicked()
 
         fun pasteClicked()
+
+        fun clearClicked()
     }
 }

--- a/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/ui/tools/DefaultClipboardToolOptionsView.kt
@@ -30,6 +30,7 @@ class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOption
     private val pasteChip: Chip
     private val copyChip: Chip
     private val cutChip: Chip
+    private val clearChip: Chip
     private val shapeSizeChip: Chip
     private val changeSizeShapeSizeChip: Chip
     private val clipboardToolOptionsView: View
@@ -48,6 +49,10 @@ class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOption
 
         pasteChip.setOnClickListener {
             callback?.pasteClicked()
+        }
+
+        clearChip.setOnClickListener {
+            callback?.clearClicked()
         }
     }
 
@@ -81,8 +86,9 @@ class DefaultClipboardToolOptionsView(rootView: ViewGroup) : ClipboardToolOption
         val stampToolOptionsView: View =
             inflater.inflate(R.layout.dialog_pocketpaint_clipboard_tool, rootView)
         copyChip = stampToolOptionsView.findViewById(R.id.action_copy)
-        pasteChip = stampToolOptionsView.findViewById(R.id.action_paste)
         cutChip = stampToolOptionsView.findViewById(R.id.action_cut)
+        pasteChip = stampToolOptionsView.findViewById(R.id.action_paste)
+        clearChip = stampToolOptionsView.findViewById(R.id.action_clear)
         enablePaste(false)
         initializeListeners()
         stampToolOptionsView.run {

--- a/Paintroid/src/main/res/layout/dialog_pocketpaint_clipboard_tool.xml
+++ b/Paintroid/src/main/res/layout/dialog_pocketpaint_clipboard_tool.xml
@@ -64,6 +64,23 @@
             app:chipIcon="@drawable/ic_pocketpaint_paste_chip_icon_selector"
             app:chipStartPadding="8dp" />
 
+        <Space
+            android:id="@+id/space_three"
+            style="@style/PocketPaintToolHorizontalSpace"
+            android:layout_alignParentBottom="true"
+            android:layout_toEndOf="@+id/action_paste" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/action_clear"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_toEndOf="@+id/space_three"
+            android:text="@string/clipboard_tool_clear"
+            android:theme="@style/Theme.MaterialComponents.Light"
+            app:chipIcon="@drawable/ic_pocketpaint_layers_delete"
+            app:chipStartPadding="8dp" />
+
     </RelativeLayout>
 
     <RelativeLayout

--- a/Paintroid/src/main/res/values/string.xml
+++ b/Paintroid/src/main/res/values/string.xml
@@ -50,6 +50,7 @@
     <string name="clipboard_tool_paste">Paste</string>
     <string name="clipboard_tool_copy">Copy</string>
     <string name="clipboard_tool_cut">Cut</string>
+    <string name="clipboard_tool_clear">Clear</string>
 
     <string name="stickers">Stickers</string>
     <string name="dialog_import_image_title" translatable="false">@string/button_import_image</string>


### PR DESCRIPTION
## PAINTROID-802 Add clear button to clipboard tool

### Summary
This PR adds a clear button to the clipboard tool, allowing users to clear the currently stored clipboard content without having to copy or cut new content.

### Changes
- Added a "Clear" button to the clipboard tool options layout (`dialog_pocketpaint_clipboard_tool.xml`)
- Added `clipboard_tool_clear` string resource
- Extended `ClipboardToolOptionsView` interface with `clearClicked()` callback method
- Implemented clear button in `DefaultClipboardToolOptionsView` with proper initialization and click listener
- Added `clearClipboardContent()` method in `ClipboardTool` that:
  - Safely recycles the bitmap to free memory
  - Nullifies the bitmap reference
  - Resets the `readyForPaste` state to false
  - Disables the paste button through the view
- Reused existing delete icon (`ic_pocketpaint_layers_delete`) for consistency

### Context
Previously, users had no way to clear the stored clipboard content once they copied or cut an image area. The only workaround was to copy/cut new content to overwrite the existing clipboard data. This PR addresses that limitation by providing an explicit clear button.

### Testing
The implementation follows existing patterns in the codebase and uses proper null safety with Kotlin's safe call operator. Manual testing should verify:
- Clear button appears in the clipboard tool
- Clicking clear removes stored content
- Paste button becomes disabled after clearing
- No crashes when clearing an empty clipboard
- Memory is properly freed when clearing
