### PR TITLE
PAINTROID-806: SourceFile - org.catrobat.paintroid.MainActivity.onCreate

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
@@ -39,6 +39,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
 import androidx.exifinterface.media.ExifInterface
 import id.zelory.compressor.Compressor
+import kotlinx.coroutines.Runnable
 import org.catrobat.paintroid.command.serialization.CommandSerializer
 import org.catrobat.paintroid.common.CATROBAT_IMAGE_ENDING
 import org.catrobat.paintroid.common.Constants.DOWNLOADS_DIRECTORY
@@ -642,10 +643,14 @@ object FileIO {
         var workspaceReturnValue: WorkspaceReturnValue? = null
         if (temporaryFilePath != null) {
             try {
-                val stream = FileInputStream(temporaryFilePath)
-                workspaceReturnValue = commandSerializer.readFromInternalMemory(stream)
+                FileInputStream(temporaryFilePath).use { stream ->
+                    workspaceReturnValue = commandSerializer.readFromInternalMemory(stream)
+                }
             } catch (e: IOException) {
                 Log.e("Cannot read", "Can't read from stream", e)
+            } catch (e: RuntimeException){
+                Log.e("Paintroid", "Temporary file corrupted", e)
+                deleteTempFile(File(temporaryFilePath))
             }
         }
         return workspaceReturnValue

--- a/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/FileIO.kt
@@ -39,7 +39,6 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
 import androidx.exifinterface.media.ExifInterface
 import id.zelory.compressor.Compressor
-import kotlinx.coroutines.Runnable
 import org.catrobat.paintroid.command.serialization.CommandSerializer
 import org.catrobat.paintroid.common.CATROBAT_IMAGE_ENDING
 import org.catrobat.paintroid.common.Constants.DOWNLOADS_DIRECTORY

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -316,12 +316,18 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
                 presenterMain.initializeFromCleanState(picturePath, pictureName)
 
                 if (!model.isOpenedFromCatroid && presenterMain.checkForTemporaryFile() && (!isRunningEspressoTests || isTemporaryFileSavingTest)) {
-                    val workspaceReturnValue = presenterMain.openTemporaryFile()
-                    commandManager.loadCommandsCatrobatImage(workspaceReturnValue?.commandManagerModel)
-                    model.colorHistory = workspaceReturnValue?.colorHistory ?: ColorHistory()
-                    model.colorHistory.colors.lastOrNull()?.let {
-                        toolReference.tool?.changePaintColor(it)
-                        presenterMain.setBottomNavigationColor(it)
+                    try{
+                        val workspaceReturnValue = presenterMain.openTemporaryFile()
+                        commandManager.loadCommandsCatrobatImage(workspaceReturnValue?.commandManagerModel)
+                        model.colorHistory = workspaceReturnValue?.colorHistory ?: ColorHistory()
+                        model.colorHistory.colors.lastOrNull()?.let {
+                            toolReference.tool?.changePaintColor(it)
+                            presenterMain.setBottomNavigationColor(it)
+                        }
+                    }
+                    catch(e: Exception){
+                        Log.e("Paintroid", "Temporary file Corrupted Error: ", e)
+                        presenterMain.initializeFromCleanState(null, null)
                     }
                 }
                 workspace.perspective.setBitmapDimensions(layerModel.width, layerModel.height)

--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.kt
@@ -407,12 +407,15 @@ class MainActivity : AppCompatActivity(), MainView, CommandListener {
     }
 
     private fun getAppFragment() {
-        supportFragmentManager.findFragmentByTag(APP_FRAGMENT_KEY)?.let { fragment ->
-            appFragment = fragment as PaintroidApplicationFragment
-        }
-        if (!this::appFragment.isInitialized) {
+        val existing = supportFragmentManager.findFragmentByTag(APP_FRAGMENT_KEY)
+
+        if (existing is PaintroidApplicationFragment) {
+            appFragment = existing
+        } else {
             appFragment = PaintroidApplicationFragment()
-            supportFragmentManager.beginTransaction().add(appFragment, APP_FRAGMENT_KEY).commit()
+            supportFragmentManager.beginTransaction()
+                .add(appFragment, APP_FRAGMENT_KEY)
+                .commitNow()
         }
     }
 


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*

Fixed fragment restoration crash in MainActivity (NoSuchMethodException) by adding safe fragment retrieval and replacing unsafe cast. Should avoid duplicate fragment creation. This is highlighted as Problem 1.

SourceFile - org.catrobat.paintroid.MainActivity.onCreate - https://catrobat.atlassian.net/browse/PAINTROID-806

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
