### PR TITLE
Fix crash on process death caused by R8 removing Fragment constructor

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,3 +33,8 @@
 -keepclassmembers class com.esotericsoftware.kryo.serializers.DefaultArraySerializers$* {
     public <init>();
 }
+
+# Fragments are restored reflectively, so R8 must not drop the no-arg constructor
+-keepclassmembers,allowobfuscation class * extends androidx.fragment.app.Fragment {
+    <init>();
+}


### PR DESCRIPTION
### Summary

Release builds crash on launch after process death. Reproduce with Developer Options > "Don't keep activities", open the app, press Home, reopen.

```
androidx.fragment.app.g: Unable to instantiate fragment a.e: could not find Fragment constructor
Caused by: java.lang.NoSuchMethodException: a.e.<init> []
```
FragmentManager restores fragments reflectively through their no-arg constructor. R8 cannot see that call, so it removes the constructor. Confirmed with apkanalyzer that the constructor is missing from the release build.

R8 full mode became the default with the AGP 8 upgrade. [release-2.13.0](https://github.com/Catrobat/Paintroid/tree/release-2.13.0) built with AGP 7.2.1, does not crash.

`a.e` has not been retraced against the release mapping, so the exact fragment is not confirmed. `PaintroidApplicationFragment` is the most likely. The fix is a keep rule in `app/proguard-rules.pro`, using `-keepclassmembers` rather than `-keep` so class names stay obfuscated.

Verified manually. A minified release build with the rule no longer crashes with "Don't keep activities" enabled.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Paintroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#paintroid* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
