### PR TITLE
PAINTROID-804 App crashes when working with color related tools

### DIFF
--- a/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorHistory.kt
+++ b/colorpicker/src/main/java/org/catrobat/paintroid/colorpicker/ColorHistory.kt
@@ -16,7 +16,7 @@ class ColorHistory : Serializable {
         }
 
         if (colorHistory.size > COLOR_HISTORY_SIZE) {
-            colorHistory.removeFirst()
+            colorHistory.removeAt(0)
         }
     }
 }


### PR DESCRIPTION
[PAINTROID-804 App crashes when working with color related tools](https://catrobat.atlassian.net/browse/PAINTROID-804)

This fixes the crash that happens when using color related tools. It happened because after the Android 15 upgrade, the removeFirst() that is used in ColorHistory.kt is not backwards compatible so I used another function removeAt(0)

Picture of the crash:
<img width="2300" height="575" alt="studio64_JsSkoFNdh4" src="https://github.com/user-attachments/assets/ecbf0a4a-4af3-4dc2-a722-74bd16d01b2a" />

After this change, I could not reproduce the bug anymore.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
