### PR TITLE
PAINTROID-781: Fix crash on image import/export in PocketCode

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
@@ -349,26 +349,43 @@ object FileIO {
     }
 
     fun parseFileName(uri: Uri, resolver: ContentResolver) {
-        var fileName = "image"
-        val cursor = resolver.query(
-            uri,
-            arrayOf(MediaStore.Images.ImageColumns.DISPLAY_NAME),
-            null, null, null
-        )
-        cursor?.use {
-            if (cursor.moveToFirst()) {
-                fileName =
-                    cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DISPLAY_NAME))
+        var fileName: String? = null
+        if (uri.scheme == ContentResolver.SCHEME_CONTENT) {
+            try {
+                val cursor = resolver.query(
+                    uri,
+                    arrayOf(MediaStore.Images.ImageColumns.DISPLAY_NAME),
+                    null, null, null
+                )
+                cursor?.use {
+                    if (cursor.moveToFirst()) {
+                        val columnIndex =
+                            cursor.getColumnIndex(MediaStore.Images.ImageColumns.DISPLAY_NAME)
+                        if (columnIndex != -1) {
+                            fileName = cursor.getString(columnIndex)
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("FileIO", "Failed to query filename from URI", e)
             }
         }
-        if (fileName.endsWith(FileType.JPG.toExtension()) || fileName.endsWith(".jpeg")) {
+        if (fileName == null) {
+            fileName = uri.lastPathSegment
+        }
+        if (fileName == null) {
+            fileName = "image"
+        }
+        if (fileName!!.endsWith(FileType.JPG.toExtension()) || fileName!!.endsWith(".jpeg")) {
             fileType = FileType.JPG
             compressFormat = CompressFormat.JPEG
-            filename = fileName.substring(0, fileName.length - fileType.toExtension().length)
-        } else if (fileName.endsWith(".png")) {
+            filename = fileName!!.substring(0, fileName!!.length - fileType.toExtension().length)
+        } else if (fileName!!.endsWith(".png")) {
             fileType = FileType.PNG
             compressFormat = CompressFormat.PNG
-            filename = fileName.substring(0, fileName.length - fileType.toExtension().length)
+            filename = fileName!!.substring(0, fileName!!.length - fileType.toExtension().length)
+        } else {
+            filename = fileName!!
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-XX:MaxPermSize=1024m -Xmx4096m
+org.gradle.jvmargs=-Xmx4096m
 android.disableAutomaticComponentCreation=true


### PR DESCRIPTION
Jira-ID: PAINTROID-781

**Description**
Fixed a crash that occurred when Paintroid was opened via PocketCode for image import/export. The issue was caused by `FileIO.parseFileName` failing to safely handle `file://` URIs or exceptions during [ContentResolver](cci:1://file:///e:/opensource/Catrobat-Paintroid/Paintroid/src/test/java/org/catrobat/paintroid/test/presenter/MainActivityPresenterTest.kt:1612:4-1618:5) queries.

**Changes**
- Added a try-catch block in `FileIO.parseFileName` to handle potential exceptions during content query.
- Added fallback logic to extract the filename from the URI path if the content query fails or returns null.
- Removed deprecated `MaxPermSize` JVM argument from `gradle.properties` which was causing build issues.