### PR TITLE
PAINTROID-805 Clip area leaves outside lines in image

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/CommandManager.kt
@@ -57,8 +57,6 @@ interface CommandManager {
 
     fun getCommandManagerModelForCatrobatImage(): CommandManagerModel?
 
-    fun adjustUndoListForClippingTool()
-
     fun undoInClippingTool()
 
     fun popFirstCommandInUndo()

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/AsyncCommandManager.kt
@@ -68,7 +68,6 @@ open class AsyncCommandManager(
                     synchronized(layerModel) { commandManager.addCommand(command) }
                 }
                 withContext(Dispatchers.Main) {
-                    commandManager.adjustUndoListForClippingTool()
                     notifyCommandPostExecute()
                 }
             }
@@ -153,10 +152,6 @@ open class AsyncCommandManager(
 
     override fun setInitialStateCommand(command: Command) {
         synchronized(layerModel) { commandManager.setInitialStateCommand(command) }
-    }
-
-    override fun adjustUndoListForClippingTool() {
-        synchronized(layerModel) { commandManager.adjustUndoListForClippingTool() }
     }
 
     override fun undoInClippingTool() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/command/implementation/DefaultCommandManager.kt
@@ -29,8 +29,6 @@ import java.util.Deque
 import java.util.ArrayDeque
 import java.util.Collections
 
-const val FIVE = 5
-
 class DefaultCommandManager(
     private val commonFactory: CommonFactory,
     private val layerModel: LayerContracts.Model
@@ -193,6 +191,10 @@ class DefaultCommandManager(
     }
 
     override fun isLastColorCommandOnTop(): Boolean {
+        if (undoCommandList.isEmpty()) {
+            return false
+        }
+
         var retVal = false
         if (undoCommandList.first is ColorChangedCommand) {
             val commandIterator = undoCommandList.iterator()
@@ -377,20 +379,6 @@ class DefaultCommandManager(
             )
         }
         return adaptedModel
-    }
-
-    override fun adjustUndoListForClippingTool() {
-        if (isUndoAvailable) {
-            if (undoCommandList.first.toString().split(".", "@").size < FIVE) {
-                return
-            }
-            val commandName = undoCommandList.first.toString().split(".", "@")[FIVE]
-            if (commandName == ClippingCommand::class.java.simpleName) {
-                val clippingCommand = undoCommandList.pop()
-                undoCommandList.pop()
-                undoCommandList.addFirst(clippingCommand)
-            }
-        }
     }
 
     override fun undoInClippingTool() {

--- a/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClippingTool.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/tools/implementation/ClippingTool.kt
@@ -106,9 +106,11 @@ class ClippingTool(
 
     override fun handleDown(coordinate: PointF?): Boolean {
         if (areaClosed) {
+            pathToDraw.rewind()
+            pointArray.clear()
             super.resetInternalState()
             areaClosed = false
-            commandManager.undoInClippingTool()
+
             changePaintColor(toolPaint.previewPaint.color)
             brushToolOptionsView.setCurrentPaint(toolPaint.paint)
             brushToolOptionsView.invalidate()
@@ -117,19 +119,37 @@ class ClippingTool(
         return super.handleDown(coordinate)
     }
 
+    override fun handleMove(coordinate: PointF?, shouldAnimate: Boolean): Boolean {
+        if (areaClosed) {
+            return false
+        }
+        return super.handleMove(coordinate, shouldAnimate)
+    }
+
     override fun handleUp(coordinate: PointF?): Boolean {
+        if (coordinate == null) {
+            return false
+        }
+
         val tempPoint = initialEventCoordinate
         if (previousEventCoordinate == initialEventCoordinate) {
             super.resetInternalState()
             return false
         }
-        if (!areaClosed && coordinate != null && tempPoint != null) {
+        if (!areaClosed && tempPoint != null) {
             pathToDraw.incReserve(1)
             pathToDraw.quadTo(coordinate.x, coordinate.y, tempPoint.x, tempPoint.y)
             pointArray.add(PointF(coordinate.x, coordinate.y))
             areaClosed = true
         }
-        return super.handleUp(coordinate)
+
+        handleUpAnimations(coordinate)
+
+        initialEventCoordinate = null
+        previousEventCoordinate = null
+        pointArray.clear()
+
+        return true
     }
 
     fun onClickOnButton() {
@@ -163,7 +183,6 @@ class ClippingTool(
                     )
                 }
                 commandManager.addCommand(command)
-                commandManager.adjustUndoListForClippingTool()
             }
             areaClosed = false
             wasRecentlyApplied = true


### PR DESCRIPTION
[PAINTROID-805 Clip area leaves outside lines in image](https://catrobat.atlassian.net/browse/PAINTROID-805?actionerId=6161a681289a54006a53e6b9&sourceType=assign)

Fixed several issues with the Clipping Tool and major problems that it caused in the Undo/Redo Command stack that sometimes resulted in crashes or even losing the drawing that were made by the user:

**AsyncCommandManager:**

- Removed the call to adjustUndoListForClippingTool() after every addCommand() execution.

- Reason: clipping manipulated the undo stack and caused issues for unrelated commands, because it can corrupt history / break undo results.

**DefaultCommandManager:**
- isLastColorCommandOnTop() now guards against an empty undo deque (to prevent NoSuchElementException when undo stack is empty) because this sometimes crashed the app when using the clipping tool and when it caused issues.
- adjustUndoListForClippingTool() was removed, because the previous implementation could reorder/pop commands and break undo/redo when doing fast interactions / async timing.

**ClippingTool:**
- When the user starts drawing a new clipping outline while a previous outline is already closed (areaClosed == true), the tool now clears only the preview path/state and does not undo any real commands anymore. This prevents accidentally undoing actual drawings when “spamming” the clipping tools helper lines.
- On confirm (checkmark), the tool adds only the ClippingCommand and no longer triggers special undo-stack reordering (adjustUndoListForClippingTool()).

~

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
